### PR TITLE
fix(draco): harden decoder attribute extraction

### DIFF
--- a/docs/modules/draco/api-reference/draco-loader.md
+++ b/docs/modules/draco/api-reference/draco-loader.md
@@ -47,6 +47,9 @@ General:
 Attributes:
 
 - Supports custom attributes.
+- Preserves multiple color, texture-coordinate, and other same-category attributes. When a Draco
+  file has no name metadata, inferred names are made unique with numeric suffixes such as
+  `COLOR_0`, `COLOR_1`, `TEXCOORD_0`, and `TEXCOORD_1`.
 - Ability to prevent decompression of specific attributes (returns quantization or octahedron transform parameters, if application wishes to perform decompression on GPU).
 
 Metadata Support:

--- a/docs/modules/draco/formats/draco.md
+++ b/docs/modules/draco/formats/draco.md
@@ -40,6 +40,9 @@ While possible to use independently, Draco compression is primarily used to comp
 
 Notes:
 
+- Multiple attributes of the same Draco category are preserved. If an attribute has no explicit
+  metadata name, the loader assigns collision-free names such as `COLOR_0`, `COLOR_1`,
+  `TEXCOORD_0`, and `TEXCOORD_1`.
 - `Float64` and other 64 bit formats are not valid for glTF geometry attributes, These are normally only used for "extra" attributes. 64 bit attributes can appear when converting LAS files with metadata to glTF or 3D Tiles, see [CesiumJS blog](https://cesium.com/blog/2024/03/20/preserving-more-metadata-for-point-clouds-using-3dtiles/)
 - loaders.gl ignores unsupported attributes.
 

--- a/docs/whats-new.mdx
+++ b/docs/whats-new.mdx
@@ -61,6 +61,7 @@ Release Date: 2026
 - `DracoLoader` and `DracoWriter` now use the Draco 1.5.7 WebAssembly decoder and encoder, including browser writer-worker support. Mesh decoding avoids an unnecessary Arrow round trip, compact meshes use 16-bit indices, and normalized attributes and typed-array view bounds survive encoding.
 - glTF Draco decompression now honors the extension's semantic-to-unique-ID mapping, including multiple texture-coordinate, color, and custom attributes.
 - `DracoWriter` preserves original application attribute names, supports explicit Draco attribute categories and point-cloud deduplication, and rejects inconsistent geometry before invoking the native encoder.
+- `DracoLoader` preserves unnamed same-category attributes with collision-free semantic names, validates native attribute and index extraction, and releases native decode status objects promptly.
 
 **@loaders.gl/gltf**
 

--- a/modules/draco/src/lib/draco-parser.ts
+++ b/modules/draco/src/lib/draco-parser.ts
@@ -669,14 +669,14 @@ function getUniqueAttributeName(
   attributeName: string,
   attributes: Record<string, MeshAttribute>
 ): string {
-  if (!(attributeName in attributes)) {
+  if (!Object.prototype.hasOwnProperty.call(attributes, attributeName)) {
     return attributeName;
   }
 
   const suffixMatch = /^(.*)_([0-9]+)$/.exec(attributeName);
-  const baseName = suffixMatch?.[1] || attributeName;
-  let suffix = suffixMatch ? Number(suffixMatch[2]) + 1 : 1;
-  while (`${baseName}_${suffix}` in attributes) {
+  const baseName = suffixMatch ? suffixMatch[1] : attributeName;
+  let suffix = suffixMatch ? BigInt(suffixMatch[2]) + 1n : 1n;
+  while (Object.prototype.hasOwnProperty.call(attributes, `${baseName}_${suffix}`)) {
     suffix++;
   }
   return `${baseName}_${suffix}`;

--- a/modules/draco/src/lib/draco-parser.ts
+++ b/modules/draco/src/lib/draco-parser.ts
@@ -21,7 +21,8 @@ import type {
   Metadata,
   MetadataQuerier,
   DracoInt32Array,
-  draco_DataType
+  draco_DataType,
+  Status
 } from '../draco3d/draco3d-types';
 
 // Parsed data types (output)
@@ -117,8 +118,8 @@ export default class DracoParser {
         ? new this.draco.Mesh()
         : new this.draco.PointCloud();
 
+    let dracoStatus: Status | null = null;
     try {
-      let dracoStatus;
       switch (geometry_type) {
         case this.draco.TRIANGULAR_MESH:
           dracoStatus = this.decoder.DecodeArrayToMesh(
@@ -166,6 +167,9 @@ export default class DracoParser {
       };
       return data;
     } finally {
+      if (dracoStatus) {
+        this.draco.destroy(dracoStatus);
+      }
       if (dracoGeometry) {
         this.draco.destroy(dracoGeometry);
       }
@@ -307,8 +311,12 @@ export default class DracoParser {
   ): {[attributeName: string]: MeshAttribute} {
     const attributes: {[key: string]: MeshAttribute} = {};
 
-    for (const loaderAttribute of Object.values(loaderData.attributes)) {
-      const attributeName = this._deduceAttributeName(loaderAttribute, options);
+    const loaderAttributes = Object.values(loaderData.attributes).sort(
+      (left, right) => left.attribute_index - right.attribute_index
+    );
+    for (const loaderAttribute of loaderAttributes) {
+      const deducedAttributeName = this._deduceAttributeName(loaderAttribute, options);
+      const attributeName = getUniqueAttributeName(deducedAttributeName, attributes);
       loaderAttribute.name = attributeName;
       const values = this._getAttributeValues(dracoGeometry, loaderAttribute);
       if (values) {
@@ -336,16 +344,22 @@ export default class DracoParser {
     // Example on how to retrieve mesh and attributes.
     const numFaces = dracoGeometry.num_faces();
     const numIndices = numFaces * 3;
-    const useUint16 = dracoGeometry.num_points() < 65535;
+    const useUint16 = dracoGeometry.num_points() <= 65536;
     const byteLength = numIndices * (useUint16 ? UINT16_INDEX_ITEM_SIZE : UINT32_INDEX_ITEM_SIZE);
 
     const ptr = this.draco._malloc(byteLength);
     try {
       if (useUint16) {
-        this.decoder.GetTrianglesUInt16Array(dracoGeometry, byteLength, ptr);
+        const decoded = this.decoder.GetTrianglesUInt16Array(dracoGeometry, byteLength, ptr);
+        if (!decoded) {
+          throw new Error('DRACO: Failed to decode triangle indices.');
+        }
         return new Uint16Array(this.draco.HEAPU8.buffer, ptr, numIndices).slice();
       }
-      this.decoder.GetTrianglesUInt32Array(dracoGeometry, byteLength, ptr);
+      const decoded = this.decoder.GetTrianglesUInt32Array(dracoGeometry, byteLength, ptr);
+      if (!decoded) {
+        throw new Error('DRACO: Failed to decode triangle indices.');
+      }
       return new Uint32Array(this.draco.HEAPU8.buffer, ptr, numIndices).slice();
     } finally {
       this.draco._free(ptr);
@@ -394,13 +408,16 @@ export default class DracoParser {
     const ptr = this.draco._malloc(byteLength);
     try {
       const dracoAttribute = this.decoder.GetAttribute(dracoGeometry, attribute.attribute_index);
-      this.decoder.GetAttributeDataArrayForAllPoints(
+      const decoded = this.decoder.GetAttributeDataArrayForAllPoints(
         dracoGeometry,
         dracoAttribute,
         dataType,
         byteLength,
         ptr
       );
+      if (!decoded) {
+        throw new Error(`DRACO: Failed to decode attribute ${attribute.unique_id}.`);
+      }
       value = new TypedArrayCtor(this.draco.HEAPU8.buffer, ptr, numValues).slice();
     } finally {
       this.draco._free(ptr);
@@ -645,4 +662,22 @@ function getUint32Array(dracoArray: DracoInt32Array): Uint32Array {
     intArray[i] = dracoArray.GetValue(i);
   }
   return intArray;
+}
+
+/** Returns a collision-free output name without discarding an earlier decoded attribute. */
+function getUniqueAttributeName(
+  attributeName: string,
+  attributes: Record<string, MeshAttribute>
+): string {
+  if (!(attributeName in attributes)) {
+    return attributeName;
+  }
+
+  const suffixMatch = /^(.*)_([0-9]+)$/.exec(attributeName);
+  const baseName = suffixMatch?.[1] || attributeName;
+  let suffix = suffixMatch ? Number(suffixMatch[2]) + 1 : 1;
+  while (`${baseName}_${suffix}` in attributes) {
+    suffix++;
+  }
+  return `${baseName}_${suffix}`;
 }

--- a/modules/draco/test/lib/draco-parser.spec.ts
+++ b/modules/draco/test/lib/draco-parser.spec.ts
@@ -228,6 +228,38 @@ test('DracoParser preserves attributes with colliding inferred names', () => {
   expect(attributes.TEXCOORD_1.value[0]).toBe(13);
 });
 
+test('DracoParser safely preserves adversarial metadata names', () => {
+  const parser = createParser();
+  const unsafeSuffixName = 'CUSTOM_9007199254740992';
+  const loaderAttributes = [
+    {unique_id: 1, attribute_index: 0, metadata: {name: {string: unsafeSuffixName}}},
+    {unique_id: 2, attribute_index: 1, metadata: {name: {string: unsafeSuffixName}}},
+    {unique_id: 3, attribute_index: 2, metadata: {name: {string: 'constructor'}}}
+  ].map(attribute => ({
+    ...attribute,
+    attribute_type: 4,
+    data_type: 9,
+    num_components: 1,
+    byte_offset: 0,
+    byte_stride: 4,
+    normalized: false
+  }));
+  const loaderData = {
+    attributes: Object.fromEntries(
+      loaderAttributes.map(attribute => [attribute.unique_id, attribute])
+    )
+  } as any;
+  (parser as any)._getAttributeValues = () => ({value: new Float32Array([1]), size: 1});
+
+  const attributes = parser._getMeshAttributes(loaderData, {} as any, {});
+
+  expect(Object.keys(attributes)).toEqual([
+    unsafeSuffixName,
+    'CUSTOM_9007199254740993',
+    'constructor'
+  ]);
+});
+
 test('DracoParser reports native extraction failures', () => {
   const parser = createParser();
   const geometry = {num_faces: () => 1, num_points: () => 3} as any;

--- a/modules/draco/test/lib/draco-parser.spec.ts
+++ b/modules/draco/test/lib/draco-parser.spec.ts
@@ -60,12 +60,15 @@ function createParser(): DracoParser {
     GetAttribute: () => new FakeAttribute(),
     GetAttributeDataArrayForAllPoints: () => {
       new Float32Array(heap).set([1, 2, 3, 4, 5, 6]);
+      return true;
     },
     GetTrianglesUInt32Array: (_geometry: unknown, _length: number, pointer: number) => {
       new Uint32Array(heap, pointer, 3).set([0, 1, 2]);
+      return true;
     },
     GetTrianglesUInt16Array: (_geometry: unknown, _length: number, pointer: number) => {
       new Uint16Array(heap, pointer, 3).set([0, 1, 2]);
+      return true;
     },
     GetTriangleStripsFromMesh: (_geometry: unknown, array: FakeIntArray) => {
       array.values = [0, 1, 2, 2, 1, 3];
@@ -77,6 +80,8 @@ function createParser(): DracoParser {
   };
   const draco: any = {
     ...decoder,
+    POINT_CLOUD: 0,
+    TRIANGULAR_MESH: 1,
     Decoder: class {
       constructor() {
         return decoder;
@@ -89,7 +94,9 @@ function createParser(): DracoParser {
       }
     },
     Mesh: class {},
-    PointCloud: class {},
+    PointCloud: class {
+      ptr = 1;
+    },
     DracoInt32Array: FakeIntArray,
     HEAPU8: {buffer: heap},
     DT_FLOAT32: 9,
@@ -176,11 +183,91 @@ test('DracoParser copies mesh indices and handles metadata absence', () => {
   expect(Array.from(parser._getTriangleListIndices(geometry))).toEqual([0, 1, 2]);
   expect(parser._getTriangleListIndices(geometry)).toBeInstanceOf(Uint16Array);
   expect(
-    parser._getTriangleListIndices({num_faces: () => 1, num_points: () => 65535} as any)
+    parser._getTriangleListIndices({num_faces: () => 1, num_points: () => 65536} as any)
+  ).toBeInstanceOf(Uint16Array);
+  expect(
+    parser._getTriangleListIndices({num_faces: () => 1, num_points: () => 65537} as any)
   ).toBeInstanceOf(Uint32Array);
   expect(Array.from(parser._getTriangleStripIndices(geometry))).toEqual([0, 1, 2, 2, 1, 3]);
   expect(parser._getDracoMetadata({ptr: 0} as any)).toEqual({});
   parser.destroy();
+});
+
+test('DracoParser preserves attributes with colliding inferred names', () => {
+  const parser = createParser();
+  const loaderAttributes = [
+    {unique_id: 11, attribute_type: 2, attribute_index: 1},
+    {unique_id: 10, attribute_type: 2, attribute_index: 0},
+    {unique_id: 13, attribute_type: 3, attribute_index: 3},
+    {unique_id: 12, attribute_type: 3, attribute_index: 2}
+  ].map(attribute => ({
+    ...attribute,
+    data_type: 9,
+    num_components: 1,
+    byte_offset: 0,
+    byte_stride: 4,
+    normalized: false,
+    metadata: {}
+  }));
+  const loaderData = {
+    attributes: Object.fromEntries(
+      loaderAttributes.map(attribute => [attribute.unique_id, attribute])
+    )
+  } as any;
+  (parser as any)._getAttributeValues = (_geometry: unknown, attribute: {unique_id: number}) => ({
+    value: new Float32Array([attribute.unique_id]),
+    size: 1
+  });
+
+  const attributes = parser._getMeshAttributes(loaderData, {} as any, {});
+
+  expect(Object.keys(attributes)).toEqual(['COLOR_0', 'COLOR_1', 'TEXCOORD_0', 'TEXCOORD_1']);
+  expect(attributes.COLOR_0.value[0]).toBe(10);
+  expect(attributes.COLOR_1.value[0]).toBe(11);
+  expect(attributes.TEXCOORD_0.value[0]).toBe(12);
+  expect(attributes.TEXCOORD_1.value[0]).toBe(13);
+});
+
+test('DracoParser reports native extraction failures', () => {
+  const parser = createParser();
+  const geometry = {num_faces: () => 1, num_points: () => 3} as any;
+  const attribute = {
+    unique_id: 7,
+    attribute_type: 4,
+    data_type: 9,
+    num_components: 3,
+    byte_offset: 0,
+    byte_stride: 12,
+    normalized: false,
+    attribute_index: 0,
+    metadata: {}
+  } as any;
+
+  parser.decoder.GetTrianglesUInt16Array = () => false;
+  expect(() => parser._getTriangleListIndices(geometry)).toThrow(
+    'DRACO: Failed to decode triangle indices.'
+  );
+  parser.decoder.GetAttributeDataArrayForAllPoints = () => false;
+  expect(() => parser._getAttributeValues(geometry, attribute)).toThrow(
+    'DRACO: Failed to decode attribute 7.'
+  );
+});
+
+test('DracoParser releases the native decode status after failure', () => {
+  const parser = createParser();
+  const status = {
+    ok: () => false,
+    error_msg: () => 'invalid fixture'
+  } as any;
+  const destroyedObjects: unknown[] = [];
+  parser.decoder.GetEncodedGeometryType = () => parser.draco.POINT_CLOUD;
+  parser.decoder.DecodeArrayToPointCloud = () => status;
+  parser.draco.destroy = object => destroyedObjects.push(object);
+
+  expect(() => parser.parseSync(new ArrayBuffer(8))).toThrow(
+    'DRACO decompression failed: invalid fixture'
+  );
+  expect(destroyedObjects).toContain(status);
 });
 
 test('DracoParser reports matching topology and glTF primitive modes', () => {


### PR DESCRIPTION
## Goals

- Preserve every decoded Draco attribute, including unnamed secondary color and texture-coordinate sets.
- Fail clearly when the native decoder cannot extract attributes or indices.
- Tighten decoder resource management and index representation correctness.

## Changes

- Resolve inferred attribute-name collisions deterministically in encoded attribute order, producing names such as `COLOR_0`, `COLOR_1`, `TEXCOORD_0`, and `TEXCOORD_1` without overwriting data.
- Check the boolean results from native attribute and triangle extraction APIs and report precise decoding errors.
- Use 16-bit indices for the complete safe range of up to 65,536 vertices.
- Destroy native decode status objects on both successful and failed parses.
- Add regression coverage for duplicate semantics, extraction failures, status cleanup, and the index boundary.
- Document multi-attribute behavior in the loader API, Draco format page, and release notes.

## Validation

- `yarn install`
- `yarn lint fix`
- `yarn build`
- `yarn build-workers`
- `yarn test-node`: 361 passed, 6 skipped
- `yarn test-headless modules/draco/test`: 53 passed
- `yarn test-headless`: 3,222 passed, 39 skipped
- `yarn test-audit`: 620 files, 0 violations