### PR TITLE
feat(draco): add per-attribute quantization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### v5.0.0-alpha.2
 
+- feat(draco): add validated per-attribute quantization and explicit quantization transforms to `DracoWriter`
 - feat(gltf): select AVIF texture sources when the active image decoder supports them, and support independent `KHR_texture_transform` transforms for textures that share UV data (#3611, #3632)
 - feat(parquet): expand the TypeScript Parquet backend with direct Arrow materialization, selective range reads, dataset discovery, browser worker decoding, and Parquet 2.13 logical-type support (#3539, #3556, #3570, #3606, #3623, #3626, #3631)
 - feat(splats): publish SPLAT, KSPLAT, SPZ, RAD, RAD source, and Gaussian PLY support, including RAD metadata validation schemas (#3408, #3430, #3569)

--- a/docs/modules/draco/api-reference/draco-writer.md
+++ b/docs/modules/draco/api-reference/draco-writer.md
@@ -41,6 +41,7 @@ const data = await encode(mesh, DracoWriter, options);
 | `draco.speed`              | `[number, number]`                                           | Draco   | Encoding and decoding speed, from `0` (slowest) to `10` (fastest).                          |
 | `draco.method`             | `'MESH_EDGEBREAKER_ENCODING' \| 'MESH_SEQUENTIAL_ENCODING'` | Draco   | Triangle mesh encoding method.                                                              |
 | `draco.quantization`       | `Partial<Record<DracoAttributeType, number>>`                | Draco   | Quantization bits keyed by Draco attribute type, such as `POSITION: 14`.                    |
+| `draco.attributeQuantization` | `Record<string, number \| DracoExplicitQuantization>`      | `{}`    | Quantization keyed by exact application attribute name.                                     |
 | `draco.attributeTypes`     | `Record<string, DracoAttributeType>`                         | `{}`    | Overrides the Draco compression category for application attributes such as `coordinates`. |
 | `draco.attributeNameEntry` | `string`                                                     | `name`  | Metadata key used to preserve each original application attribute name.                     |
 | `draco.metadata`           | `DracoMetadata`                                              | `{}`    | Geometry metadata containing strings, numbers, or `Int32Array` values.                      |
@@ -56,6 +57,24 @@ await encode(mesh, DracoWriter, {
   }
 });
 ```
+
+Use `attributeQuantization` when attributes in the same Draco category need different settings.
+An exact attribute setting overrides `quantization` for that attribute. A number selects only the
+bit depth; an object also supplies the quantization origin and range.
+
+```typescript
+await encode(mesh, DracoWriter, {
+  draco: {
+    quantization: {TEX_COORD: 10},
+    attributeQuantization: {
+      TEXCOORD_1: {bits: 14, origin: [-1, -1], range: 2}
+    }
+  }
+});
+```
+
+Quantization bits must be integers from `1` through `30`. Explicit origins must have one finite
+value per attribute component, and explicit ranges must be positive and finite.
 
 ## Dependencies
 

--- a/modules/draco/src/draco3d/draco3d-types.ts
+++ b/modules/draco/src/draco3d/draco3d-types.ts
@@ -405,8 +405,7 @@ export declare class Encoder {
 
 /** Draco3D expert encoder */
 export declare class ExpertEncoder {
-  constructor();
-  ExpertEncoder(pc: PointCloud): void;
+  constructor(pointCloud: PointCloud);
   SetEncodingMethod(method: number): void;
   SetAttributeQuantization(att_id: number, quantization_bits: number);
   SetAttributeExplicitQuantization(
@@ -467,6 +466,7 @@ export interface Draco3D {
   readonly Metadata: typeof Metadata;
 
   readonly Encoder: typeof Encoder;
+  readonly ExpertEncoder: typeof ExpertEncoder;
   readonly MeshBuilder: typeof MeshBuilder;
   readonly MetadataBuilder: typeof MetadataBuilder;
 

--- a/modules/draco/src/index.ts
+++ b/modules/draco/src/index.ts
@@ -14,10 +14,12 @@ export {DracoFormat} from './draco-format';
 
 export type {DracoWriterAttributes, DracoWriterInput, DracoWriterOptions} from './draco-writer';
 export type {
+  DracoAttributeQuantization,
   DracoAttributeType,
   DracoBuilderMesh,
   DracoBuildOptions,
   DracoEncodingMethod,
+  DracoExplicitQuantization,
   DracoMetadata
 } from './lib/draco-builder';
 export {DracoWriterWorker, DracoWriter} from './draco-writer';

--- a/modules/draco/src/lib/draco-builder.ts
+++ b/modules/draco/src/lib/draco-builder.ts
@@ -8,6 +8,7 @@ import type {
   Draco3D,
   DracoInt8Array,
   Encoder,
+  ExpertEncoder,
   Mesh,
   MeshBuilder,
   PointCloud,
@@ -35,6 +36,19 @@ export type DracoEncodingMethod = 'MESH_EDGEBREAKER_ENCODING' | 'MESH_SEQUENTIAL
 /** Draco attribute categories used to select compression transforms. */
 export type DracoAttributeType = 'POSITION' | 'NORMAL' | 'COLOR' | 'TEX_COORD' | 'GENERIC';
 
+/** Explicit quantization transform for one Draco attribute. */
+export type DracoExplicitQuantization = {
+  /** Number of quantization bits, from 1 through 30. */
+  bits: number;
+  /** Quantization origin, with one finite value per attribute component. */
+  origin: number[];
+  /** Positive finite quantization range shared by every component. */
+  range: number;
+};
+
+/** Per-attribute quantization, expressed as a bit count or an explicit transform. */
+export type DracoAttributeQuantization = number | DracoExplicitQuantization;
+
 export type DracoBuildOptions = {
   pointcloud?: boolean;
   /** Deduplicate identical point-cloud attribute tuples before encoding. */
@@ -50,7 +64,19 @@ export type DracoBuildOptions = {
   // draco encoding options
   speed?: [number, number];
   method?: DracoEncodingMethod;
+  /** Quantization bits keyed by Draco attribute category. */
   quantization?: Partial<Record<DracoAttributeType, number>>;
+  /** Quantization keyed by application attribute name, overriding category settings. */
+  attributeQuantization?: Record<string, DracoAttributeQuantization>;
+};
+
+type DracoBuilderAttributeInfo = {
+  /** Unique attribute identifier assigned by Draco's geometry builder. */
+  attributeId: number;
+  /** Draco compression category for the attribute. */
+  attributeType: draco_GeometryAttribute_Type;
+  /** Number of scalar components in each attribute value. */
+  componentCount: number;
 };
 
 // Native Draco attribute names to GLTF attribute names.
@@ -98,7 +124,6 @@ export default class DracoBuilder {
    */
   encodeSync(mesh: DracoBuilderMesh, options: DracoBuildOptions = {}): ArrayBuffer {
     this.log = options.log || noop;
-    this._setOptions(options);
 
     return options.pointcloud
       ? this._encodePointCloud(mesh, options)
@@ -117,18 +142,31 @@ export default class DracoBuilder {
   _encodePointCloud(pointcloud: DracoBuilderMesh, options: DracoBuildOptions): ArrayBuffer {
     const dracoPointCloud = new this.draco.PointCloud();
     const dracoData = new this.draco.DracoInt8Array();
+    let expertEncoder: ExpertEncoder | null = null;
 
     try {
       if (options.metadata) {
         this._addGeometryMetadata(dracoPointCloud, options.metadata);
       }
       const attributes = this._getAttributesFromMesh(pointcloud);
-      this._createDracoPointCloud(dracoPointCloud, attributes, options);
-      const encodedLen = this.dracoEncoder.EncodePointCloudToDracoBuffer(
-        dracoPointCloud,
-        options.deduplicateValues ?? false,
-        dracoData
-      );
+      const attributeInfo = this._createDracoPointCloud(dracoPointCloud, attributes, options);
+      const useExpertEncoder = hasAttributeQuantization(options);
+      let encodedLen: number;
+      if (useExpertEncoder) {
+        expertEncoder = new this.draco.ExpertEncoder(dracoPointCloud);
+        this._setExpertOptions(expertEncoder, attributeInfo, options);
+        encodedLen = expertEncoder.EncodeToDracoBuffer(
+          options.deduplicateValues ?? false,
+          dracoData
+        );
+      } else {
+        this._setOptions(options);
+        encodedLen = this.dracoEncoder.EncodePointCloudToDracoBuffer(
+          dracoPointCloud,
+          options.deduplicateValues ?? false,
+          dracoData
+        );
+      }
 
       if (!(encodedLen > 0)) {
         throw new Error('Draco encoding failed.');
@@ -139,6 +177,7 @@ export default class DracoBuilder {
 
       return dracoInt8ArrayToArrayBuffer(dracoData);
     } finally {
+      this.destroyEncodedObject(expertEncoder);
       this.destroyEncodedObject(dracoData);
       this.destroyEncodedObject(dracoPointCloud);
     }
@@ -147,14 +186,24 @@ export default class DracoBuilder {
   _encodeMesh(mesh: DracoBuilderMesh, options: DracoBuildOptions): ArrayBuffer {
     const dracoMesh = new this.draco.Mesh();
     const dracoData = new this.draco.DracoInt8Array();
+    let expertEncoder: ExpertEncoder | null = null;
 
     try {
       if (options.metadata) {
         this._addGeometryMetadata(dracoMesh, options.metadata);
       }
       const attributes = this._getAttributesFromMesh(mesh);
-      this._createDracoMesh(dracoMesh, attributes, options);
-      const encodedLen = this.dracoEncoder.EncodeMeshToDracoBuffer(dracoMesh, dracoData);
+      const attributeInfo = this._createDracoMesh(dracoMesh, attributes, options);
+      const useExpertEncoder = hasAttributeQuantization(options);
+      let encodedLen: number;
+      if (useExpertEncoder) {
+        expertEncoder = new this.draco.ExpertEncoder(dracoMesh);
+        this._setExpertOptions(expertEncoder, attributeInfo, options);
+        encodedLen = expertEncoder.EncodeToDracoBuffer(false, dracoData);
+      } else {
+        this._setOptions(options);
+        encodedLen = this.dracoEncoder.EncodeMeshToDracoBuffer(dracoMesh, dracoData);
+      }
       if (encodedLen <= 0) {
         throw new Error('Draco encoding failed.');
       }
@@ -164,6 +213,7 @@ export default class DracoBuilder {
 
       return dracoInt8ArrayToArrayBuffer(dracoData);
     } finally {
+      this.destroyEncodedObject(expertEncoder);
       this.destroyEncodedObject(dracoData);
       this.destroyEncodedObject(dracoMesh);
     }
@@ -183,8 +233,63 @@ export default class DracoBuilder {
         const attributeType = attribute as DracoAttributeType;
         const bits = options.quantization[attributeType];
         if (bits !== undefined) {
+          validateQuantizationBits(attributeType, bits);
           this.dracoEncoder.SetAttributeQuantization(this.draco[attributeType], bits);
         }
+      }
+    }
+  }
+
+  /** Applies common options and per-attribute quantization to an expert encoder. */
+  _setExpertOptions(
+    expertEncoder: ExpertEncoder,
+    attributes: Record<string, DracoBuilderAttributeInfo>,
+    options: DracoBuildOptions
+  ): void {
+    if (options.speed) {
+      expertEncoder.SetSpeedOptions(...options.speed);
+    }
+    if (options.method) {
+      expertEncoder.SetEncodingMethod(this.draco[options.method]);
+    }
+
+    const categoryQuantization = new Map<draco_GeometryAttribute_Type, number>();
+    for (const attributeType of Object.keys(options.quantization || {}) as DracoAttributeType[]) {
+      const bits = options.quantization?.[attributeType];
+      if (bits !== undefined) {
+        validateQuantizationBits(attributeType, bits);
+        categoryQuantization.set(this.draco[attributeType], bits);
+      }
+    }
+
+    const quantization = new Map<string, DracoAttributeQuantization>();
+    for (const [attributeName, attribute] of Object.entries(attributes)) {
+      const bits = categoryQuantization.get(attribute.attributeType);
+      if (bits !== undefined) {
+        quantization.set(attributeName, bits);
+      }
+    }
+    for (const [attributeName, setting] of Object.entries(options.attributeQuantization || {})) {
+      if (!attributes[attributeName]) {
+        throw new Error(`DracoWriter: quantized attribute "${attributeName}" does not exist`);
+      }
+      quantization.set(attributeName, setting);
+    }
+
+    for (const [attributeName, setting] of quantization) {
+      const attribute = attributes[attributeName];
+      if (typeof setting === 'number') {
+        validateQuantizationBits(attributeName, setting);
+        expertEncoder.SetAttributeQuantization(attribute.attributeId, setting);
+      } else {
+        validateExplicitQuantization(attributeName, attribute.componentCount, setting);
+        expertEncoder.SetAttributeExplicitQuantization(
+          attribute.attributeId,
+          setting.bits,
+          attribute.componentCount,
+          setting.origin,
+          setting.range
+        );
       }
     }
   }
@@ -198,8 +303,9 @@ export default class DracoBuilder {
     dracoMesh: Mesh,
     attributes: Record<string, TypedArray | MeshAttribute>,
     options: DracoBuildOptions
-  ): Mesh {
+  ): Record<string, DracoBuilderAttributeInfo> {
     const optionalMetadata = options.attributesMetadata || {};
+    const attributeInfo: Record<string, DracoBuilderAttributeInfo> = {};
 
     const vertexCount = this._getVertexCount(attributes, options);
     for (const [attributeName, attribute] of Object.entries(attributes)) {
@@ -212,6 +318,15 @@ export default class DracoBuilder {
       );
 
       if (uniqueId !== -1) {
+        const attributeValue = getAttributeValue(attribute);
+        attributeInfo[attributeName] = {
+          attributeId: uniqueId,
+          attributeType: this._getDracoAttributeType(
+            attributeName,
+            options.attributeTypes
+          ) as draco_GeometryAttribute_Type,
+          componentCount: getAttributeSize(attribute, attributeValue!.length / vertexCount)
+        };
         this._addAttributeMetadata(dracoMesh, uniqueId, {
           [options.attributeNameEntry || 'name']: attributeName,
           ...(optionalMetadata[attributeName] || {})
@@ -219,7 +334,7 @@ export default class DracoBuilder {
       }
     }
 
-    return dracoMesh;
+    return attributeInfo;
   }
 
   /**
@@ -230,8 +345,9 @@ export default class DracoBuilder {
     dracoPointCloud: PointCloud,
     attributes: Record<string, TypedArray | MeshAttribute>,
     options: DracoBuildOptions
-  ): PointCloud {
+  ): Record<string, DracoBuilderAttributeInfo> {
     const optionalMetadata = options.attributesMetadata || {};
+    const attributeInfo: Record<string, DracoBuilderAttributeInfo> = {};
 
     const vertexCount = this._getVertexCount(attributes, options);
     for (const [attributeName, attribute] of Object.entries(attributes)) {
@@ -243,6 +359,15 @@ export default class DracoBuilder {
         options
       );
       if (uniqueId !== -1) {
+        const attributeValue = getAttributeValue(attribute);
+        attributeInfo[attributeName] = {
+          attributeId: uniqueId,
+          attributeType: this._getDracoAttributeType(
+            attributeName,
+            options.attributeTypes
+          ) as draco_GeometryAttribute_Type,
+          componentCount: getAttributeSize(attribute, attributeValue!.length / vertexCount)
+        };
         this._addAttributeMetadata(dracoPointCloud, uniqueId, {
           [options.attributeNameEntry || 'name']: attributeName,
           ...(optionalMetadata[attributeName] || {})
@@ -250,7 +375,7 @@ export default class DracoBuilder {
       }
     }
 
-    return dracoPointCloud;
+    return attributeInfo;
   }
 
   /**
@@ -530,5 +655,41 @@ function validateIndices(indices: TypedArray, vertexCount: number): void {
         `DracoWriter: triangle index ${index} is outside vertex range 0-${vertexCount - 1}`
       );
     }
+  }
+}
+
+/** Returns true when exact application attributes require the expert encoder. */
+function hasAttributeQuantization(options: DracoBuildOptions): boolean {
+  return Boolean(
+    options.attributeQuantization && Object.keys(options.attributeQuantization).length
+  );
+}
+
+/** Validates a Draco quantization bit count. */
+function validateQuantizationBits(attributeName: string, bits: number): void {
+  if (!Number.isInteger(bits) || bits < 1 || bits > 30) {
+    throw new Error(
+      `DracoWriter: quantization bits for "${attributeName}" must be an integer from 1 to 30`
+    );
+  }
+}
+
+/** Validates an explicit per-attribute quantization transform. */
+function validateExplicitQuantization(
+  attributeName: string,
+  componentCount: number,
+  quantization: DracoExplicitQuantization
+): void {
+  validateQuantizationBits(attributeName, quantization.bits);
+  if (!Array.isArray(quantization.origin) || quantization.origin.length !== componentCount) {
+    throw new Error(
+      `DracoWriter: quantization origin for "${attributeName}" must contain ${componentCount} values`
+    );
+  }
+  if (!quantization.origin.every(Number.isFinite)) {
+    throw new Error(`DracoWriter: quantization origin for "${attributeName}" must be finite`);
+  }
+  if (!Number.isFinite(quantization.range) || quantization.range <= 0) {
+    throw new Error(`DracoWriter: quantization range for "${attributeName}" must be positive`);
   }
 }

--- a/modules/draco/test/draco-writer.spec.ts
+++ b/modules/draco/test/draco-writer.spec.ts
@@ -453,6 +453,53 @@ test('DracoWriter#preserves secondary glTF attribute semantics', async () => {
 
   expect(decodedMesh.attributes.TEXCOORD_1.value).toHaveLength(6);
 });
+
+test('DracoWriter#applies independent quantization to attributes in one category', async () => {
+  const compressedMesh = await encode(
+    {
+      attributes: {
+        POSITION: new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]),
+        TEXCOORD_0: new Float32Array([0, 0, 1, 0, 0, 1]),
+        TEXCOORD_1: new Float32Array([-1, -1, 1, -1, -1, 1])
+      },
+      indices: new Uint16Array([0, 1, 2])
+    },
+    DracoWriter,
+    {
+      core: {worker: false},
+      useLocalLibraries: true,
+      draco: {
+        quantization: {TEX_COORD: 8},
+        attributeQuantization: {
+          TEXCOORD_1: {bits: 12, origin: [-1, -1], range: 2}
+        }
+      }
+    }
+  );
+  const decodedMesh = await parse(compressedMesh, DracoLoader, {
+    core: {worker: false},
+    useLocalLibraries: true,
+    draco: {quantizedAttributes: ['TEX_COORD']}
+  });
+  const loaderAttributes = Object.values(decodedMesh.loaderData.attributes);
+  const texCoord0 = loaderAttributes.find(
+    attribute => attribute.metadata.name?.string === 'TEXCOORD_0'
+  );
+  const texCoord1 = loaderAttributes.find(
+    attribute => attribute.metadata.name?.string === 'TEXCOORD_1'
+  );
+
+  expect(texCoord0?.quantization_transform).toMatchObject({
+    quantization_bits: 8,
+    range: 1
+  });
+  expect(texCoord0?.quantization_transform?.min_values).toEqual(new Float32Array([0, 0]));
+  expect(texCoord1?.quantization_transform).toMatchObject({
+    quantization_bits: 12,
+    range: 2
+  });
+  expect(texCoord1?.quantization_transform?.min_values).toEqual(new Float32Array([-1, -1]));
+});
 function validatePositionMetadata(data) {
   const POSITION = 0;
   expect(data.loaderData.attributes[POSITION].metadata).toBeTruthy();

--- a/modules/draco/test/lib/draco-builder.spec.ts
+++ b/modules/draco/test/lib/draco-builder.spec.ts
@@ -87,6 +87,47 @@ function createFakeDraco(): {draco: any; state: FakeDracoState} {
     }
   }
 
+  class FakeExpertEncoder {
+    /** Records construction against a completed Draco geometry. */
+    constructor(_pointCloud: unknown) {
+      state.encoderCalls.push('expert');
+    }
+
+    /** Records expert encoder speed configuration. */
+    SetSpeedOptions(encodeSpeed: number, decodeSpeed: number): void {
+      state.encoderCalls.push(`expert-speed:${encodeSpeed}:${decodeSpeed}`);
+    }
+
+    /** Records the selected expert mesh encoding method. */
+    SetEncodingMethod(method: number): void {
+      state.encoderCalls.push(`expert-method:${method}`);
+    }
+
+    /** Records per-attribute quantization configuration. */
+    SetAttributeQuantization(attributeId: number, bits: number): void {
+      state.encoderCalls.push(`expert-quantization:${attributeId}:${bits}`);
+    }
+
+    /** Records explicit per-attribute quantization configuration. */
+    SetAttributeExplicitQuantization(
+      attributeId: number,
+      bits: number,
+      componentCount: number,
+      origin: number[],
+      range: number
+    ): void {
+      state.encoderCalls.push(
+        `expert-explicit:${attributeId}:${bits}:${componentCount}:${origin.join(',')}:${range}`
+      );
+    }
+
+    /** Produces deterministic expert-encoder output. */
+    EncodeToDracoBuffer(deduplicateValues: boolean): number {
+      state.encoderCalls.push(`expert-encode:${deduplicateValues}`);
+      return state.encodeLength;
+    }
+  }
+
   class FakeMeshBuilder {
     private nextAttributeId = 0;
 
@@ -236,6 +277,7 @@ function createFakeDraco(): {draco: any; state: FakeDracoState} {
     GENERIC: 4,
     MESH_EDGEBREAKER_ENCODING: 9,
     Encoder: FakeEncoder,
+    ExpertEncoder: FakeExpertEncoder,
     MeshBuilder: FakeMeshBuilder,
     MetadataBuilder: FakeMetadataBuilder,
     Mesh: FakeGeometry,
@@ -325,6 +367,81 @@ test('DracoBuilder encodes point clouds and accepts Map metadata', () => {
   expect(Array.from(new Uint8Array(output))).toEqual([11, 22, 33]);
   expect(state.encoderCalls).toEqual(['pointcloud:true']);
   expect(state.attributeCalls).toEqual(['float32']);
+});
+
+test('DracoBuilder applies exact attribute quantization with ExpertEncoder', () => {
+  const {draco, state} = createFakeDraco();
+  const builder = new DracoBuilder(draco);
+
+  builder.encodeSync(
+    {
+      attributes: {
+        POSITION: new Float32Array([0, 0, 0, 1, 1, 1]),
+        TEXCOORD_0: new Float32Array([0, 0, 1, 1]),
+        TEXCOORD_1: new Float32Array([-1, -1, 1, 1])
+      },
+      indices: new Uint16Array([0, 1, 0])
+    },
+    {
+      speed: [1, 3],
+      method: 'MESH_EDGEBREAKER_ENCODING',
+      quantization: {POSITION: 12, TEX_COORD: 8},
+      attributeQuantization: {
+        TEXCOORD_1: {bits: 14, origin: [-1, -1], range: 2}
+      }
+    }
+  );
+
+  expect(state.encoderCalls).toEqual([
+    'expert',
+    'expert-speed:1:3',
+    'expert-method:9',
+    'expert-quantization:0:12',
+    'expert-quantization:1:8',
+    'expert-explicit:2:14:2:-1,-1:2',
+    'expert-encode:false'
+  ]);
+  expect(state.destroyed).toHaveLength(3);
+});
+
+test('DracoBuilder uses ExpertEncoder for exact point-cloud quantization', () => {
+  const {draco, state} = createFakeDraco();
+  const builder = new DracoBuilder(draco);
+
+  builder.encodeSync(
+    {attributes: {POSITION: new Float32Array([0, 0, 0, 1, 1, 1])}},
+    {
+      pointcloud: true,
+      deduplicateValues: true,
+      attributeQuantization: {POSITION: 10}
+    }
+  );
+
+  expect(state.encoderCalls).toEqual(['expert', 'expert-quantization:0:10', 'expert-encode:true']);
+});
+
+test.each([
+  [{attributeQuantization: {missing: 8}}, 'quantized attribute "missing" does not exist'],
+  [{attributeQuantization: {POSITION: 0}}, 'must be an integer from 1 to 30'],
+  [
+    {attributeQuantization: {POSITION: {bits: 8, origin: [0, 0], range: 1}}},
+    'must contain 3 values'
+  ],
+  [
+    {attributeQuantization: {POSITION: {bits: 8, origin: [0, 0, Infinity], range: 1}}},
+    'origin for "POSITION" must be finite'
+  ],
+  [
+    {attributeQuantization: {POSITION: {bits: 8, origin: [0, 0, 0], range: 0}}},
+    'range for "POSITION" must be positive'
+  ],
+  [{quantization: {POSITION: 31}}, 'must be an integer from 1 to 30']
+])('DracoBuilder validates quantization options', (options, message) => {
+  const {draco} = createFakeDraco();
+  const builder = new DracoBuilder(draco);
+  const mesh = {attributes: {POSITION: new Float32Array([0, 0, 0])}};
+
+  expect(() => builder.encodeSync(mesh, options as any)).toThrow(message);
 });
 
 test('DracoBuilder reports missing positions and encoder failures', () => {


### PR DESCRIPTION
## Goals

- Let applications tune quantization independently for attributes that share a Draco category.
- Expose the official Draco ExpertEncoder path without changing existing category-level writer behavior.
- Reject malformed quantization settings before native encoding.

## Changes

- Adds typed `draco.attributeQuantization` options keyed by application attribute name.
- Supports either a bit count or an explicit `{bits, origin, range}` quantization transform.
- Expands existing category defaults by Draco attribute ID and lets exact attribute settings override them.
- Corrects and exports the vendored `ExpertEncoder` TypeScript declaration.
- Validates bit depth, attribute names, explicit origin dimensions and values, and explicit ranges.
- Adds deterministic builder coverage plus a real browser/WASM round trip proving independent `TEXCOORD_0` and `TEXCOORD_1` transforms.
- Documents the new option and exports its public types.

## Validation

- `yarn install`
- `yarn lint fix`
- `yarn build`
- `yarn build-workers`
- `yarn test-node` (361 passed, 6 skipped)
- `yarn test-headless` (3258 passed, 39 skipped)
- focused Draco headless tests (28 passed)
- `yarn test-audit` (0 violations)