### PR TITLE
feat(i3s): implement horizontal CRS transforms

### DIFF
--- a/docs/developer-guide/coordinate-reference-systems.md
+++ b/docs/developer-guide/coordinate-reference-systems.md
@@ -187,7 +187,7 @@ mean coordinate transformation.
 | WFS | Capability/request identifiers and GML `srsName` | Identifier preservation is partial | Server-side output CRS request where supported |
 | WMTS | Tile-matrix-set supported CRS | Capability metadata | Server-selected tile matrix set; no client tile reprojection |
 | ArcGIS services | Spatial reference WKID/latestWKID fields | Service metadata and request fields are retained | Server-side `outSR`/image request behavior where implemented |
-| I3S | WKID/latestWKID, WKT, VCS WKIDs, `heightModelInfo`, and extent CRS | Raw fields plus normalized `spatialMetadata`; longitude/latitude wire order is explicit | Shared Proj4/geoid transformer available; complete mesh/Point Cloud bounds and elevation integration is in progress |
+| I3S | WKID/latestWKID, WKT, VCS WKIDs, `heightModelInfo`, and extent CRS | Raw fields plus normalized `spatialMetadata`; longitude/latitude wire order is explicit | Mesh and Point Cloud vertices, origins, normals, and bounds support requested geographic/projected output; vertical placement integration is in progress |
 | 3D Tiles | CRS/epoch metadata semantics and region-established global frames | Raw schema/entity metadata plus normalized `spatialMetadata`; local/unknown tilesets stay unknown | Shared transformer available; nonlinear content/bounds and nested-tileset integration is in progress |
 | MVT / TileJSON | Implicit tile coordinates; TileJSON bounds are longitude/latitude | Tile transform and metadata retained | Implicit Web Mercator tiling; no arbitrary CRS |
 | KML | Implicit WGS84 longitude/latitude/altitude | Coordinate values retained | None |

--- a/docs/modules/i3s/api-reference/i3s-point-cloud-source.md
+++ b/docs/modules/i3s/api-reference/i3s-point-cloud-source.md
@@ -23,6 +23,7 @@ encodings and authoring are intentionally outside this read-only source.
 
 `spatial.targetCrs` requests geographic, projected, or WGS84 geocentric output. The source
 reprojects absolute `Float64` points, then returns renderer-ready `Float32` offsets around a stable
-target origin. Node bounds and view metadata are rebuilt in the same target frame. See
-[Coordinate reference systems in I3S](../concepts/coordinate-reference-systems) for supported
-definitions and registration rules.
+target origin. Each tile retains a WGS84 geographic `boundingVolume` for generic traversal and
+exposes the content/output-frame bound separately as `spatialBoundingVolume`. See [Coordinate
+reference systems in I3S](../concepts/coordinate-reference-systems) for supported definitions and
+registration rules.

--- a/docs/modules/i3s/api-reference/i3s-point-cloud-source.md
+++ b/docs/modules/i3s/api-reference/i3s-point-cloud-source.md
@@ -9,7 +9,8 @@ import {I3SPointCloudSource} from '@loaders.gl/i3s';
 import {PointCloudTileset} from '@loaders.gl/tiles';
 
 const source = new I3SPointCloudSource(layerUrl, {
-  i3s: {token: arcgisToken, coordinateSystem: 'meter-offsets'}
+  i3s: {token: arcgisToken},
+  spatial: {targetCrs: 'EPSG:3857'}
 });
 const tileset = new PointCloudTileset(source, {pointBudget: 2_000_000});
 await tileset.tilesetInitializationPromise;
@@ -19,3 +20,9 @@ The source decodes LEPCC XYZ, RGB, intensity, and flag resources and maps them t
 point-list Arrow tables. Metadata-described scalar attributes are retained under their declared
 names. `density-threshold` node-page metrics are honored by `PointCloudTileset`; producer-specific
 encodings and authoring are intentionally outside this read-only source.
+
+`spatial.targetCrs` requests geographic, projected, or WGS84 geocentric output. The source
+reprojects absolute `Float64` points, then returns renderer-ready `Float32` offsets around a stable
+target origin. Node bounds and view metadata are rebuilt in the same target frame. See
+[Coordinate reference systems in I3S](../concepts/coordinate-reference-systems) for supported
+definitions and registration rules.

--- a/docs/modules/i3s/concepts/coordinate-reference-systems.md
+++ b/docs/modules/i3s/concepts/coordinate-reference-systems.md
@@ -102,7 +102,10 @@ affine across a tile. Normals use local inverse-transpose/Jacobian information; 
 through the position function.
 
 At the antimeridian, geographic bounds use wrapped intervals rather than expanding across nearly
-the entire globe. Cartesian bounds are rebuilt from samples so culling and LOD remain continuous.
+the entire globe. Target-frame Cartesian bounds are rebuilt from samples and exposed as
+`spatialBoundingVolume`. Mesh traversal retains a WGS84 ECEF bound and Point Cloud traversal
+retains a WGS84 geographic bound, because generic traversal operates in those common frames
+independently of the renderer's requested output CRS.
 
 ## Current v5 boundary
 
@@ -123,7 +126,8 @@ falls back to coordinates in a different CRS.
 Renderer-facing positions remain `Float32` offsets around a double-precision target origin.
 Projected and geocentric outputs include that origin in `modelMatrix`; geographic output uses
 `lnglat-offsets`. Returned content and source metadata report `status: 'transformed'` only after
-geometry and traversal bounds have both moved into the requested frame.
+geometry and the parallel `spatialBoundingVolume` have moved into the requested frame. Traversal
+bounds are normalized separately into their documented ECEF or geographic common frame.
 
 ## Authoring requirements
 

--- a/docs/modules/i3s/concepts/coordinate-reference-systems.md
+++ b/docs/modules/i3s/concepts/coordinate-reference-systems.md
@@ -31,6 +31,32 @@ console.log(layer.spatialMetadata);  // normalized descriptor
 SceneServer metadata exposes the descriptor as `spatialMetadata`; mesh `Tileset3D` exposes it as
 `tileset.spatialReference`; `I3SPointCloudSource.spatialReference` is populated at initialization.
 
+## Requesting horizontal output
+
+Mesh and Point Cloud sources share the same `TilesetSpatialOptions` contract. Configure a mesh
+target on `Tileset3D`, after constructing its `I3SSource`:
+
+```ts
+const source = new I3SSource({url: layerUrl, loader: I3SLoader});
+const tileset = new Tileset3D(source, {
+  spatial: {targetCrs: 'EPSG:3857'}
+});
+await tileset.tilesetInitializationPromise;
+```
+
+Point Cloud layers receive the same option directly on their source:
+
+```ts
+const source = new I3SPointCloudSource(layerUrl, {
+  spatial: {targetCrs: 'EPSG:3857'}
+});
+await source.initialize();
+```
+
+Common definitions known to Proj4 can be used directly. Register application-owned WKT or PROJ
+definitions with `registerSpatialCrs()` before constructing the source. Resource lookup is always
+explicit and no EPSG definition, datum grid, or geoid is downloaded while loading a layer.
+
 ## Wire order
 
 I3S global geometry, node centers, spheres, boxes, and extents use longitude, latitude, height
@@ -87,12 +113,17 @@ the entire globe. Cartesian bounds are rebuilt from samples so culling and LOD r
 | Normalized loader, source, service, and runtime metadata | Implemented |
 | Deterministic Proj4 and geoid primitive | Implemented |
 | Existing WGS84 mesh and Point Cloud output | Implemented |
-| Arbitrary projected vertices, normals, origins, and bounds | Integration in progress |
+| Supported geographic/projected vertices, normals, origins, and bounds | Implemented for mesh and Point Cloud sources |
 | All elevation placement modes | Requires terrain/scene provider integration |
 | Dynamic coordinate-epoch operations | Not yet executable |
 
 Missing metadata or registered resources cause an actionable error. A requested operation never
 falls back to coordinates in a different CRS.
+
+Renderer-facing positions remain `Float32` offsets around a double-precision target origin.
+Projected and geocentric outputs include that origin in `modelMatrix`; geographic output uses
+`lnglat-offsets`. Returned content and source metadata report `status: 'transformed'` only after
+geometry and traversal bounds have both moved into the requested frame.
 
 ## Authoring requirements
 

--- a/docs/modules/i3s/formats/i3s.md
+++ b/docs/modules/i3s/formats/i3s.md
@@ -166,7 +166,7 @@ transformation boundary.
 | Normalized CRS discovery metadata | **Supported** | **v5.0** | WKID aliases, WKT, VCS, height model, axis order, provenance, and placement qualifications are exposed on loader, source, service, and tileset results. |
 | Cartesian meter-offset output | **Supported** | v2.0 | This is the default geometry representation for deck.gl-compatible rendering. |
 | Longitude/latitude-offset output | **Supported** | v3.1 | Select with `i3s.coordinateSystem: 'lnglat-offsets'`. |
-| Projected or custom horizontal CRS | **Supported** | **v5.0** | Mesh and Point Cloud sources transform vertices, stable origins, normals, and bounds into supported Proj4 target definitions. EPSG:4978 uses the WGS84 geocentric path. Custom definitions must be registered explicitly. The WebScene loader retains its WGS84 boundary. |
+| Projected or custom horizontal CRS | **Supported** | **v5.0** | Mesh and Point Cloud sources transform vertices, stable origins, normals, and parallel `spatialBoundingVolume` metadata into supported Proj4 target definitions while retaining WGS84 traversal bounds. EPSG:4978 uses the WGS84 geocentric path. Custom definitions must be registered explicitly. The WebScene loader retains its WGS84 boundary. |
 | Vertical CRS and height models | **Partial** | **v5.0** | Height models and VCS are normalized, geoid resources can be registered, and conversion follows `h = H + N`; profile unit/placement integration remains tranche 6b. |
 | `elevationInfo` placement modes | **Not supported** | — | Ground-relative and scene-relative placement policies are not applied by the loader. |
 

--- a/docs/modules/i3s/formats/i3s.md
+++ b/docs/modules/i3s/formats/i3s.md
@@ -166,7 +166,7 @@ transformation boundary.
 | Normalized CRS discovery metadata | **Supported** | **v5.0** | WKID aliases, WKT, VCS, height model, axis order, provenance, and placement qualifications are exposed on loader, source, service, and tileset results. |
 | Cartesian meter-offset output | **Supported** | v2.0 | This is the default geometry representation for deck.gl-compatible rendering. |
 | Longitude/latitude-offset output | **Supported** | v3.1 | Select with `i3s.coordinateSystem: 'lnglat-offsets'`. |
-| Projected or custom horizontal CRS | **Partial** | **v5.0** | Definitions are normalized and the shared Proj4 path is implemented; complete per-profile vertex, origin, normal, and bound integration remains tranche 6a. The WebScene loader retains its WGS84 boundary. |
+| Projected or custom horizontal CRS | **Supported** | **v5.0** | Mesh and Point Cloud sources transform vertices, stable origins, normals, and bounds into supported Proj4 target definitions. EPSG:4978 uses the WGS84 geocentric path. Custom definitions must be registered explicitly. The WebScene loader retains its WGS84 boundary. |
 | Vertical CRS and height models | **Partial** | **v5.0** | Height models and VCS are normalized, geoid resources can be registered, and conversion follows `h = H + N`; profile unit/placement integration remains tranche 6b. |
 | `elevationInfo` placement modes | **Not supported** | — | Ground-relative and scene-relative placement policies are not applied by the loader. |
 
@@ -208,7 +208,7 @@ the sub-tranches under feature intelligence keep the remaining gaps independentl
 | 5f. Renderer metadata | Return point-list tables, coordinate-system/origin metadata, bounds, and stable canonical attribute names. | **Complete** (**v5.0**) |
 | 5g. Point Cloud conformance | Add deterministic decoder/source fixtures and document unsupported producer-specific extensions. | **Complete** (**v5.0**) |
 | 5h. Point profile support | Decode Point geometry, symbols, attributes, and renderer metadata with representative fixtures. | Planned |
-| 6a. Horizontal CRS transforms | Reproject supported projected and geographic layer/node coordinates into the requested output coordinate system, with axis-order and unit tests. | **In progress**: discovery/Proj4 foundation complete |
+| 6a. Horizontal CRS transforms | Reproject supported projected and geographic layer/node coordinates into the requested output coordinate system, with axis-order and unit tests. | **Complete** (**v5.0**) |
 | 6b. Vertical CRS and elevation | Resolve vertical CRS units and apply every `elevationInfo` mode, including offsets and relative-to-ground behavior. | **In progress**: height/geoid foundation complete |
 | 6c. Precision and dateline handling | Preserve Float64 source precision through origin-relative output, and cover antimeridian/dateline bounds without discontinuities. | **Complete** (**v5.0**) |
 | 7a. Profile schema validation | Add discriminated schemas for Point Cloud and mesh profiles, including required index/geometry fields and conditional profile checks. | **Complete** (**v5.0**) |
@@ -217,7 +217,7 @@ the sub-tranches under feature intelligence keep the remaining gaps independentl
 | 8a. ArcGIS SceneServer source | Provide a typed service facade and registry entry that selects the existing mesh or Point Cloud source for an explicit SceneServer layer. | **Complete** (**v5.0**) |
 | 8b. Service discovery and selection | Extend ArcGIS capability discovery to recognize SceneServer metadata and select compatible mesh/Point Cloud layers. | Planned |
 
-The next high-value work is renderer styling, CRS/elevation transforms, query helpers, and Point
+The next high-value work is renderer styling, vertical CRS/elevation placement, query helpers, and Point
 Cloud authoring.
 
 ### Remaining roadmap gaps
