### PR TITLE
test: reduce dense coverage drag with Avro and SQL mega-tranche

### DIFF
--- a/modules/parquet/src/lib/parsers/parse-avro.ts
+++ b/modules/parquet/src/lib/parsers/parse-avro.ts
@@ -220,19 +220,13 @@ export async function* parseAvroInBatchesFromUrl(
         throw new Error('Invalid Avro OCF sync marker');
     const selected = !options?.blockIndices || options.blockIndices.includes(blockIndex);
     if (selected) {
-      const reader = new AvroReader(
-        await decompressAvro(header.codec, blockBytes.subarray(0, sizeResult.value)),
-        header.schema,
+      for await (const row of decodeAvroBlockRows(
+        blockBytes.subarray(0, sizeResult.value),
+        countResult.value,
+        header,
         options
-      );
-      for (let index = 0; index < countResult.value; index++) {
-        const value = reader.readValue(header.schema);
-        if (!isRecord(value)) throw new Error('Avro root schema must be a record');
-        batch.push(
-          options?.readerSchema
-            ? resolveReaderRecord(value, header.schema, options.readerSchema as AvroSchema)
-            : value
-        );
+      )) {
+        batch.push(row);
         if (batch.length >= batchSize) {
           yield createAvroBatch(batch);
           batch = [];
@@ -301,19 +295,13 @@ export async function* parseAvroInBatchesFromFile(
       if (blockBytes[sizeResult.value + index] !== header.syncMarker[index])
         throw new Error('Invalid Avro OCF sync marker');
     if (!options?.blockIndices || options.blockIndices.includes(blockIndex)) {
-      const reader = new AvroReader(
-        await decompressAvro(header.codec, blockBytes.subarray(0, sizeResult.value)),
-        header.schema,
+      for await (const row of decodeAvroBlockRows(
+        blockBytes.subarray(0, sizeResult.value),
+        countResult.value,
+        header,
         options
-      );
-      for (let index = 0; index < countResult.value; index++) {
-        const value = reader.readValue(header.schema);
-        if (!isRecord(value)) throw new Error('Avro root schema must be a record');
-        batch.push(
-          options?.readerSchema
-            ? resolveReaderRecord(value, header.schema, options.readerSchema as AvroSchema)
-            : value
-        );
+      )) {
+        batch.push(row);
         if (batch.length >= batchSize) {
           yield createAvroBatch(batch);
           batch = [];
@@ -324,6 +312,27 @@ export async function* parseAvroInBatchesFromFile(
     blockIndex++;
   }
   if (batch.length > 0) yield createAvroBatch(batch);
+}
+
+/** Decodes one Avro OCF block and applies the optional reader schema. */
+async function* decodeAvroBlockRows(
+  compressedBytes: Uint8Array,
+  rowCount: number,
+  header: AvroOCFHeader,
+  options?: AvroParseOptions
+): AsyncIterable<Record<string, unknown>> {
+  const reader = new AvroReader(
+    await decompressAvro(header.codec, compressedBytes),
+    header.schema,
+    options
+  );
+  for (let index = 0; index < rowCount; index++) {
+    const value = reader.readValue(header.schema);
+    if (!isRecord(value)) throw new Error('Avro root schema must be a record');
+    yield options?.readerSchema
+      ? resolveReaderRecord(value, header.schema, options.readerSchema as AvroSchema)
+      : value;
+  }
 }
 
 /** Reads a byte range and detects servers that ignore the Range header. */
@@ -473,7 +482,6 @@ async function* readAvroRows(
   const bytes = new Uint8Array(arrayBuffer);
   const ocf = parseAvroOCF(arrayBuffer);
   const {schema, codec} = ocf;
-  const readerSchema = options?.readerSchema as AvroSchema | undefined;
   if (
     codec !== 'null' &&
     codec !== 'deflate' &&
@@ -492,21 +500,19 @@ async function* readAvroRows(
       })
     : ocf.blocks;
   for (const blockInfo of blocks) {
-    const block = new AvroReader(
-      await decompressAvro(
+    const rows = decodeAvroBlockRows(
+      bytes.subarray(blockInfo.dataOffset, blockInfo.dataOffset + blockInfo.compressedSize),
+      blockInfo.count,
+      {
+        schema,
         codec,
-        bytes.subarray(blockInfo.dataOffset, blockInfo.dataOffset + blockInfo.compressedSize)
-      ),
-      schema,
+        syncMarker: ocf.syncMarker,
+        metadata: ocf.metadata,
+        dataOffset: 0
+      },
       options
     );
-    for (let index = 0; index < blockInfo.count; index++) {
-      const value = block.readValue(schema);
-      if (!isRecord(value)) {
-        throw new Error('Avro root schema must be a record to produce an object-row table');
-      }
-      yield readerSchema ? resolveReaderRecord(value, schema, readerSchema) : value;
-    }
+    yield* rows;
   }
 }
 

--- a/modules/parquet/test/avro-file-parser.spec.ts
+++ b/modules/parquet/test/avro-file-parser.spec.ts
@@ -1,0 +1,50 @@
+import * as arrow from 'apache-arrow';
+import {expect, test} from 'vitest';
+import {createReadableFileFromBuffer} from 'test/utils/readable-files';
+import {AvroWriter} from '../src/avro-writer';
+import {parseAvroInBatchesFromFile} from '../src/lib/parsers/parse-avro';
+
+test('Avro file parsing reads small files through the whole-file path', async () => {
+  const encoded = await AvroWriter.encode({
+    shape: 'arrow-table',
+    data: arrow.tableFromArrays({id: [1, 2], label: ['one', 'two']})
+  });
+  const file = await createReadableFileFromBuffer(encoded);
+  const batches = [];
+
+  for await (const batch of parseAvroInBatchesFromFile(file, {batchSize: 1})) {
+    batches.push(batch);
+  }
+
+  expect(batches.map(batch => batch.length)).toEqual([1, 1]);
+  expect(batches[1].data.getChild('label')?.get(0)).toBe('two');
+});
+
+test('Avro file parsing reads multiple ranged blocks and applies block selection', async () => {
+  const encoded = await AvroWriter.encode(
+    {
+      shape: 'arrow-table',
+      data: arrow.tableFromArrays({
+        id: Array.from({length: 160}, (_, index) => index),
+        label: Array.from({length: 160}, (_, index) => `${'x'.repeat(40)}-${index}`)
+      })
+    },
+    {avro: {blockSize: 1000}}
+  );
+  const file = await createReadableFileFromBuffer(encoded);
+  const batches = [];
+
+  for await (const batch of parseAvroInBatchesFromFile(file, {
+    batchSize: 15,
+    blockIndices: [2, 5],
+    rangeChunkSize: 1024
+  })) {
+    batches.push(batch);
+  }
+
+  const selectedIds = batches.flatMap(batch => Array.from(batch.data.getChild('id')?.toArray() || []));
+  expect(selectedIds.length).toBeGreaterThan(20);
+  expect(selectedIds.every(id => Number(id) >= 0 && Number(id) < 160)).toBe(true);
+  expect(selectedIds.includes(0)).toBe(false);
+  expect(selectedIds.includes(159)).toBe(false);
+});

--- a/modules/parquet/test/avro-schema-validation.spec.ts
+++ b/modules/parquet/test/avro-schema-validation.spec.ts
@@ -1,0 +1,68 @@
+import {expect, test} from 'vitest';
+import {parseAvroSchema} from '../src/lib/parsers/parse-avro-schema';
+
+test.each([
+  ['{', 'Invalid Avro schema JSON'],
+  ['null', 'expected a string, object, or union'],
+  ['[]', 'empty union'],
+  ['"missing"', 'unknown type'],
+  ['{"type":"record"}', 'invalid or missing name'],
+  ['{"type":"record","name":"Root"}', 'expected an array'],
+  ['{"type":"record","name":"Root","fields":[null]}', 'invalid field'],
+  ['{"type":"array"}', 'expected a string, object, or union'],
+  ['{"type":"map","values":"missing"}', 'unknown type'],
+  ['{"type":"unknown"}', 'unknown type'],
+  ['{"type":"fixed","name":"Value","size":-1}', 'non-negative integer'],
+  ['{"type":"enum","name":"Kind","symbols":["A",1]}', 'array of strings']
+])('rejects invalid standalone schema: %s', (schema, message) => {
+  expect(() => parseAvroSchema(schema)).toThrow(message);
+});
+
+test('validates nested named schemas, unions, collections, and defaults', () => {
+  const schema = {
+    type: 'record',
+    name: 'Root',
+    fields: [
+      {name: 'enabled', type: 'boolean', default: false},
+      {name: 'count', type: 'long', default: 3},
+      {name: 'payload', type: 'bytes', default: 'abc'},
+      {name: 'items', type: {type: 'array', items: 'int'}, default: [1, 2]},
+      {name: 'labels', type: {type: 'map', values: 'string'}, default: {first: 'one'}},
+      {
+        name: 'kind',
+        type: {type: 'enum', name: 'Kind', symbols: ['A', 'B']},
+        default: 'A'
+      },
+      {
+        name: 'value',
+        type: {type: 'fixed', name: 'Value', size: 2},
+        default: 'ab'
+      },
+      {
+        name: 'nested',
+        type: {
+          type: 'record',
+          name: 'Nested',
+          fields: [{name: 'id', type: 'int'}]
+        },
+        default: {id: 7}
+      },
+      {name: 'optional', type: ['null', 'string'], default: null}
+    ]
+  };
+
+  expect(parseAvroSchema(JSON.stringify(schema))).toEqual(schema);
+});
+
+test.each([
+  ['{"type":"record","name":"Root","fields":[{"name":"value","type":"int","default":1.5}]}', 'expected integer'],
+  ['{"type":"record","name":"Root","fields":[{"name":"value","type":"boolean","default":1}]}', 'expected boolean'],
+  ['{"type":"record","name":"Root","fields":[{"name":"value","type":"null","default":false}]}', 'expected null'],
+  ['{"type":"record","name":"Root","fields":[{"name":"value","type":["string","null"],"default":null}]}', 'expected string'],
+  ['{"type":"record","name":"Root","fields":[{"name":"value","type":{"type":"array","items":"int"},"default":{}}]}', 'expected array'],
+  ['{"type":"record","name":"Root","fields":[{"name":"value","type":{"type":"map","values":"int"},"default":[]}]}', 'expected object map'],
+  ['{"type":"record","name":"Root","fields":[{"name":"value","type":{"type":"enum","name":"Kind","symbols":["A"]},"default":"B"}]}', 'unknown enum symbol'],
+  ['{"type":"record","name":"Root","fields":[{"name":"value","type":{"type":"fixed","name":"Value","size":2},"default":1}]}', 'expected string']
+])('rejects incompatible Avro defaults: %s', (schema, message) => {
+  expect(() => parseAvroSchema(schema)).toThrow(message);
+});

--- a/modules/sql/test/arrow-query.spec.ts
+++ b/modules/sql/test/arrow-query.spec.ts
@@ -397,6 +397,77 @@ test('queryArrowTable computes min, max, count-all, and empty aggregates', () =>
   ).toEqual([]);
 });
 
+test('queryArrowTable evaluates scalar expression edge cases', () => {
+  const result = queryArrowTable(
+    makeArrowTable({left: [8, null], right: [2, 0], label: ['x', 'y']}),
+    {
+      expressions: [
+        {name: 'difference', expression: {op: 'subtract', left: 'left', right: 'right'}},
+        {name: 'ratio', expression: {op: 'divide', left: 'left', right: 'right'}},
+        {name: 'literal', expression: {op: 'literal', value: 'constant'}},
+        {name: 'copied', expression: {op: 'column', column: 'label'}}
+      ],
+      columns: ['difference', 'ratio', 'literal', 'copied']
+    }
+  );
+
+  expect(toRows(result)).toEqual([
+    {difference: 6, ratio: 4, literal: 'constant', copied: 'x'},
+    {difference: null, ratio: null, literal: 'constant', copied: 'y'}
+  ]);
+  expect(() =>
+    queryArrowTable(makeArrowTable({left: ['x'], right: [1]}), {
+      expressions: [{name: 'invalid', expression: {op: 'add', left: 'left', right: 'right'}}]
+    })
+  ).toThrow(/numeric operands/);
+});
+
+test('queryArrowTable orders supported scalar types and rejects unsupported types', () => {
+  const result = queryArrowTable(
+    makeArrowTable({
+      date: [new Date(2), new Date(1)],
+      bytes: [new Uint8Array([2]), new Uint8Array([1])],
+      flag: [false, true]
+    }),
+    {columns: ['date'], orderBy: [{column: 'date'}]}
+  );
+  expect(toRows(result).map(row => row.date)).toEqual([1, 2]);
+
+  expect(() =>
+    queryArrowTable(makeArrowTable({bytes: [new Uint8Array([1]), new Uint8Array([2])]}), {
+      orderBy: [{column: 'bytes'}]
+    })
+  ).toThrow(/cannot compare/);
+  expect(
+    toRows(
+      queryArrowTable(makeArrowTable({flag: [false, true]}), {
+        columns: ['flag'],
+        orderBy: [{column: 'flag', direction: 'desc'}]
+      })
+    )
+  ).toEqual([{flag: true}, {flag: false}]);
+});
+
+test('queryArrowTable reports missing UNION and JOIN sources', () => {
+  const table = makeArrowTable({id: [1]});
+  expect(() => queryArrowTable(table, {union: [{source: 'missing'}], tables: {}})).toThrow(
+    /union source not found/
+  );
+  expect(() =>
+    queryArrowTable(table, {
+      join: {child: {source: 'missing'}, left: 'id', right: 'id'},
+      tables: {}
+    })
+  ).toThrow(/join source not found/);
+  expect(() =>
+    queryArrowTable(table, {
+      join: {child: {source: 'child'}, left: 'id', right: 'id'},
+      tables: {child: makeArrowTable({id: [1]})},
+      columns: ['id', 'child.id', 'child.id']
+    })
+  ).toThrow(/more than once/);
+});
+
 /** Wraps simple test columns in the loaders.gl Arrow table shape. */
 function makeArrowTable(columns: Record<string, readonly unknown[]>): ArrowTable {
   const data = arrow.tableFromArrays(columns);


### PR DESCRIPTION
## Goals

- Move coverage with high-signal tests around dense Avro and Arrow SQL paths.
- Remove duplicated Avro block-decoding control flow without changing streaming behavior.
- Keep performance-sensitive CSV and format fast paths intact.

## Changes

- Consolidate OCF block row decoding across in-memory, URL-range, and random-access file parsing into one streaming async generator.
- Add ranged-file Avro tests covering whole-file reads, multi-block reads, batching, and block selection.
- Add standalone Avro schema validation coverage for nested records, unions, arrays, maps, enums, fixed values, and invalid defaults.
- Add SQL expression, ordering, and missing-source/error-path coverage.
- Test audit remains at 0 Tape and 0 violations.

## Validation

- `yarn lint fix`
- `yarn test-audit`
- Focused Chromium suites: 81 tests passed
- `yarn build` type-checked the changed Parquet module, then stopped on the existing LAS WASM artifact-copy issue: `dist/libs/laz-rs-wasm` is not a directory.