@@ -231,7 +231,7 @@ still visible in the matrix and should be treated as the open work list:
 | P0 | Point profile (5h) | Decode Point geometry, symbols, attributes, and renderer metadata with representative fixtures. Point Cloud support is complete for the documented v5.0 boundary. |
 | P1 | Feature queries and aggregation (4d) | Add authenticated SceneServer attribute query/filter helpers and client-side aggregation over loaded feature batches. |
 | P1 | Service discovery and selection (8b) | Recognize SceneServer entries in ArcGIS service directories and select compatible mesh or Point Cloud layer endpoints. |
-| P1 | Spatial semantics (6a–6b) | Reproject supported horizontal CRSs, honor vertical CRS and units, and apply all `elevationInfo` placement modes. Precision and dateline handling (6c) are complete. |
+| P1 | Vertical spatial semantics (6b) | Honor vertical CRS and units, then apply all `elevationInfo` placement modes. Horizontal reprojection (6a) and precision/dateline handling (6c) are complete. |
 | P1 | Mesh renderer fidelity | Decode legacy mesh-segmentation draw ranges, expose additional UV sets, map sampler wrap values to renderer constants, and add non-screen-space LOD policies. |
 | P2 | Authoring parity (7c) | Add Point/Point Cloud converter output and make generated resources pass the profile and semantic tests now covering the loaders. |
 | P2 | Delivery edge cases | Resolve direct-load token propagation, provide a first-class extracted-SLPK source, and cover mixed REST/object-store authentication in tests. |

--- a/docs/modules/tiles/api-reference/i3s-source.md
+++ b/docs/modules/tiles/api-reference/i3s-source.md
@@ -17,7 +17,9 @@ const source = new I3SSource({
   loader: I3SLoader
 })
 
-const tileset = new Tileset3D(source)
+const tileset = new Tileset3D(source, {
+  spatial: {targetCrs: 'EPSG:3857'}
+})
 await tileset.tilesetInitializationPromise
 ```
 
@@ -45,6 +47,12 @@ Parameters:
 - assembles tile-loader `_tileOptions` and `_tilesetOptions`
 - derives view state from `fullExtent` or `store.extent`
 - tracks observed content formats such as Draco, DDS, and KTX2
+- applies requested horizontal CRS transforms consistently to vertices, normals, origins, and
+  traversal bounds
+
+Set `Tileset3D`'s `spatial.targetCrs` to request geographic, projected, or WGS84 geocentric output.
+Common Proj4 definitions work directly; custom definitions and datum grids must be registered
+before tileset initialization. See [Coordinate reference systems in I3S](/docs/modules/i3s/concepts/coordinate-reference-systems).
 
 ## Key Methods
 

--- a/docs/modules/tiles/api-reference/i3s-source.md
+++ b/docs/modules/tiles/api-reference/i3s-source.md
@@ -48,7 +48,7 @@ Parameters:
 - derives view state from `fullExtent` or `store.extent`
 - tracks observed content formats such as Draco, DDS, and KTX2
 - applies requested horizontal CRS transforms consistently to vertices, normals, origins, and
-  traversal bounds
+  target-space `spatialBoundingVolume` metadata while retaining WGS84 ECEF traversal bounds
 
 Set `Tileset3D`'s `spatial.targetCrs` to request geographic, projected, or WGS84 geocentric output.
 Common Proj4 definitions work directly; custom definitions and datum grids must be registered

--- a/docs/whats-new.mdx
+++ b/docs/whats-new.mdx
@@ -45,8 +45,9 @@ Release Date: 2026
 - GeoPackage prefers `definition_12_063` WKT2 metadata when available and exposes the selected
   table CRS through source, scan, and GeoArrow field metadata.
 - I3S mesh and Point Cloud sources now apply requested horizontal CRS transforms to vertices,
-  stable origins, normals, traversal bounds, and spatial metadata, with Proj4-backed geographic and
-  projected targets plus direct WGS84 geocentric support.
+  stable origins, normals, and parallel target-space bounds, with Proj4-backed geographic and
+  projected targets plus direct WGS84 geocentric support. Traversal retains normalized WGS84
+  ECEF/geographic bounds so culling and LOD remain compatible with existing runtimes.
 
 **@loaders.gl/arrow**
 

--- a/docs/whats-new.mdx
+++ b/docs/whats-new.mdx
@@ -44,6 +44,9 @@ Release Date: 2026
   metadata instead of returning untransformed coordinates or assuming WGS84.
 - GeoPackage prefers `definition_12_063` WKT2 metadata when available and exposes the selected
   table CRS through source, scan, and GeoArrow field metadata.
+- I3S mesh and Point Cloud sources now apply requested horizontal CRS transforms to vertices,
+  stable origins, normals, traversal bounds, and spatial metadata, with Proj4-backed geographic and
+  projected targets plus direct WGS84 geocentric support.
 
 **@loaders.gl/arrow**
 

--- a/modules/i3s/src/i3s-point-cloud-source.ts
+++ b/modules/i3s/src/i3s-point-cloud-source.ts
@@ -9,6 +9,7 @@ import type {MeshAttributes} from '@loaders.gl/schema';
 import {Matrix4, Vector3} from '@math.gl/core';
 import {Ellipsoid} from '@math.gl/geospatial';
 import type {
+  PointCloudBoundingVolume,
   PointCloudTileContent,
   PointCloudTileHeader,
   PointCloudTilesetSource,
@@ -225,7 +226,7 @@ export class I3SPointCloudSource
       })
     );
 
-    const volume = tile.boundingVolume;
+    const volume = tile.spatialBoundingVolume || tile.boundingVolume;
     const table = makeMeshArrowTable(attributes, {
       topology: 'point-list',
       boundingBox: volume.cartographicBounds
@@ -236,7 +237,8 @@ export class I3SPointCloudSource
       cartographicOrigin: normalizedPositions.cartographicOrigin,
       coordinateSystem: normalizedPositions.coordinateSystem,
       modelMatrix: normalizedPositions.modelMatrix,
-      spatialReference: this.spatialTransformer?.spatialReference
+      spatialReference: this.spatialTransformer?.spatialReference,
+      spatialBoundingVolume: tile.spatialBoundingVolume
     };
   }
 
@@ -306,33 +308,35 @@ export class I3SPointCloudSource
     const center = Array.from(node.obb.center as number[]);
     const halfSize = Array.from(node.obb.halfSize as number[]);
     const radius = Math.hypot(...halfSize);
+    const commonHeader = {
+      id: String(nodeId),
+      level,
+      pointCount: node.vertexCount,
+      geometricError: node.lodThreshold || 0,
+      lodSelectionMetricType:
+        (this.metadata?.nodePages?.lodSelectionMetricType as
+          | 'maxScreenThresholdSQ'
+          | 'density-threshold'
+          | undefined) || 'maxScreenThresholdSQ',
+      lodThreshold: node.lodThreshold
+    };
     if (this.spatialTransformer) {
-      const boundingVolume = this.spatialTransformer.transformBoundingVolume({
+      const sourceBounds = {
         obb: node.obb,
         normalReferenceFrame: this.metadata?.store.normalReferenceFrame
-      });
-      const [minimum, maximum, transformedCenter, transformedRadius] =
-        getTransformedPointCloudBounds(boundingVolume);
+      };
+      const boundingVolume = getTransformedPointCloudBounds(
+        this.spatialTransformer.transformBoundingVolumeToGeographic(sourceBounds),
+        'geographic'
+      );
+      const spatialBoundingVolume = getTransformedPointCloudBounds(
+        this.spatialTransformer.transformBoundingVolume(sourceBounds),
+        this.spatialTransformer.targetCoordinateFrame === 'geographic' ? 'geographic' : 'cartesian'
+      );
       return {
-        id: String(nodeId),
-        level,
-        pointCount: node.vertexCount,
-        geometricError: node.lodThreshold || 0,
-        lodSelectionMetricType:
-          (this.metadata?.nodePages?.lodSelectionMetricType as
-            | 'maxScreenThresholdSQ'
-            | 'density-threshold'
-            | undefined) || 'maxScreenThresholdSQ',
-        lodThreshold: node.lodThreshold,
-        boundingVolume: {
-          cartographicBounds: [minimum, maximum],
-          center: transformedCenter,
-          radius: transformedRadius,
-          coordinateFrame:
-            this.spatialTransformer.targetCoordinateFrame === 'geographic'
-              ? 'geographic'
-              : 'cartesian'
-        }
+        ...commonHeader,
+        boundingVolume,
+        spatialBoundingVolume
       };
     }
     const latitudeRadians = (center[1] * Math.PI) / 180;
@@ -353,16 +357,7 @@ export class I3SPointCloudSource
       center[2] + radius
     ];
     return {
-      id: String(nodeId),
-      level,
-      pointCount: node.vertexCount,
-      geometricError: node.lodThreshold || 0,
-      lodSelectionMetricType:
-        (this.metadata?.nodePages?.lodSelectionMetricType as
-          | 'maxScreenThresholdSQ'
-          | 'density-threshold'
-          | undefined) || 'maxScreenThresholdSQ',
-      lodThreshold: node.lodThreshold,
+      ...commonHeader,
       boundingVolume: {
         cartographicBounds: [minimum, maximum],
         wrapsDateline: !coversFullLongitude && minimum[0] > maximum[0],
@@ -550,10 +545,13 @@ function normalizePointPositions(
 }
 
 /** Convert a generic transformed tile bound into the point-cloud source contract. */
-function getTransformedPointCloudBounds(boundingVolume: {
-  box?: number[];
-  region?: number[];
-}): [number[], number[], number[], number] {
+function getTransformedPointCloudBounds(
+  boundingVolume: {
+    box?: number[];
+    region?: number[];
+  },
+  coordinateFrame: 'geographic' | 'cartesian'
+): PointCloudBoundingVolume {
   if (boundingVolume.region) {
     const [west, south, east, north, minimumHeight, maximumHeight] = boundingVolume.region;
     const minimum = [(west * 180) / Math.PI, (south * 180) / Math.PI, minimumHeight];
@@ -564,12 +562,21 @@ function getTransformedPointCloudBounds(boundingVolume: {
     }
     const centerLongitude = normalizeLongitude((minimum[0] + eastUnwrapped) / 2);
     const center = [centerLongitude, (minimum[1] + maximum[1]) / 2, (minimum[2] + maximum[2]) / 2];
+    const longitudeSpan = eastUnwrapped - minimum[0];
+    const coversFullLongitude = longitudeSpan >= 360 - 1e-9;
     const radius = Math.hypot(
-      (eastUnwrapped - minimum[0]) / 2,
+      longitudeSpan / 2,
       (maximum[1] - minimum[1]) / 2,
       (maximum[2] - minimum[2]) / 2
     );
-    return [minimum, maximum, center, radius];
+    return {
+      cartographicBounds: [minimum, maximum],
+      wrapsDateline: !coversFullLongitude && minimum[0] > maximum[0],
+      coversFullLongitude,
+      center,
+      radius,
+      coordinateFrame
+    };
   }
 
   const box = boundingVolume.box;
@@ -584,5 +591,10 @@ function getTransformedPointCloudBounds(boundingVolume: {
   ];
   const minimum = center.map((value, index) => value - halfSize[index]);
   const maximum = center.map((value, index) => value + halfSize[index]);
-  return [minimum, maximum, center, Math.hypot(...halfSize)];
+  return {
+    cartographicBounds: [minimum, maximum],
+    center,
+    radius: Math.hypot(...halfSize),
+    coordinateFrame
+  };
 }

--- a/modules/i3s/src/i3s-point-cloud-source.ts
+++ b/modules/i3s/src/i3s-point-cloud-source.ts
@@ -6,16 +6,21 @@ import type {DataSourceOptions, ReadableFile} from '@loaders.gl/loader-utils';
 import {BlobFile, HttpFile} from '@loaders.gl/loader-utils';
 import {makeMeshArrowTable} from '@loaders.gl/schema-utils';
 import type {MeshAttributes} from '@loaders.gl/schema';
-import {Vector3} from '@math.gl/core';
+import {Matrix4, Vector3} from '@math.gl/core';
 import {Ellipsoid} from '@math.gl/geospatial';
 import type {
   PointCloudTileContent,
   PointCloudTileHeader,
   PointCloudTilesetSource,
   PointCloudCoordinateSystem,
+  TilesetSpatialOptions,
   TilesetSpatialReference
 } from '@loaders.gl/tiles';
-import {getI3SSpatialReference} from '@loaders.gl/tiles';
+import {
+  applyTilesetSpatialOptions,
+  getI3SSpatialReference,
+  I3SSpatialTransformer
+} from '@loaders.gl/tiles';
 import {DataSource} from '@loaders.gl/loader-utils';
 import {parseSLPKArchive} from './lib/parsers/parse-slpk/parse-slpk';
 import type {SLPKArchive} from './lib/parsers/parse-slpk/slpk-archieve';
@@ -31,6 +36,8 @@ import {getUrlWithToken} from './lib/utils/url-utils';
 
 /** Options for an {@link I3SPointCloudSource}. */
 export type I3SPointCloudSourceOptions = DataSourceOptions & {
+  /** Shared target CRS options. */
+  spatial?: TilesetSpatialOptions;
   /** I3S point-cloud options. */
   i3s?: {
     /** ArcGIS access token. */
@@ -76,6 +83,10 @@ export class I3SPointCloudSource
   private nodesPerPage = 1;
   /** Global node id of the hierarchy root. */
   private rootIndex = 0;
+  /** Shared adapter used when a target CRS has been requested. */
+  private spatialTransformer: I3SSpatialTransformer | null = null;
+  /** Transformed root header cached for view-state initialization. */
+  private rootTileHeader: PointCloudTileHeader | null = null;
 
   /**
    * Creates an I3S Point Cloud source.
@@ -101,7 +112,17 @@ export class I3SPointCloudSource
     const layerJson = await this.readJson('');
     const pointCloudLayer = I3SPointCloudSceneLayerSchema.parse(layerJson);
     this.metadata = pointCloudLayer as SceneLayer3D;
-    this.spatialReference = getI3SSpatialReference(this.metadata);
+    this.spatialReference = applyTilesetSpatialOptions(
+      getI3SSpatialReference(this.metadata),
+      this.options.spatial
+    );
+    if (this.spatialReference.status === 'transformable') {
+      this.spatialTransformer = new I3SSpatialTransformer(
+        this.spatialReference,
+        this.options.spatial
+      );
+      this.spatialReference = this.spatialTransformer.spatialReference;
+    }
     this.baseUrl = this.url.replace(/\/+$/, '');
     this.nodesPerPage = Math.max(
       1,
@@ -121,7 +142,8 @@ export class I3SPointCloudSource
   async getRootTile(): Promise<PointCloudTileHeader> {
     await this.initialize();
     const node = await this.getNode(this.rootIndex);
-    return this.makeTileHeader(this.rootIndex, node, 0);
+    this.rootTileHeader ||= this.makeTileHeader(this.rootIndex, node, 0);
+    return this.rootTileHeader;
   }
 
   /** Return the children of a point-cloud tile. */
@@ -164,11 +186,14 @@ export class I3SPointCloudSource
     // MeshArrowTable's canonical POSITION field is Float32. Preserve the tile
     // origin separately in the returned content so renderers can reconstruct
     // full precision without widening the shared Arrow schema.
-    const normalizedPositions = normalizePointPositions(
-      positions,
-      tile.boundingVolume.center,
-      this.options.i3s?.coordinateSystem
-    );
+    const sourceCenter = Array.from(node.obb.center as number[]);
+    const normalizedPositions = this.spatialTransformer
+      ? this.spatialTransformer.transformPositions(positions, sourceCenter)
+      : normalizePointPositions(
+          positions,
+          tile.boundingVolume.center,
+          this.options.i3s?.coordinateSystem
+        );
     const attributes: MeshAttributes = {
       POSITION: {value: normalizedPositions.positions, size: 3}
     };
@@ -209,12 +234,25 @@ export class I3SPointCloudSource
       data: table,
       pointCount,
       cartographicOrigin: normalizedPositions.cartographicOrigin,
-      coordinateSystem: normalizedPositions.coordinateSystem
+      coordinateSystem: normalizedPositions.coordinateSystem,
+      modelMatrix: normalizedPositions.modelMatrix,
+      spatialReference: this.spatialTransformer?.spatialReference
     };
   }
 
   /** Return a view state suitable for PointCloudTileset initialization. */
   getViewState() {
+    if (this.spatialTransformer && this.rootTileHeader) {
+      const rootNode = this.nodes.get(String(this.rootIndex));
+      const cartographicCenter = rootNode
+        ? this.spatialTransformer.transformSourcePositionToGeographic(rootNode.obb.center)
+        : undefined;
+      return {
+        cartographicCenter,
+        boundingVolume: this.rootTileHeader.boundingVolume,
+        zoom: 1
+      };
+    }
     const extent = this.metadata?.fullExtent;
     const center = extent?.xmin !== undefined ? [extent.xmin, extent.ymin, 0] : undefined;
     return center ? {cartographicCenter: center} : {};
@@ -268,6 +306,35 @@ export class I3SPointCloudSource
     const center = Array.from(node.obb.center as number[]);
     const halfSize = Array.from(node.obb.halfSize as number[]);
     const radius = Math.hypot(...halfSize);
+    if (this.spatialTransformer) {
+      const boundingVolume = this.spatialTransformer.transformBoundingVolume({
+        obb: node.obb,
+        normalReferenceFrame: this.metadata?.store.normalReferenceFrame
+      });
+      const [minimum, maximum, transformedCenter, transformedRadius] =
+        getTransformedPointCloudBounds(boundingVolume);
+      return {
+        id: String(nodeId),
+        level,
+        pointCount: node.vertexCount,
+        geometricError: node.lodThreshold || 0,
+        lodSelectionMetricType:
+          (this.metadata?.nodePages?.lodSelectionMetricType as
+            | 'maxScreenThresholdSQ'
+            | 'density-threshold'
+            | undefined) || 'maxScreenThresholdSQ',
+        lodThreshold: node.lodThreshold,
+        boundingVolume: {
+          cartographicBounds: [minimum, maximum],
+          center: transformedCenter,
+          radius: transformedRadius,
+          coordinateFrame:
+            this.spatialTransformer.targetCoordinateFrame === 'geographic'
+              ? 'geographic'
+              : 'cartesian'
+        }
+      };
+    }
     const latitudeRadians = (center[1] * Math.PI) / 180;
     const latitudeDelta = (radius / EARTH_EQUATORIAL_RADIUS) * (180 / Math.PI);
     const longitudeDelta = Math.min(
@@ -429,6 +496,8 @@ type NormalizedPointPositions = Readonly<{
   cartographicOrigin: number[];
   /** Concrete renderer coordinate system after resolving `default`. */
   coordinateSystem: PointCloudCoordinateSystem;
+  /** Optional translation for Cartesian offsets. */
+  modelMatrix?: Matrix4;
 }>;
 
 /** Converts absolute geographic LEPCC positions to the requested renderer representation. */
@@ -478,4 +547,42 @@ function normalizePointPositions(
     cartographicOrigin: [...center],
     coordinateSystem: 'lnglat-offsets'
   };
+}
+
+/** Convert a generic transformed tile bound into the point-cloud source contract. */
+function getTransformedPointCloudBounds(boundingVolume: {
+  box?: number[];
+  region?: number[];
+}): [number[], number[], number[], number] {
+  if (boundingVolume.region) {
+    const [west, south, east, north, minimumHeight, maximumHeight] = boundingVolume.region;
+    const minimum = [(west * 180) / Math.PI, (south * 180) / Math.PI, minimumHeight];
+    const maximum = [(east * 180) / Math.PI, (north * 180) / Math.PI, maximumHeight];
+    let eastUnwrapped = maximum[0];
+    if (eastUnwrapped < minimum[0]) {
+      eastUnwrapped += 360;
+    }
+    const centerLongitude = normalizeLongitude((minimum[0] + eastUnwrapped) / 2);
+    const center = [centerLongitude, (minimum[1] + maximum[1]) / 2, (minimum[2] + maximum[2]) / 2];
+    const radius = Math.hypot(
+      (eastUnwrapped - minimum[0]) / 2,
+      (maximum[1] - minimum[1]) / 2,
+      (maximum[2] - minimum[2]) / 2
+    );
+    return [minimum, maximum, center, radius];
+  }
+
+  const box = boundingVolume.box;
+  if (!box) {
+    throw new Error('Transformed I3S Point Cloud bound must contain a box or region');
+  }
+  const center = box.slice(0, 3);
+  const halfSize = [
+    Math.hypot(box[3], box[4], box[5]),
+    Math.hypot(box[6], box[7], box[8]),
+    Math.hypot(box[9], box[10], box[11])
+  ];
+  const minimum = center.map((value, index) => value - halfSize[index]);
+  const maximum = center.map((value, index) => value + halfSize[index]);
+  return [minimum, maximum, center, Math.hypot(...halfSize)];
 }

--- a/modules/i3s/src/lib/parsers/parse-i3s-tile-content.ts
+++ b/modules/i3s/src/lib/parsers/parse-i3s-tile-content.ts
@@ -9,6 +9,7 @@ import {StrictLoaderOptions, LoaderContext, parseFromContext} from '@loaders.gl/
 import {ImageBitmapLoader, getImageData} from '@loaders.gl/images';
 import {DracoLoader, DracoMesh} from '@loaders.gl/draco';
 import {BasisLoader, CompressedTextureLoader} from '@loaders.gl/textures';
+import {I3SSpatialTransformer} from '@loaders.gl/tiles';
 
 import {
   FeatureAttribute,
@@ -307,7 +308,32 @@ async function parseI3SNodeGeometry(
     attributes = concatAttributes(normalizedVertexAttributes, normalizedFeatureAttributes);
   }
 
-  if (
+  const spatialReference = tilesetOptions.spatialReference;
+  if (spatialReference?.status === 'transformable' || spatialReference?.status === 'transformed') {
+    const spatialTransformer = new I3SSpatialTransformer(
+      spatialReference,
+      tilesetOptions.spatialOptions || options?.i3s?.spatial
+    );
+    const sourcePositions = offsetsToSourcePositions(
+      attributes.position.value,
+      attributes.position.metadata,
+      tileOptions.mbs
+    );
+    const transformed = spatialTransformer.transformPositions(sourcePositions, tileOptions.mbs);
+    attributes.position.value = transformed.positions;
+    if (attributes.normal?.value) {
+      attributes.normal.value = spatialTransformer.transformNormals(
+        attributes.normal.value,
+        transformed.sourcePositions,
+        tilesetOptions.store.normalReferenceFrame
+      );
+    }
+    content.modelMatrix = transformed.modelMatrix;
+    content.coordinateSystem = transformed.coordinateSystem;
+    content.origin = transformed.origin;
+    content.cartographicOrigin = transformed.cartographicOrigin;
+    content.spatialReference = spatialTransformer.spatialReference;
+  } else if (
     !options?.i3s?.coordinateSystem ||
     // eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison
     options.i3s.coordinateSystem === COORDINATE_SYSTEM.METER_OFFSETS
@@ -549,6 +575,30 @@ function parsePositions(attribute: I3SMeshAttribute, options: I3STileOptions): M
 }
 
 /**
+ * Reconstruct absolute source positions from I3S node-relative vertex values.
+ *
+ * @param vertices - Relative I3S positions.
+ * @param metadata - Draco scale metadata.
+ * @param sourceOrigin - Node MBS center in source CRS coordinates.
+ * @returns Absolute positions retained as Float64.
+ */
+function offsetsToSourcePositions(
+  vertices: ArrayLike<number>,
+  metadata: any = {},
+  sourceOrigin: ArrayLike<number>
+): Float64Array {
+  const positions = new Float64Array(vertices.length);
+  const scaleX = (metadata['i3s-scale_x'] && metadata['i3s-scale_x'].double) || 1;
+  const scaleY = (metadata['i3s-scale_y'] && metadata['i3s-scale_y'].double) || 1;
+  for (let index = 0; index < positions.length; index += 3) {
+    positions[index] = vertices[index] * scaleX + sourceOrigin[0];
+    positions[index + 1] = vertices[index + 1] * scaleY + sourceOrigin[1];
+    positions[index + 2] = vertices[index + 2] + sourceOrigin[2];
+  }
+  return positions;
+}
+
+/**
  * Converts position coordinates to absolute cartesian coordinates
  * @param vertices - "position" attribute data
  * @param metadata - When the geometry is DRACO compressed, contain position attribute's metadata
@@ -561,14 +611,7 @@ function offsetsToCartesians(
   metadata: any = {},
   cartographicOrigin: Vector3
 ): Float64Array {
-  const positions = new Float64Array(vertices.length);
-  const scaleX = (metadata['i3s-scale_x'] && metadata['i3s-scale_x'].double) || 1;
-  const scaleY = (metadata['i3s-scale_y'] && metadata['i3s-scale_y'].double) || 1;
-  for (let i = 0; i < positions.length; i += 3) {
-    positions[i] = vertices[i] * scaleX + cartographicOrigin.x;
-    positions[i + 1] = vertices[i + 1] * scaleY + cartographicOrigin.y;
-    positions[i + 2] = vertices[i + 2] + cartographicOrigin.z;
-  }
+  const positions = offsetsToSourcePositions(vertices, metadata, cartographicOrigin);
 
   for (let i = 0; i < positions.length; i += 3) {
     // @ts-ignore

--- a/modules/i3s/src/types.ts
+++ b/modules/i3s/src/types.ts
@@ -8,7 +8,7 @@ import type {Matrix4, Quaternion, Vector3} from '@math.gl/core';
 import type {ImageDataType} from '@loaders.gl/images';
 import type {TypedArray, MeshAttribute, TextureLevel} from '@loaders.gl/schema';
 import {TILESET_TYPE, TILE_REFINEMENT, TILE_TYPE, Tile3D, Tileset3D} from '@loaders.gl/tiles';
-import type {TilesetSpatialReference} from '@loaders.gl/tiles';
+import type {TilesetSpatialOptions, TilesetSpatialReference} from '@loaders.gl/tiles';
 import I3SNodePagesTiles from './lib/helpers/i3s-nodepages-tiles';
 import {LoaderWithParser} from '@loaders.gl/loader-utils';
 import type {CoordinateSystem} from './lib/parsers/constants';
@@ -220,6 +220,8 @@ export type I3SParseOptions = {
    * Supported coordinate systems: `meter-offsets`, `lnglat-offsets`
    */
   coordinateSystem?: CoordinateSystem;
+  /** Shared target CRS options used by direct I3S content parsing. */
+  spatial?: TilesetSpatialOptions;
   /** Options to colorize 3DObjects by attribute value */
   colorsByAttribute?: {
     /** Feature attribute name */
@@ -266,6 +268,10 @@ export type I3STilesetOptions = {
   store: Store;
   attributeStorageInfo: AttributeStorageInfo[];
   fields: Field[];
+  /** Normalized source and requested target CRS metadata. */
+  spatialReference?: TilesetSpatialReference;
+  /** Registered resources used by the requested spatial operation. */
+  spatialOptions?: TilesetSpatialOptions;
 };
 
 // TODO Replace "[key: string]: any" with actual defenition
@@ -276,6 +282,12 @@ export type I3STileContent = {
   vertexCount: number;
   modelMatrix: Matrix4;
   coordinateSystem: CoordinateSystem;
+  /** Stable target origin subtracted before Float32 conversion. */
+  origin?: [number, number, number];
+  /** Geographic target origin used with longitude/latitude offsets. */
+  cartographicOrigin?: [number, number, number];
+  /** Spatial descriptor for the returned positions, origins, normals, and bounds. */
+  spatialReference?: TilesetSpatialReference;
   byteLength: number;
   texture: TileContentTexture;
   /** Decoded texture-set resources keyed by texture-set definition id. */

--- a/modules/i3s/test/i3s-point-cloud-source.browser.spec.ts
+++ b/modules/i3s/test/i3s-point-cloud-source.browser.spec.ts
@@ -131,14 +131,25 @@ test('I3SPointCloudSource traverses node pages and decodes content', async () =>
     | Iterable<number>
     | undefined;
 
-  expect(transformedRoot.boundingVolume.coordinateFrame).toBe('cartesian');
+  expect(transformedRoot.boundingVolume.coordinateFrame).toBe('geographic');
+  expect(transformedRoot.spatialBoundingVolume?.coordinateFrame).toBe('cartesian');
   expect(transformedContent?.coordinateSystem).toBe('cartesian');
   expect(transformedContent?.spatialReference).toMatchObject({
     targetCrs: 'EPSG:3857',
     status: 'transformed'
   });
   expect(transformedFirstPosition ? Array.from(transformedFirstPosition) : []).toEqual([0, 0, 0]);
+  expect(transformedContent?.spatialBoundingVolume).toBe(transformedRoot.spatialBoundingVolume);
   expect(Array.from(transformedContent?.modelMatrix || []).slice(12, 13)[0]).toBeGreaterThan(
     20_000_000
   );
+
+  const geographicTransformedSource = new I3SPointCloudSource('https://example.com/layer', {
+    spatial: {targetCrs: 'EPSG:4326'},
+    core: {loadOptions: {core: {fetch: fetchResource}}}
+  });
+  const geographicTransformedRoot = await geographicTransformedSource.getRootTile();
+  expect(geographicTransformedRoot.spatialBoundingVolume?.coordinateFrame).toBe('geographic');
+  expect(geographicTransformedRoot.spatialBoundingVolume?.wrapsDateline).toBe(true);
+  expect(geographicTransformedRoot.spatialBoundingVolume?.coversFullLongitude).toBe(false);
 });

--- a/modules/i3s/test/i3s-point-cloud-source.browser.spec.ts
+++ b/modules/i3s/test/i3s-point-cloud-source.browser.spec.ts
@@ -22,6 +22,7 @@ test('I3SPointCloudSource traverses node pages and decodes content', async () =>
           id: 1,
           layerType: 'PointCloud',
           version: '2.1',
+          spatialReference: {wkid: 4326},
           capabilities: [],
           disablePopup: false,
           store: {
@@ -114,4 +115,30 @@ test('I3SPointCloudSource traverses node pages and decodes content', async () =>
     | undefined;
   expect(cartesianContent?.coordinateSystem).toBe('cartesian');
   expect(firstPosition ? Array.from(firstPosition)[0] : 0).toBeGreaterThan(6_000_000);
+
+  const transformedSource = new I3SPointCloudSource('https://example.com/layer', {
+    spatial: {targetCrs: 'EPSG:3857'},
+    core: {loadOptions: {core: {fetch: fetchResource}}}
+  });
+  const transformedRoot = await transformedSource.getRootTile();
+  const transformedPositions = new Float64Array(106 * 3);
+  for (let index = 0; index < transformedPositions.length; index += 3) {
+    transformedPositions.set([179.999, 0, 0], index);
+  }
+  (transformedSource as any).decoder.decodeXyz = () => transformedPositions;
+  const transformedContent = await transformedSource.loadTileContent(transformedRoot);
+  const transformedFirstPosition = transformedContent?.data.data.getChild('POSITION')?.get(0) as
+    | Iterable<number>
+    | undefined;
+
+  expect(transformedRoot.boundingVolume.coordinateFrame).toBe('cartesian');
+  expect(transformedContent?.coordinateSystem).toBe('cartesian');
+  expect(transformedContent?.spatialReference).toMatchObject({
+    targetCrs: 'EPSG:3857',
+    status: 'transformed'
+  });
+  expect(transformedFirstPosition ? Array.from(transformedFirstPosition) : []).toEqual([0, 0, 0]);
+  expect(Array.from(transformedContent?.modelMatrix || []).slice(12, 13)[0]).toBeGreaterThan(
+    20_000_000
+  );
 });

--- a/modules/i3s/test/i3s-spatial-transform.spec.ts
+++ b/modules/i3s/test/i3s-spatial-transform.spec.ts
@@ -1,0 +1,59 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {createTilesetSpatialReference} from '@loaders.gl/tiles';
+import {expect, test} from 'vitest';
+import {parseI3STileContent} from '../src/lib/parsers/parse-i3s-tile-content';
+
+test('parseI3STileContent transforms mesh geometry to a requested CRS', async () => {
+  const arrayBuffer = new ArrayBuffer(44);
+  const dataView = new DataView(arrayBuffer);
+  dataView.setUint32(0, 3, true);
+  dataView.setUint32(4, 0, true);
+  const positions = [0, 0, 0, 0.001, 0, 0, 0, 0.001, 0];
+  positions.forEach((position, index) => dataView.setFloat32(8 + index * 4, position, true));
+
+  const content = await parseI3STileContent(
+    arrayBuffer,
+    {mbs: [10, 0, 12, 100]} as any,
+    {
+      store: {
+        normalReferenceFrame: 'earth-centered',
+        defaultGeometrySchema: {
+          header: [
+            {property: 'vertexCount', type: 'UInt32'},
+            {property: 'featureCount', type: 'UInt32'}
+          ],
+          ordering: ['position'],
+          vertexAttributes: {
+            position: {valueType: 'Float32', valuesPerElement: 3}
+          },
+          featureAttributeOrder: [],
+          featureAttributes: {}
+        }
+      },
+      spatialReference: createTilesetSpatialReference(
+        {
+          sourceCrs: 'EPSG:4326',
+          coordinateFrame: 'geographic',
+          axisOrder: 'xyz',
+          heightReference: 'ellipsoidal',
+          provenance: 'metadata'
+        },
+        {targetCrs: 'EPSG:3857'}
+      )
+    } as any
+  );
+
+  expect(content.coordinateSystem).toBe('cartesian');
+  expect(content.spatialReference).toMatchObject({
+    targetCrs: 'EPSG:3857',
+    status: 'transformed'
+  });
+  expect(content.attributes.positions.value).toBeInstanceOf(Float32Array);
+  expect(Array.from(content.attributes.positions.value.slice(0, 3))).toEqual([0, 0, 0]);
+  expect(content.attributes.positions.value[3]).toBeCloseTo(111.31949, 4);
+  expect(content.origin?.every(Number.isFinite)).toBe(true);
+  expect(Array.from(content.modelMatrix).slice(12, 15)).toEqual(content.origin);
+});

--- a/modules/tiles/src/index.ts
+++ b/modules/tiles/src/index.ts
@@ -114,13 +114,21 @@ export type {
 } from './spatial/spatial-types';
 export {
   applyTilesetSpatialOptions,
-  createTilesetSpatialReference
+  createTilesetSpatialReference,
+  markTilesetSpatialReferenceTransformed
 } from './spatial/spatial-types';
 export {
   get3DTilesSpatialReference,
   getI3SSpatialReference
 } from './spatial/format-spatial-reference';
 export {SpatialCoordinateTransformer} from './spatial/spatial-coordinate-transformer';
+export {getSpatialCoordinateFrame} from './spatial/spatial-coordinate-transformer';
+export type {
+  I3SSpatialBounds,
+  I3SSpatialObb,
+  I3STransformedPositions
+} from './spatial/i3s-spatial-transformer';
+export {I3SSpatialTransformer} from './spatial/i3s-spatial-transformer';
 export {
   getGeoidModel,
   registerGeoidModel,

--- a/modules/tiles/src/point-cloud/point-cloud-tileset.ts
+++ b/modules/tiles/src/point-cloud/point-cloud-tileset.ts
@@ -614,6 +614,9 @@ export class PointCloudTileset {
     if (!boundingVolume) {
       return 1;
     }
+    if (boundingVolume.coordinateFrame === 'cartesian') {
+      return 1;
+    }
 
     const [minBounds, maxBounds] = boundingVolume.cartographicBounds;
     const longitudeSpan = boundingVolume.coversFullLongitude

--- a/modules/tiles/src/point-cloud/types.ts
+++ b/modules/tiles/src/point-cloud/types.ts
@@ -37,6 +37,8 @@ export type PointCloudTileContent = {
   modelMatrix?: number[] | Float32Array;
   /** Spatial descriptor for returned points, origins, and bounds. */
   spatialReference?: TilesetSpatialReference;
+  /** Content bound expressed in the selected spatial output frame. */
+  spatialBoundingVolume?: PointCloudBoundingVolume;
 };
 
 /**
@@ -63,6 +65,8 @@ export type PointCloudTileHeader = {
   pointCount: number;
   geometricError: number;
   boundingVolume: PointCloudBoundingVolume;
+  /** Bound expressed in the selected content/output frame; traversal retains geographic bounds. */
+  spatialBoundingVolume?: PointCloudBoundingVolume;
   /** I3S LOD metric used to decide whether this node refines. */
   lodSelectionMetricType?: 'maxScreenThresholdSQ' | 'density-threshold';
   /** Source-provided LOD threshold for density or screen metrics. */

--- a/modules/tiles/src/point-cloud/types.ts
+++ b/modules/tiles/src/point-cloud/types.ts
@@ -4,6 +4,7 @@
 
 import type {DataSource, DataSourceOptions} from '@loaders.gl/loader-utils';
 import type {MeshArrowTable} from '@loaders.gl/schema';
+import type {TilesetSpatialReference} from '../spatial/spatial-types';
 
 /**
  * An accessor-like description for point cloud attributes.
@@ -34,6 +35,8 @@ export type PointCloudTileContent = {
   coordinateSystem: PointCloudCoordinateSystem;
   constantRGBA?: number[];
   modelMatrix?: number[] | Float32Array;
+  /** Spatial descriptor for returned points, origins, and bounds. */
+  spatialReference?: TilesetSpatialReference;
 };
 
 /**
@@ -47,6 +50,8 @@ export type PointCloudBoundingVolume = {
   coversFullLongitude?: boolean;
   center: number[];
   radius: number;
+  /** Broad coordinate frame of `center` and `cartographicBounds`. */
+  coordinateFrame?: 'geographic' | 'cartesian';
 };
 
 /**

--- a/modules/tiles/src/spatial/i3s-spatial-transformer.ts
+++ b/modules/tiles/src/spatial/i3s-spatial-transformer.ts
@@ -1,0 +1,433 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {Matrix4, Quaternion, Vector3} from '@math.gl/core';
+import {Ellipsoid} from '@math.gl/geospatial';
+import {
+  getSpatialCoordinateFrame,
+  SpatialCoordinateTransformer
+} from './spatial-coordinate-transformer';
+import {
+  createTilesetSpatialReference,
+  markTilesetSpatialReferenceTransformed
+} from './spatial-types';
+import type {
+  TilesetCoordinateFrame,
+  TilesetSpatialOptions,
+  TilesetSpatialReference
+} from './spatial-types';
+
+/** Minimal I3S oriented bounding box required by the spatial adapter. */
+export type I3SSpatialObb = {
+  /** Center in source CRS coordinates. */
+  center: ArrayLike<number>;
+  /** Half lengths along the oriented axes. */
+  halfSize: ArrayLike<number>;
+  /** Orientation quaternion. */
+  quaternion: ArrayLike<number>;
+};
+
+/** Input used to rebuild an I3S node bound in the selected output frame. */
+export type I3SSpatialBounds = {
+  /** Minimum bounding sphere encoded as source center plus radius. */
+  mbs?: ArrayLike<number>;
+  /** Oriented source bound, preferred when available. */
+  obb?: I3SSpatialObb;
+  /** Frame in which I3S vectors and quaternions are expressed. */
+  normalReferenceFrame?: string;
+};
+
+/** Renderer-ready positions and metadata produced for an I3S geometry resource. */
+export type I3STransformedPositions = {
+  /** Float32 offsets from the stable target origin. */
+  positions: Float32Array;
+  /** Reconstructed absolute source positions retained for normal transformation. */
+  sourcePositions: Float64Array;
+  /** Stable origin in target CRS coordinates. */
+  origin: [number, number, number];
+  /** Origin used by geographic deck.gl coordinate systems. */
+  cartographicOrigin: [number, number, number];
+  /** Renderer coordinate-system discriminator. */
+  coordinateSystem: 'cartesian' | 'lnglat-offsets';
+  /** Translation matrix used for Cartesian target offsets. */
+  modelMatrix: Matrix4;
+};
+
+/**
+ * Applies one normalized I3S horizontal CRS operation consistently to geometry, normals, origins,
+ * and node bounds.
+ */
+export class I3SSpatialTransformer {
+  /** Descriptor attached to output after all adapter-owned spatial values have been transformed. */
+  readonly spatialReference: TilesetSpatialReference;
+
+  /** Broad coordinate frame of the selected output CRS. */
+  readonly targetCoordinateFrame: TilesetCoordinateFrame;
+
+  /** Source-to-target position operation. */
+  private readonly positionTransformer: SpatialCoordinateTransformer;
+
+  /** Source-to-WGS84 geographic operation used for vector-frame conversion. */
+  private readonly sourceToGeographicTransformer: SpatialCoordinateTransformer;
+
+  /** WGS84-geographic-to-target operation used for normal finite differences. */
+  private readonly geographicToTargetTransformer: SpatialCoordinateTransformer;
+
+  /** Source frame recorded by I3S metadata. */
+  private readonly sourceCoordinateFrame: TilesetCoordinateFrame;
+
+  /**
+   * Creates an I3S spatial adapter.
+   *
+   * @param spatialReference - Transformable I3S spatial descriptor.
+   * @param options - Registered geoid and custom resource options used by the shared transformer.
+   */
+  constructor(spatialReference: TilesetSpatialReference, options: TilesetSpatialOptions = {}) {
+    if (spatialReference.status !== 'transformable' && spatialReference.status !== 'transformed') {
+      throw new Error('I3SSpatialTransformer requires a requested, transformable spatial output');
+    }
+    const targetCrs = spatialReference.targetCrs || spatialReference.sourceCrs;
+    if (!targetCrs) {
+      throw new Error('I3S spatial transformation requires a target CRS');
+    }
+
+    this.positionTransformer = new SpatialCoordinateTransformer(spatialReference, options);
+    this.sourceCoordinateFrame = spatialReference.coordinateFrame;
+    this.targetCoordinateFrame = getSpatialCoordinateFrame(targetCrs);
+    this.spatialReference = markTilesetSpatialReferenceTransformed(spatialReference);
+
+    const sourceToGeographicReference = createTilesetSpatialReference(
+      {
+        sourceCrs: spatialReference.sourceCrs,
+        heightReference: spatialReference.heightReference,
+        coordinateFrame: spatialReference.coordinateFrame,
+        axisOrder: spatialReference.axisOrder,
+        provenance: spatialReference.provenance
+      },
+      {targetCrs: 'EPSG:4326'}
+    );
+    this.sourceToGeographicTransformer = new SpatialCoordinateTransformer(
+      sourceToGeographicReference
+    );
+
+    const geographicToTargetReference = createTilesetSpatialReference(
+      {
+        sourceCrs: 'EPSG:4326',
+        heightReference:
+          spatialReference.targetHeightReference === 'native'
+            ? spatialReference.heightReference
+            : spatialReference.targetHeightReference,
+        coordinateFrame: 'geographic',
+        axisOrder: 'xyz',
+        provenance: 'format-default'
+      },
+      {targetCrs}
+    );
+    this.geographicToTargetTransformer = new SpatialCoordinateTransformer(
+      geographicToTargetReference
+    );
+  }
+
+  /** Transform one absolute I3S source position. */
+  transformPosition(position: ArrayLike<number>): [number, number, number] {
+    const transformed = this.positionTransformer.transformPosition([
+      position[0],
+      position[1],
+      position[2]
+    ]);
+    return [transformed[0], transformed[1], transformed[2]];
+  }
+
+  /** Transform one absolute I3S source position to WGS84 longitude, latitude, and height. */
+  transformSourcePositionToGeographic(position: ArrayLike<number>): [number, number, number] {
+    const transformed = this.sourceToGeographicTransformer.transformPosition([
+      position[0],
+      position[1],
+      position[2]
+    ]);
+    return [transformed[0], transformed[1], transformed[2]];
+  }
+
+  /**
+   * Transform absolute Float64 positions and return stable Float32 offsets around a target origin.
+   *
+   * @param sourcePositions - Absolute positions in source CRS order.
+   * @param sourceOrigin - Stable source origin, normally the node MBS or OBB center.
+   */
+  transformPositions(
+    sourcePositions: ArrayLike<number>,
+    sourceOrigin: ArrayLike<number>
+  ): I3STransformedPositions {
+    const origin = this.transformPosition(sourceOrigin);
+    const positions = new Float32Array(sourcePositions.length);
+    const absoluteSourcePositions = Float64Array.from(sourcePositions);
+
+    for (let index = 0; index < sourcePositions.length; index += 3) {
+      const transformed = this.transformPosition([
+        sourcePositions[index],
+        sourcePositions[index + 1],
+        sourcePositions[index + 2]
+      ]);
+      positions[index] = transformed[0] - origin[0];
+      positions[index + 1] = transformed[1] - origin[1];
+      positions[index + 2] = transformed[2] - origin[2];
+    }
+
+    const isGeographic = this.targetCoordinateFrame === 'geographic';
+    const modelMatrix = isGeographic ? new Matrix4() : new Matrix4().translate(origin);
+    return {
+      positions,
+      sourcePositions: absoluteSourcePositions,
+      origin,
+      cartographicOrigin: isGeographic ? origin : [0, 0, 0],
+      coordinateSystem: isGeographic ? 'lnglat-offsets' : 'cartesian',
+      modelMatrix
+    };
+  }
+
+  /**
+   * Transform I3S normals into the selected target basis.
+   *
+   * Earth-centered normals are rotated directly. Vertex-reference-frame normals are first mapped
+   * through the local east/north/up basis at each source position.
+   *
+   * @param normals - Three-component normal vectors.
+   * @param sourcePositions - Absolute source position paired with each normal.
+   * @param normalReferenceFrame - I3S normal frame declaration.
+   */
+  transformNormals(
+    normals: ArrayLike<number>,
+    sourcePositions: ArrayLike<number>,
+    normalReferenceFrame = 'earth-centered'
+  ): Float32Array {
+    const transformedNormals = new Float32Array(normals.length);
+    for (let index = 0; index < normals.length; index += 3) {
+      const geographic = this.sourceToGeographicTransformer.transformPosition([
+        sourcePositions[index],
+        sourcePositions[index + 1],
+        sourcePositions[index + 2]
+      ]);
+      const inputNormal = new Vector3([
+        normals[index],
+        normals[index + 1],
+        normals[index + 2]
+      ]).normalize();
+      const ecefNormal =
+        normalReferenceFrame === 'earth-centered'
+          ? inputNormal
+          : localEnuVectorToEcef(inputNormal, geographic);
+      const outputNormal = this.transformEcefNormal(ecefNormal, geographic);
+      transformedNormals.set(outputNormal, index);
+    }
+    return transformedNormals;
+  }
+
+  /**
+   * Rebuild an I3S node bound from transformed corner or sphere-axis samples.
+   *
+   * @param bounds - Source MBS/OBB fields.
+   * @returns A generic tile `region` for geographic output or axis-aligned `box` otherwise.
+   */
+  transformBoundingVolume(bounds: I3SSpatialBounds): {box?: number[]; region?: number[]} {
+    const sourceSamples = getSourceBoundSamples(
+      bounds,
+      this.sourceCoordinateFrame,
+      this.sourceToGeographicTransformer
+    );
+    if (!sourceSamples.length) {
+      throw new Error('I3S spatial transformation requires an MBS or OBB bound');
+    }
+    const targetSamples = sourceSamples.map(position =>
+      this.sourceCoordinateFrame === 'geographic'
+        ? this.geographicToTargetTransformer.transformPosition(position)
+        : this.transformPosition(position)
+    );
+    return this.targetCoordinateFrame === 'geographic'
+      ? {region: getGeographicRegion(targetSamples)}
+      : {box: getAxisAlignedBox(targetSamples)};
+  }
+
+  /** Transform one earth-centered normal to the selected target basis. */
+  private transformEcefNormal(ecefNormal: Vector3, geographic: number[]): Vector3 {
+    if (this.targetCoordinateFrame === 'geocentric') {
+      return ecefNormal.normalize();
+    }
+    if (this.targetCoordinateFrame === 'geographic') {
+      return ecefVectorToLocalEnu(ecefNormal, geographic).normalize();
+    }
+
+    const cartesian = Ellipsoid.WGS84.cartographicToCartesian(new Vector3(geographic));
+    const displacedCartesian = new Vector3(cartesian).add(ecefNormal);
+    const displacedGeographic = Ellipsoid.WGS84.cartesianToCartographic(displacedCartesian);
+    const target = this.geographicToTargetTransformer.transformPosition(geographic);
+    const displacedTarget =
+      this.geographicToTargetTransformer.transformPosition(displacedGeographic);
+    return new Vector3(displacedTarget).subtract(target).normalize();
+  }
+}
+
+/** Generate source-frame samples that conservatively cover an I3S MBS or OBB. */
+function getSourceBoundSamples(
+  bounds: I3SSpatialBounds,
+  sourceFrame: TilesetCoordinateFrame,
+  sourceToGeographicTransformer: SpatialCoordinateTransformer
+): number[][] {
+  const obb = bounds.obb;
+  if (obb) {
+    const center = Array.from(obb.center).slice(0, 3);
+    const halfSize = Array.from(obb.halfSize).slice(0, 3);
+    const quaternion = new Quaternion().fromArray(Array.from(obb.quaternion));
+    const axes = [
+      new Vector3([halfSize[0], 0, 0]).transformByQuaternion(quaternion),
+      new Vector3([0, halfSize[1], 0]).transformByQuaternion(quaternion),
+      new Vector3([0, 0, halfSize[2]]).transformByQuaternion(quaternion)
+    ];
+    if (sourceFrame === 'geographic') {
+      const geographicCenter = sourceToGeographicTransformer.transformPosition(center);
+      const cartesianCenter = Ellipsoid.WGS84.cartographicToCartesian(
+        new Vector3(geographicCenter)
+      );
+      const cartesianAxes =
+        bounds.normalReferenceFrame === 'vertex-reference-frame'
+          ? axes.map(axis => localEnuVectorToEcef(axis, geographicCenter))
+          : axes;
+      return getBoxSigns().map(signs => {
+        const corner = new Vector3(cartesianCenter);
+        for (let axisIndex = 0; axisIndex < 3; axisIndex++) {
+          corner.add(new Vector3(cartesianAxes[axisIndex]).scale(signs[axisIndex]));
+        }
+        return Array.from(Ellipsoid.WGS84.cartesianToCartographic(corner));
+      });
+    }
+    return getBoxSigns().map(signs => {
+      const corner = new Vector3(center);
+      for (let axisIndex = 0; axisIndex < 3; axisIndex++) {
+        corner.add(new Vector3(axes[axisIndex]).scale(signs[axisIndex]));
+      }
+      return Array.from(corner);
+    });
+  }
+
+  const mbs = bounds.mbs ? Array.from(bounds.mbs) : [];
+  if (mbs.length < 4) {
+    return [];
+  }
+  const center = mbs.slice(0, 3);
+  const radius = mbs[3];
+  if (sourceFrame === 'geographic') {
+    const geographicCenter = sourceToGeographicTransformer.transformPosition(center);
+    const cartesianCenter = Ellipsoid.WGS84.cartographicToCartesian(new Vector3(geographicCenter));
+    return getAxisDirections().map(direction =>
+      Array.from(
+        Ellipsoid.WGS84.cartesianToCartographic(
+          new Vector3(cartesianCenter).add(new Vector3(direction).scale(radius))
+        )
+      )
+    );
+  }
+  return getAxisDirections().map(direction =>
+    Array.from(new Vector3(center).add(new Vector3(direction).scale(radius)))
+  );
+}
+
+/** Return the eight sign combinations of a box. */
+function getBoxSigns(): number[][] {
+  return [-1, 1].flatMap(x => [-1, 1].flatMap(y => [-1, 1].map(z => [x, y, z])));
+}
+
+/** Return positive and negative unit directions for three Cartesian axes. */
+function getAxisDirections(): number[][] {
+  return [
+    [1, 0, 0],
+    [-1, 0, 0],
+    [0, 1, 0],
+    [0, -1, 0],
+    [0, 0, 1],
+    [0, 0, -1]
+  ];
+}
+
+/** Convert a local east/north/up vector into an earth-centered vector. */
+function localEnuVectorToEcef(vector: ArrayLike<number>, geographic: ArrayLike<number>): Vector3 {
+  const longitude = (geographic[0] * Math.PI) / 180;
+  const latitude = (geographic[1] * Math.PI) / 180;
+  const east = new Vector3([-Math.sin(longitude), Math.cos(longitude), 0]);
+  const north = new Vector3([
+    -Math.sin(latitude) * Math.cos(longitude),
+    -Math.sin(latitude) * Math.sin(longitude),
+    Math.cos(latitude)
+  ]);
+  const up = new Vector3([
+    Math.cos(latitude) * Math.cos(longitude),
+    Math.cos(latitude) * Math.sin(longitude),
+    Math.sin(latitude)
+  ]);
+  return east.scale(vector[0]).add(north.scale(vector[1])).add(up.scale(vector[2]));
+}
+
+/** Convert an earth-centered vector into local east/north/up components. */
+function ecefVectorToLocalEnu(vector: Vector3, geographic: ArrayLike<number>): Vector3 {
+  const longitude = (geographic[0] * Math.PI) / 180;
+  const latitude = (geographic[1] * Math.PI) / 180;
+  const east = new Vector3([-Math.sin(longitude), Math.cos(longitude), 0]);
+  const north = new Vector3([
+    -Math.sin(latitude) * Math.cos(longitude),
+    -Math.sin(latitude) * Math.sin(longitude),
+    Math.cos(latitude)
+  ]);
+  const up = new Vector3([
+    Math.cos(latitude) * Math.cos(longitude),
+    Math.cos(latitude) * Math.sin(longitude),
+    Math.sin(latitude)
+  ]);
+  return new Vector3([east.dot(vector), north.dot(vector), up.dot(vector)]);
+}
+
+/** Build a target-frame axis-aligned generic tile box. */
+function getAxisAlignedBox(positions: number[][]): number[] {
+  const minimum = [Infinity, Infinity, Infinity];
+  const maximum = [-Infinity, -Infinity, -Infinity];
+  for (const position of positions) {
+    for (let component = 0; component < 3; component++) {
+      minimum[component] = Math.min(minimum[component], position[component]);
+      maximum[component] = Math.max(maximum[component], position[component]);
+    }
+  }
+  const center = minimum.map((value, index) => (value + maximum[index]) / 2);
+  const halfSize = minimum.map((value, index) => (maximum[index] - value) / 2);
+  return [center[0], center[1], center[2], halfSize[0], 0, 0, 0, halfSize[1], 0, 0, 0, halfSize[2]];
+}
+
+/** Build a dateline-aware geographic tile region in radians. */
+function getGeographicRegion(positions: number[][]): number[] {
+  const referenceLongitude = positions[0][0];
+  let minimumLongitude = Infinity;
+  let maximumLongitude = -Infinity;
+  let minimumLatitude = Infinity;
+  let maximumLatitude = -Infinity;
+  let minimumHeight = Infinity;
+  let maximumHeight = -Infinity;
+  for (const position of positions) {
+    const longitude = referenceLongitude + normalizeLongitude(position[0] - referenceLongitude);
+    minimumLongitude = Math.min(minimumLongitude, longitude);
+    maximumLongitude = Math.max(maximumLongitude, longitude);
+    minimumLatitude = Math.min(minimumLatitude, position[1]);
+    maximumLatitude = Math.max(maximumLatitude, position[1]);
+    minimumHeight = Math.min(minimumHeight, position[2]);
+    maximumHeight = Math.max(maximumHeight, position[2]);
+  }
+  return [
+    (normalizeLongitude(minimumLongitude) * Math.PI) / 180,
+    (minimumLatitude * Math.PI) / 180,
+    (normalizeLongitude(maximumLongitude) * Math.PI) / 180,
+    (maximumLatitude * Math.PI) / 180,
+    minimumHeight,
+    maximumHeight
+  ];
+}
+
+/** Normalize a longitude delta to the interval [-180, 180). */
+function normalizeLongitude(longitude: number): number {
+  return ((((longitude + 180) % 360) + 360) % 360) - 180;
+}

--- a/modules/tiles/src/spatial/i3s-spatial-transformer.ts
+++ b/modules/tiles/src/spatial/i3s-spatial-transformer.ts
@@ -114,18 +114,20 @@ export class I3SSpatialTransformer {
     const geographicToTargetReference = createTilesetSpatialReference(
       {
         sourceCrs: 'EPSG:4326',
-        heightReference:
-          spatialReference.targetHeightReference === 'native'
-            ? spatialReference.heightReference
-            : spatialReference.targetHeightReference,
+        heightReference: spatialReference.heightReference,
         coordinateFrame: 'geographic',
         axisOrder: 'xyz',
         provenance: 'format-default'
       },
-      {targetCrs}
+      {
+        targetCrs,
+        targetHeightReference: spatialReference.targetHeightReference,
+        geoidModel: options.geoidModel
+      }
     );
     this.geographicToTargetTransformer = new SpatialCoordinateTransformer(
-      geographicToTargetReference
+      geographicToTargetReference,
+      options
     );
   }
 
@@ -230,6 +232,47 @@ export class I3SSpatialTransformer {
    * @returns A generic tile `region` for geographic output or axis-aligned `box` otherwise.
    */
   transformBoundingVolume(bounds: I3SSpatialBounds): {box?: number[]; region?: number[]} {
+    const geographicSamples = this.getGeographicBoundSamples(bounds);
+    const targetSamples = geographicSamples.map(position =>
+      this.geographicToTargetTransformer.transformPosition(position)
+    );
+    return this.targetCoordinateFrame === 'geographic'
+      ? {region: getGeographicRegion(targetSamples)}
+      : {box: getAxisAlignedBox(targetSamples)};
+  }
+
+  /** Rebuild an I3S bound as a WGS84 geographic region for geographic traversal algorithms. */
+  transformBoundingVolumeToGeographic(bounds: I3SSpatialBounds): {region: number[]} {
+    return {region: getGeographicRegion(this.getGeographicBoundSamples(bounds))};
+  }
+
+  /** Rebuild an I3S bound as a WGS84 ECEF box for generic `Tileset3D` traversal. */
+  transformBoundingVolumeToGeocentric(bounds: I3SSpatialBounds): {box: number[]} {
+    const cartesianSamples = this.getGeographicBoundSamples(bounds).map(position =>
+      Array.from(Ellipsoid.WGS84.cartographicToCartesian(new Vector3(position)))
+    );
+    return {box: getAxisAlignedBox(cartesianSamples)};
+  }
+
+  /** Return a WGS84 geographic MBS used by the I3S screen-threshold calculation. */
+  transformBoundingSphereToGeographic(bounds: I3SSpatialBounds): [number, number, number, number] {
+    const sourceCenter = bounds.mbs?.length
+      ? Array.from(bounds.mbs).slice(0, 3)
+      : bounds.obb
+        ? Array.from(bounds.obb.center).slice(0, 3)
+        : null;
+    if (!sourceCenter) {
+      throw new Error('I3S spatial transformation requires an MBS or OBB bound');
+    }
+    const geographicCenter = this.sourceToGeographicTransformer.transformPosition(sourceCenter);
+    const radius = bounds.mbs?.length
+      ? bounds.mbs[3]
+      : Math.hypot(...Array.from(bounds.obb!.halfSize).slice(0, 3));
+    return [geographicCenter[0], geographicCenter[1], geographicCenter[2], radius];
+  }
+
+  /** Sample a source I3S bound and normalize every sample to WGS84 geographic coordinates. */
+  private getGeographicBoundSamples(bounds: I3SSpatialBounds): number[][] {
     const sourceSamples = getSourceBoundSamples(
       bounds,
       this.sourceCoordinateFrame,
@@ -238,14 +281,11 @@ export class I3SSpatialTransformer {
     if (!sourceSamples.length) {
       throw new Error('I3S spatial transformation requires an MBS or OBB bound');
     }
-    const targetSamples = sourceSamples.map(position =>
-      this.sourceCoordinateFrame === 'geographic'
-        ? this.geographicToTargetTransformer.transformPosition(position)
-        : this.transformPosition(position)
-    );
-    return this.targetCoordinateFrame === 'geographic'
-      ? {region: getGeographicRegion(targetSamples)}
-      : {box: getAxisAlignedBox(targetSamples)};
+    return this.sourceCoordinateFrame === 'geographic'
+      ? sourceSamples
+      : sourceSamples.map(position =>
+          this.sourceToGeographicTransformer.transformPosition(position)
+        );
   }
 
   /** Transform one earth-centered normal to the selected target basis. */

--- a/modules/tiles/src/spatial/spatial-coordinate-transformer.ts
+++ b/modules/tiles/src/spatial/spatial-coordinate-transformer.ts
@@ -3,17 +3,22 @@
 // Copyright (c) vis.gl contributors
 
 import type {Geoid} from '@math.gl/geoid';
+import {Vector3} from '@math.gl/core';
+import {Ellipsoid} from '@math.gl/geospatial';
+import type {CRSDefinition} from '@math.gl/crs';
 import {Proj4Projection} from '@math.gl/proj4';
 import type {Proj4CRSDefinition} from '@math.gl/proj4';
 import {getGeoidModel} from './spatial-resource-registry';
 import type {
   TilesetHeightReference,
+  TilesetCoordinateFrame,
   TilesetSpatialOptions,
   TilesetSpatialReference,
   TilesetTargetHeightReference
 } from './spatial-types';
 
 const GEOGRAPHIC_CRS = 'EPSG:4326';
+const GEOCENTRIC_CRS = 'EPSG:4978';
 
 /**
  * Deterministic coordinate transformer used by 3D tile format adapters.
@@ -35,6 +40,18 @@ export class SpatialCoordinateTransformer {
   /** Projection from adjusted geographic coordinates to the requested output CRS. */
   private readonly heightOutputProjection?: Proj4Projection;
 
+  /** Whether source coordinates use the WGS84 geocentric frame handled by math.gl. */
+  private readonly sourceIsGeocentric: boolean;
+
+  /** Whether output coordinates use the WGS84 geocentric frame handled by math.gl. */
+  private readonly outputIsGeocentric: boolean;
+
+  /** Whether source coordinates already use conventional WGS84 longitude/latitude order. */
+  private readonly sourceIsGeographic: boolean;
+
+  /** Whether output coordinates use conventional WGS84 longitude/latitude order. */
+  private readonly outputIsGeographic: boolean;
+
   /** Geoid model used to convert between ellipsoidal and orthometric heights. */
   private readonly geoid?: Geoid;
 
@@ -47,13 +64,44 @@ export class SpatialCoordinateTransformer {
   constructor(spatialReference: TilesetSpatialReference, options: TilesetSpatialOptions = {}) {
     this.spatialReference = spatialReference;
     validateTransformRequest(spatialReference);
+    const outputCrs = spatialReference.targetCrs || spatialReference.sourceCrs;
+    this.sourceIsGeocentric = isWgs84Geocentric(spatialReference.sourceCrs);
+    this.outputIsGeocentric = isWgs84Geocentric(outputCrs);
+    this.sourceIsGeographic = isWgs84Geographic(spatialReference.sourceCrs);
+    this.outputIsGeographic = isWgs84Geographic(outputCrs);
 
-    if (spatialReference.sourceCrs && spatialReference.targetCrs) {
+    if (
+      spatialReference.sourceCrs &&
+      spatialReference.targetCrs &&
+      !this.sourceIsGeocentric &&
+      !this.outputIsGeocentric
+    ) {
       this.horizontalProjection = new Proj4Projection({
         from: spatialReference.sourceCrs as Proj4CRSDefinition,
         to: spatialReference.targetCrs as Proj4CRSDefinition,
         enforceAxis: false
       });
+    }
+
+    if (
+      requiresHeightTransformation(spatialReference) ||
+      this.sourceIsGeocentric ||
+      this.outputIsGeocentric
+    ) {
+      if (!this.sourceIsGeographic && !this.sourceIsGeocentric) {
+        this.geographicProjection = new Proj4Projection({
+          from: spatialReference.sourceCrs as Proj4CRSDefinition,
+          to: GEOGRAPHIC_CRS,
+          enforceAxis: false
+        });
+      }
+      if (!this.outputIsGeographic && !this.outputIsGeocentric) {
+        this.heightOutputProjection = new Proj4Projection({
+          from: GEOGRAPHIC_CRS,
+          to: outputCrs as Proj4CRSDefinition,
+          enforceAxis: false
+        });
+      }
     }
 
     if (requiresHeightTransformation(spatialReference)) {
@@ -65,16 +113,6 @@ export class SpatialCoordinateTransformer {
             'call registerGeoidModel() or pass a parsed Geoid instance'
         );
       }
-      this.geographicProjection = new Proj4Projection({
-        from: spatialReference.sourceCrs as Proj4CRSDefinition,
-        to: GEOGRAPHIC_CRS,
-        enforceAxis: false
-      });
-      this.heightOutputProjection = new Proj4Projection({
-        from: GEOGRAPHIC_CRS,
-        to: (spatialReference.targetCrs || spatialReference.sourceCrs) as Proj4CRSDefinition,
-        enforceAxis: false
-      });
     }
   }
 
@@ -90,19 +128,25 @@ export class SpatialCoordinateTransformer {
     }
 
     const result = [...coordinate];
-    if (requiresHeightTransformation(this.spatialReference)) {
+    if (
+      requiresHeightTransformation(this.spatialReference) ||
+      this.sourceIsGeocentric ||
+      this.outputIsGeocentric
+    ) {
       if (result.length < 3 || !Number.isFinite(result[2])) {
-        throw new Error('Height conversion requires a finite z coordinate');
+        throw new Error('Three-dimensional CRS conversion requires a finite z coordinate');
       }
-      const geographic = this.geographicProjection!.project([result[0], result[1], result[2]]);
-      const geoidUndulation = this.geoid!.getHeight(geographic[1], geographic[0]);
-      geographic[2] = transformHeight(
-        geographic[2],
-        geoidUndulation,
-        this.spatialReference.heightReference,
-        this.spatialReference.targetHeightReference
-      );
-      const projected = this.heightOutputProjection!.project(geographic);
+      const geographic = this.toGeographic(result);
+      if (requiresHeightTransformation(this.spatialReference)) {
+        const geoidUndulation = this.geoid!.getHeight(geographic[1], geographic[0]);
+        geographic[2] = transformHeight(
+          geographic[2],
+          geoidUndulation,
+          this.spatialReference.heightReference,
+          this.spatialReference.targetHeightReference
+        );
+      }
+      const projected = this.fromGeographic(geographic);
       result.splice(0, projected.length, ...projected);
       return result;
     }
@@ -112,6 +156,28 @@ export class SpatialCoordinateTransformer {
       result.splice(0, projected.length, ...projected);
     }
     return result;
+  }
+
+  /** Convert one source coordinate to conventional WGS84 longitude, latitude, and height. */
+  private toGeographic(coordinate: number[]): number[] {
+    if (this.sourceIsGeocentric) {
+      return Array.from(Ellipsoid.WGS84.cartesianToCartographic(new Vector3(coordinate)));
+    }
+    if (this.sourceIsGeographic) {
+      return coordinate.slice(0, 3);
+    }
+    return this.geographicProjection!.project(coordinate.slice(0, 3));
+  }
+
+  /** Convert one conventional WGS84 geographic coordinate to the selected output CRS. */
+  private fromGeographic(coordinate: number[]): number[] {
+    if (this.outputIsGeocentric) {
+      return Array.from(Ellipsoid.WGS84.cartographicToCartesian(new Vector3(coordinate)));
+    }
+    if (this.outputIsGeographic) {
+      return coordinate.slice(0, 3);
+    }
+    return this.heightOutputProjection!.project(coordinate.slice(0, 3));
   }
 }
 
@@ -135,17 +201,89 @@ function validateTransformRequest(spatialReference: TilesetSpatialReference): vo
     throw new Error('Cannot convert heights because the source height reference is unknown');
   }
   if (
-    requiresHeightTransformation(spatialReference) &&
-    spatialReference.coordinateFrame === 'geocentric'
+    spatialReference.coordinateFrame === 'geocentric' &&
+    !isWgs84Geocentric(spatialReference.sourceCrs)
   ) {
     throw new Error(
-      'Geocentric height conversion is not supported until the projection runtime can convert ' +
-        'between geocentric coordinates and geographic ellipsoidal heights'
+      'Only EPSG:4978 geocentric coordinates are supported by the current spatial transformer'
     );
   }
   if (spatialReference.status === 'unresolved') {
     throw new Error('The requested spatial output cannot be resolved from the available metadata');
   }
+}
+
+/** Return whether a CRS definition identifies the WGS84 geocentric frame. */
+function isWgs84Geocentric(definition: unknown): boolean {
+  return typeof definition === 'string' && normalizeCrsIdentifier(definition) === GEOCENTRIC_CRS;
+}
+
+/** Return whether a CRS definition uses conventional WGS84 longitude/latitude coordinates. */
+function isWgs84Geographic(definition: unknown): boolean {
+  if (typeof definition !== 'string') {
+    return false;
+  }
+  const identifier = normalizeCrsIdentifier(definition);
+  return identifier === GEOGRAPHIC_CRS || identifier === 'EPSG:4979' || identifier === 'OGC:CRS84';
+}
+
+/** Normalize common OGC URL and URN CRS spellings to authority identifiers. */
+function normalizeCrsIdentifier(identifier: string): string {
+  const normalizedIdentifier = identifier.trim().toUpperCase();
+  const ogcMatch = normalizedIdentifier.match(
+    /(?:\/DEF\/CRS\/|URN:OGC:DEF:CRS:)([A-Z0-9_-]+)(?:\/|::)(?:[^/:]*[/:])?([A-Z0-9_.-]+)$/
+  );
+  return ogcMatch ? `${ogcMatch[1]}:${ogcMatch[2]}` : normalizedIdentifier;
+}
+
+/** Classify a CRS definition into the broad frame needed by 3D render adapters. */
+export function getSpatialCoordinateFrame(definition: CRSDefinition): TilesetCoordinateFrame {
+  if (typeof definition === 'string') {
+    const normalized = normalizeCrsIdentifier(definition);
+    if (normalized === GEOCENTRIC_CRS || /^GEOCCS\s*[\[(]/.test(normalized)) {
+      return 'geocentric';
+    }
+    if (
+      normalized === GEOGRAPHIC_CRS ||
+      normalized === 'EPSG:4490' ||
+      normalized === 'EPSG:4979' ||
+      normalized === 'OGC:CRS84' ||
+      normalized.includes('+PROJ=LONGLAT') ||
+      normalized.includes('+PROJ=LATLONG') ||
+      /^(?:GEOGCS|GEOGCRS|GEOGRAPHICCRS|GEOGRAPHIC2DCRS|GEOGRAPHIC3DCRS)\s*[\[(]/.test(normalized)
+    ) {
+      return 'geographic';
+    }
+    if (/^(?:GEODCRS|GEODETICCRS)\s*[\[(]/.test(normalized)) {
+      return /CS\s*[\[(]\s*CARTESIAN/.test(normalized) ? 'geocentric' : 'geographic';
+    }
+    return 'projected';
+  }
+
+  const projJsonDefinition = definition as {
+    type?: string;
+    source_crs?: CRSDefinition;
+    components?: CRSDefinition[];
+    coordinate_system?: {subtype?: string};
+  };
+  if (projJsonDefinition.type === 'BoundCRS' && projJsonDefinition.source_crs) {
+    return getSpatialCoordinateFrame(projJsonDefinition.source_crs);
+  }
+  if (projJsonDefinition.type === 'CompoundCRS' && projJsonDefinition.components?.[0]) {
+    return getSpatialCoordinateFrame(projJsonDefinition.components[0]);
+  }
+  if (String(projJsonDefinition.type).includes('Projected')) {
+    return 'projected';
+  }
+  if (String(projJsonDefinition.type).includes('Geographic')) {
+    return 'geographic';
+  }
+  if (String(projJsonDefinition.type).includes('Geodetic')) {
+    return projJsonDefinition.coordinate_system?.subtype === 'Cartesian'
+      ? 'geocentric'
+      : 'geographic';
+  }
+  return 'projected';
 }
 
 /** Return whether source and target height interpretations differ. */

--- a/modules/tiles/src/spatial/spatial-types.ts
+++ b/modules/tiles/src/spatial/spatial-types.ts
@@ -175,3 +175,19 @@ export function applyTilesetSpatialOptions(
     options
   );
 }
+
+/**
+ * Marks a normalized descriptor after every returned coordinate and bound has entered its target
+ * frame.
+ *
+ * @param spatialReference - Transformable spatial descriptor.
+ * @returns An immutable descriptor with `status: 'transformed'`.
+ */
+export function markTilesetSpatialReferenceTransformed(
+  spatialReference: TilesetSpatialReference
+): TilesetSpatialReference {
+  if (spatialReference.status !== 'transformable' && spatialReference.status !== 'transformed') {
+    throw new Error('Only a transformable spatial reference can be marked as transformed');
+  }
+  return Object.freeze({...spatialReference, status: 'transformed'});
+}

--- a/modules/tiles/src/tileset-3d/common/tileset-3d.ts
+++ b/modules/tiles/src/tileset-3d/common/tileset-3d.ts
@@ -1096,9 +1096,13 @@ export class Tileset3D {
     this.groups = tileset.groups || [];
     this.metadata = tileset.metadata || null;
     this.statistics = tileset.statistics ?? null;
-    this.spatialReference = applyTilesetSpatialOptions(
+    const spatialReference = applyTilesetSpatialOptions(
       metadata.spatialReference,
       this.options.spatial
+    );
+    this.spatialReference = preserveTransformedSpatialReference(
+      this.spatialReference,
+      spatialReference
     );
     this.properties = this.source.properties ?? this.properties;
     this.extras = this.source.extras ?? this.extras;
@@ -1135,4 +1139,18 @@ export class Tileset3D {
       return null;
     }
   }
+}
+
+/** Preserve a completed runtime operation when asynchronous source metadata describes the same request. */
+function preserveTransformedSpatialReference(
+  current: TilesetSpatialReference,
+  next: TilesetSpatialReference
+): TilesetSpatialReference {
+  return current?.status === 'transformed' &&
+    current.sourceCrs === next.sourceCrs &&
+    current.targetCrs === next.targetCrs &&
+    current.targetHeightReference === next.targetHeightReference &&
+    current.outputCoordinates === next.outputCoordinates
+    ? current
+    : next;
 }

--- a/modules/tiles/src/tileset-3d/format-i3s/i3s-source.ts
+++ b/modules/tiles/src/tileset-3d/format-i3s/i3s-source.ts
@@ -405,13 +405,18 @@ export class I3SSource implements Tileset3DSource {
       tileset.options.spatial
     );
     tileset.spatialReference = this.spatialTransformer.spatialReference;
+    const sourceBounds = {
+      mbs: header.mbs,
+      obb: header.obb,
+      normalReferenceFrame: this.getMetadata().tileset.store?.normalReferenceFrame
+    };
     return {
       ...header,
-      boundingVolume: this.spatialTransformer.transformBoundingVolume({
-        mbs: header.mbs,
-        obb: header.obb,
-        normalReferenceFrame: this.getMetadata().tileset.store?.normalReferenceFrame
-      })
+      // Tileset3D traversal and culling operate in WGS84 ECEF independently of content output.
+      boundingVolume: this.spatialTransformer.transformBoundingVolumeToGeocentric(sourceBounds),
+      // Preserve the renderer/output-frame bound for applications and content coordination.
+      spatialBoundingVolume: this.spatialTransformer.transformBoundingVolume(sourceBounds),
+      i3sLodMbs: this.spatialTransformer.transformBoundingSphereToGeographic(sourceBounds)
     };
   }
 }

--- a/modules/tiles/src/tileset-3d/format-i3s/i3s-source.ts
+++ b/modules/tiles/src/tileset-3d/format-i3s/i3s-source.ts
@@ -26,6 +26,7 @@ import {getZoomFromExtent, getZoomFromFullExtent} from '../helpers/zoom';
 import {TILESET_TYPE} from '../../constants';
 import type {TilesetTraverser, TilesetTraverserProps} from '../common/tileset-traverser';
 import {getI3SSpatialReference} from '../../spatial/format-spatial-reference';
+import {I3SSpatialTransformer} from '../../spatial/i3s-spatial-transformer';
 
 const EMPTY_CONTENT_FORMATS: TilesetContentFormats = {
   draco: false,
@@ -64,6 +65,8 @@ export class I3SSource implements Tileset3DSource {
   private readonly queryParams: Record<string, string> = {};
   private readonly resolver?: TilesetSourceResolver;
   private rootTileset: TilesetJSON;
+  /** Spatial adapter created lazily after Tileset3D applies target options. */
+  private spatialTransformer?: I3SSpatialTransformer;
 
   /**
    * Creates an I3S source.
@@ -134,7 +137,8 @@ export class I3SSource implements Tileset3DSource {
     tilesetJson: TilesetJSON,
     parentTile?: Tile3D | null
   ): Tile3D {
-    const rootTile = new Tile3DNode(tileset, tilesetJson.root, parentTile || undefined);
+    const rootHeader = this.transformTileHeader(tilesetJson.root, tileset);
+    const rootTile = new Tile3DNode(tileset, rootHeader, parentTile || undefined);
     if (parentTile) {
       parentTile.children.push(rootTile);
       rootTile.depth = parentTile.depth + 1;
@@ -175,7 +179,9 @@ export class I3SSource implements Tileset3DSource {
         _tilesetOptions: {
           store: metadata.tileset.store,
           attributeStorageInfo: metadata.tileset.attributeStorageInfo,
-          fields: metadata.tileset.fields
+          fields: metadata.tileset.fields,
+          spatialReference: tile.tileset.spatialReference,
+          spatialOptions: tile.tileset.options.spatial
         },
         isTileHeader: false
       }
@@ -195,7 +201,8 @@ export class I3SSource implements Tileset3DSource {
   ): Promise<any> {
     const metadata = this.getMetadata();
     if (metadata.tileset.nodePages) {
-      return await metadata.tileset.nodePagesTile.formTileFromNodePages(childId);
+      const header = await metadata.tileset.nodePagesTile.formTileFromNodePages(childId);
+      return this.transformTileHeader(header, _parentTile.tileset);
     }
 
     const nodeUrl = this.getTileUrl(`${this.url}/nodes/${childId}`);
@@ -211,7 +218,8 @@ export class I3SSource implements Tileset3DSource {
       }
     };
 
-    return await this.loadResourceData(nodeUrl, options);
+    const header = await this.loadResourceData(nodeUrl, options);
+    return this.transformTileHeader(header, _parentTile.tileset);
   }
 
   /**
@@ -249,7 +257,28 @@ export class I3SSource implements Tileset3DSource {
   /**
    * Derives the default view state from full extent or store extent metadata.
    */
-  getViewState(_rootTile: Tile3D | null): TilesetSourceViewState {
+  getViewState(rootTile: Tile3D | null): TilesetSourceViewState {
+    if (this.spatialTransformer && rootTile) {
+      const center = new Vector3(rootTile.boundingVolume.center);
+      const sourceCenter = rootTile.header.obb?.center || rootTile.header.mbs;
+      const cartographicCenter = new Vector3(
+        this.spatialTransformer.transformSourcePositionToGeographic(sourceCenter)
+      );
+      if (this.spatialTransformer.targetCoordinateFrame === 'geographic') {
+        return {
+          boundingVolume: rootTile.boundingVolume,
+          cartographicCenter,
+          cartesianCenter: center,
+          zoom: 1
+        };
+      }
+      return {
+        boundingVolume: rootTile.boundingVolume,
+        cartographicCenter,
+        cartesianCenter: center,
+        zoom: 1
+      };
+    }
     const metadata = this.getMetadata();
     const fullExtent = metadata.tileset.fullExtent;
     if (fullExtent) {
@@ -360,6 +389,30 @@ export class I3SSource implements Tileset3DSource {
     }
 
     return await this.loadWithCoreApi(url, options);
+  }
+
+  /** Transform one I3S header bound after target options have been applied by Tileset3D. */
+  private transformTileHeader(header: any, tileset?: Tileset3D): any {
+    if (
+      !tileset?.spatialReference ||
+      (tileset.spatialReference.status !== 'transformable' &&
+        tileset.spatialReference.status !== 'transformed')
+    ) {
+      return header;
+    }
+    this.spatialTransformer ||= new I3SSpatialTransformer(
+      tileset.spatialReference,
+      tileset.options.spatial
+    );
+    tileset.spatialReference = this.spatialTransformer.spatialReference;
+    return {
+      ...header,
+      boundingVolume: this.spatialTransformer.transformBoundingVolume({
+        mbs: header.mbs,
+        obb: header.obb,
+        normalReferenceFrame: this.getMetadata().tileset.store?.normalReferenceFrame
+      })
+    };
   }
 }
 

--- a/modules/tiles/src/tileset-3d/helpers/i3s-lod.ts
+++ b/modules/tiles/src/tileset-3d/helpers/i3s-lod.ts
@@ -49,10 +49,11 @@ export function getLodStatus(tile: Tile3D, frameState: FrameState): 'DIG' | 'OUT
 // eslint-disable-next-line max-statements
 export function getProjectedRadius(tile: Tile3D, frameState: FrameState): number {
   const {topDownViewport: viewport} = frameState;
-  const mbsLat = tile.header.mbs[1];
-  const mbsLon = tile.header.mbs[0];
-  const mbsZ = tile.header.mbs[2];
-  const mbsR = tile.header.mbs[3];
+  const mbs = tile.header.i3sLodMbs || tile.header.mbs;
+  const mbsLat = mbs[1];
+  const mbsLon = mbs[0];
+  const mbsZ = mbs[2];
+  const mbsR = mbs[3];
   const mbsCenterCartesian = [...tile.boundingVolume.center];
   const cameraPositionCartographic = viewport.unprojectPosition(viewport.cameraPosition);
   Ellipsoid.WGS84.cartographicToCartesian(cameraPositionCartographic, cameraPositionCartesian);

--- a/modules/tiles/test/spatial/i3s-spatial-transformer.spec.ts
+++ b/modules/tiles/test/spatial/i3s-spatial-transformer.spec.ts
@@ -3,6 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import {describe, expect, test} from 'vitest';
+import type {Geoid} from '@math.gl/geoid';
 import {createTilesetSpatialReference, I3SSpatialTransformer} from '@loaders.gl/tiles';
 
 describe('I3SSpatialTransformer', () => {
@@ -87,5 +88,29 @@ describe('I3SSpatialTransformer', () => {
     expect(transformed.region).toHaveLength(6);
     expect(transformed.region![0]).toBeGreaterThan(transformed.region![2]);
     expect(transformed.region!.every(Number.isFinite)).toBe(true);
+  });
+
+  test('applies requested geoid conversion to target-space bounds', () => {
+    const spatialReference = createTilesetSpatialReference(
+      {
+        sourceCrs: 'EPSG:4326',
+        coordinateFrame: 'geographic',
+        axisOrder: 'xyz',
+        heightReference: 'orthometric',
+        provenance: 'metadata'
+      },
+      {targetCrs: 'EPSG:4326', targetHeightReference: 'ellipsoidal'}
+    );
+    const geoid = {getHeight: () => 30} as Geoid;
+    const transformer = new I3SSpatialTransformer(spatialReference, {geoidModel: geoid});
+    const targetBounds = transformer.transformBoundingVolume({mbs: [10, 20, 100, 0]});
+    const traversalBounds = transformer.transformBoundingVolumeToGeographic({
+      mbs: [10, 20, 100, 0]
+    });
+
+    expect(targetBounds.region?.[4]).toBeCloseTo(130, 8);
+    expect(targetBounds.region?.[5]).toBeCloseTo(130, 8);
+    expect(traversalBounds.region[4]).toBeCloseTo(100, 8);
+    expect(traversalBounds.region[5]).toBeCloseTo(100, 8);
   });
 });

--- a/modules/tiles/test/spatial/i3s-spatial-transformer.spec.ts
+++ b/modules/tiles/test/spatial/i3s-spatial-transformer.spec.ts
@@ -1,0 +1,91 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {describe, expect, test} from 'vitest';
+import {createTilesetSpatialReference, I3SSpatialTransformer} from '@loaders.gl/tiles';
+
+describe('I3SSpatialTransformer', () => {
+  test('returns stable geographic offsets for projected source positions', () => {
+    const spatialReference = createTilesetSpatialReference(
+      {
+        sourceCrs: 'EPSG:3857',
+        coordinateFrame: 'projected',
+        axisOrder: 'xyz',
+        heightReference: 'ellipsoidal',
+        provenance: 'metadata'
+      },
+      {targetCrs: 'EPSG:4326'}
+    );
+    const transformer = new I3SSpatialTransformer(spatialReference);
+    const transformed = transformer.transformPositions(
+      [1113194.9079327357, 0, 12, 1113306.227423362, 0, 12],
+      [1113194.9079327357, 0, 12]
+    );
+
+    expect(transformed.coordinateSystem).toBe('lnglat-offsets');
+    expect(transformed.origin[0]).toBeCloseTo(10, 8);
+    expect(Array.from(transformed.positions.slice(0, 3))).toEqual([0, 0, 0]);
+    expect(transformed.positions[3]).toBeCloseTo(0.001, 6);
+    expect(transformer.spatialReference.status).toBe('transformed');
+  });
+
+  test('returns Float32 Cartesian offsets and a high-precision projected origin', () => {
+    const spatialReference = createTilesetSpatialReference(
+      {
+        sourceCrs: 'EPSG:4326',
+        coordinateFrame: 'geographic',
+        axisOrder: 'xyz',
+        heightReference: 'ellipsoidal',
+        provenance: 'metadata'
+      },
+      {targetCrs: 'EPSG:3857'}
+    );
+    const transformer = new I3SSpatialTransformer(spatialReference);
+    const transformed = transformer.transformPositions([10, 0, 12, 10.001, 0, 12], [10, 0, 12]);
+
+    expect(transformed.coordinateSystem).toBe('cartesian');
+    expect(transformed.origin[0]).toBeCloseTo(1113194.9079327357, 6);
+    expect(Array.from(transformed.positions.slice(0, 3))).toEqual([0, 0, 0]);
+    expect(transformed.positions[3]).toBeCloseTo(111.31949, 4);
+    expect(Array.from(transformed.modelMatrix).slice(12, 15)).toEqual(transformed.origin);
+  });
+
+  test('transforms earth-centered normals into the target projected basis', () => {
+    const spatialReference = createTilesetSpatialReference(
+      {
+        sourceCrs: 'EPSG:4326',
+        coordinateFrame: 'geographic',
+        axisOrder: 'xyz',
+        heightReference: 'ellipsoidal',
+        provenance: 'metadata'
+      },
+      {targetCrs: 'EPSG:3857'}
+    );
+    const transformer = new I3SSpatialTransformer(spatialReference);
+    const normals = transformer.transformNormals([1, 0, 0], [0, 0, 0]);
+
+    expect(normals[0]).toBeCloseTo(0, 5);
+    expect(normals[1]).toBeCloseTo(0, 5);
+    expect(normals[2]).toBeCloseTo(1, 5);
+  });
+
+  test('produces dateline-aware geographic bounds', () => {
+    const spatialReference = createTilesetSpatialReference(
+      {
+        sourceCrs: 'EPSG:4326',
+        coordinateFrame: 'geographic',
+        axisOrder: 'xyz',
+        heightReference: 'ellipsoidal',
+        provenance: 'metadata'
+      },
+      {targetCrs: 'EPSG:4326'}
+    );
+    const transformer = new I3SSpatialTransformer(spatialReference);
+    const transformed = transformer.transformBoundingVolume({mbs: [179.999, 0, 0, 500]});
+
+    expect(transformed.region).toHaveLength(6);
+    expect(transformed.region![0]).toBeGreaterThan(transformed.region![2]);
+    expect(transformed.region!.every(Number.isFinite)).toBe(true);
+  });
+});

--- a/modules/tiles/test/spatial/spatial-coordinate-transformer.spec.ts
+++ b/modules/tiles/test/spatial/spatial-coordinate-transformer.spec.ts
@@ -6,11 +6,20 @@ import {describe, expect, test} from 'vitest';
 import type {Geoid} from '@math.gl/geoid';
 import {
   createTilesetSpatialReference,
+  getSpatialCoordinateFrame,
   registerGeoidModel,
   SpatialCoordinateTransformer
 } from '@loaders.gl/tiles';
 
 describe('SpatialCoordinateTransformer', () => {
+  test.each([
+    ['GEOGCRS["WGS 84"]', 'geographic'],
+    ['GEODCRS["WGS 84",CS[Cartesian,3]]', 'geocentric'],
+    ['PROJCRS["WGS 84 / Pseudo-Mercator"]', 'projected']
+  ] as const)('classifies WKT target frame %s', (definition, expectedFrame) => {
+    expect(getSpatialCoordinateFrame(definition)).toBe(expectedFrame);
+  });
+
   test('retains native coordinates and extra components', () => {
     const spatialReference = createTilesetSpatialReference({
       sourceCrs: 'EPSG:4326',
@@ -63,7 +72,7 @@ describe('SpatialCoordinateTransformer', () => {
     expect(transformer.transformPosition([10, 20, 100])).toEqual([10, 20, 130]);
   });
 
-  test('rejects geocentric height conversion instead of treating Cartesian z as height', () => {
+  test('converts geocentric heights in geographic space before projecting the output', () => {
     const constantGeoid = {getHeight: () => 30} as Geoid;
     const spatialReference = createTilesetSpatialReference(
       {
@@ -76,9 +85,33 @@ describe('SpatialCoordinateTransformer', () => {
       {targetCrs: 'EPSG:4326', targetHeightReference: 'orthometric'}
     );
 
-    expect(
-      () => new SpatialCoordinateTransformer(spatialReference, {geoidModel: constantGeoid})
-    ).toThrow('Geocentric height conversion is not supported');
+    const transformer = new SpatialCoordinateTransformer(spatialReference, {
+      geoidModel: constantGeoid
+    });
+    const transformed = transformer.transformPosition([6378237, 0, 0]);
+
+    expect(transformed[0]).toBeCloseTo(0, 8);
+    expect(transformed[1]).toBeCloseTo(0, 8);
+    expect(transformed[2]).toBeCloseTo(70, 6);
+  });
+
+  test('converts geographic coordinates to WGS84 geocentric output', () => {
+    const spatialReference = createTilesetSpatialReference(
+      {
+        sourceCrs: 'EPSG:4326',
+        coordinateFrame: 'geographic',
+        axisOrder: 'xyz',
+        heightReference: 'ellipsoidal',
+        provenance: 'metadata'
+      },
+      {outputCoordinates: 'ecef'}
+    );
+    const transformer = new SpatialCoordinateTransformer(spatialReference);
+    const transformed = transformer.transformPosition([0, 0, 100]);
+
+    expect(transformed[0]).toBeCloseTo(6378237, 6);
+    expect(transformed[1]).toBeCloseTo(0, 8);
+    expect(transformed[2]).toBeCloseTo(0, 8);
   });
 
   test('rejects requested conversion with unknown source metadata', () => {

--- a/modules/tiles/test/tileset/tileset-3d-source.spec.ts
+++ b/modules/tiles/test/tileset/tileset-3d-source.spec.ts
@@ -226,7 +226,10 @@ test('I3SSource transforms traversal bounds and preserves a geographic view cent
     status: 'transformed'
   });
   expect(tileset.root?.header.boundingVolume.box).toHaveLength(12);
-  expect(tileset.root?.boundingVolume.center[0]).toBeCloseTo(1113194.9079, 2);
+  expect(tileset.root?.header.spatialBoundingVolume.box).toHaveLength(12);
+  expect(tileset.root?.header.spatialBoundingVolume.box[0]).toBeCloseTo(1113194.9079, 2);
+  expect(tileset.root?.boundingVolume.center[0]).toBeGreaterThan(6_000_000);
+  expect(tileset.root?.header.i3sLodMbs.slice(0, 3)).toEqual([10, 0, 12]);
   expect(tileset.cartographicCenter[0]).toBeCloseTo(10, 8);
   expect(tileset.cartographicCenter[1]).toBeCloseTo(0, 8);
 });

--- a/modules/tiles/test/tileset/tileset-3d-source.spec.ts
+++ b/modules/tiles/test/tileset/tileset-3d-source.spec.ts
@@ -200,6 +200,36 @@ test('I3SSource initializes promised roots and appends auth tokens to tile urls'
   );
   expect(source.getTilesTotalCount()).toBe(7);
 });
+test('I3SSource transforms traversal bounds and preserves a geographic view center', async () => {
+  const source = new I3SSource({
+    type: 'tileset',
+    url: 'https://example.com/SceneServer/layers/0',
+    loader: I3SLoader,
+    root: {
+      id: 'root-node',
+      refine: 'REPLACE',
+      mbs: [10, 0, 12, 100],
+      boundingVolume: {sphere: [10, 0, 12, 100]},
+      lodMetricType: 'maxScreenThresholdSQ',
+      lodMetricValue: 4
+    },
+    lodMetricType: 'maxScreenThresholdSQ',
+    lodMetricValue: 4,
+    spatialReference: {wkid: 4326},
+    store: {normalReferenceFrame: 'earth-centered'}
+  } as any);
+  const tileset = new Tileset3D(source, {spatial: {targetCrs: 'EPSG:3857'}});
+  await tileset.tilesetInitializationPromise;
+
+  expect(tileset.spatialReference).toMatchObject({
+    targetCrs: 'EPSG:3857',
+    status: 'transformed'
+  });
+  expect(tileset.root?.header.boundingVolume.box).toHaveLength(12);
+  expect(tileset.root?.boundingVolume.center[0]).toBeCloseTo(1113194.9079, 2);
+  expect(tileset.cartographicCenter[0]).toBeCloseTo(10, 8);
+  expect(tileset.cartographicCenter[1]).toBeCloseTo(0, 8);
+});
 test('I3SSource appends auth tokens before loading URL-backed root metadata', async () => {
   const requestedUrls: string[] = [];
   const resolver: TilesetSourceResolver = {


### PR DESCRIPTION
## Goals

- Complete I3S roadmap tranche 6a by applying requested horizontal CRS transforms consistently across mesh and Point Cloud profiles.
- Keep projection and CRS math in math.gl while preserving I3S-specific precision, normal-frame, traversal-bound, and dateline semantics.
- Expose a small target-CRS option surface and document the supported boundary for v5.0.

## Changes

- Add an `I3SSpatialTransformer` adapter that uses `@math.gl/proj4` for geographic/projected operations and `@math.gl/geospatial` for WGS84 geographic/ECEF and ENU calculations.
- Extend the shared transformer with WGS84 ECEF input/output, WKT/PROJ/PROJJSON coordinate-frame classification, and correct geographic-space height handling.
- Reconstruct absolute Float64 I3S mesh positions, transform them, and return renderer-ready Float32 offsets around a stable target origin.
- Transform earth-centered and vertex-reference-frame normals into the selected target basis.
- Keep mesh traversal/culling bounds in WGS84 ECEF and Point Cloud traversal bounds in WGS84 geographic coordinates, independent of the requested output CRS.
- Expose parallel target-frame `spatialBoundingVolume` metadata for mesh and Point Cloud output, including wrapped-antimeridian and full-longitude state.
- Apply target-CRS and height-reference conversion consistently to geometry, output bounds, content metadata, model matrices, and geographic navigation centers.
- Preserve completed `transformed` runtime descriptors when asynchronous source metadata is synchronized.
- Add mesh, Point Cloud, projection, ECEF, normal, precision, WKT-frame, height-reference, traversal, and dateline regression coverage.
- Mark tranche 6a complete and update the framework CRS guide, I3S CRS guide, API pages, feature table, roadmap, and v5.0 release notes.

## Validation

- `yarn install`
- `yarn lint fix`
- `yarn build`
- `yarn test-node` — 361 passed, 6 skipped
- `yarn test-headless` — 3,260 passed, 39 skipped
- Focused Chromium CRS/profile suite — 33 passed
- `yarn test-audit` — 0 Tape tests, 0 violations
