### PR TITLE
docs: add combined coverage badge

### DIFF
--- a/docs/README.mdx
+++ b/docs/README.mdx
@@ -6,9 +6,7 @@ import {FormatLogoGallery} from '@site/src/components/docs/format-logo-gallery';
 <img src="https://img.shields.io/badge/License-MIT-green.svg" /> &nbsp;
 <img src="https://img.shields.io/npm/dm/@loaders.gl/core.svg" />  &nbsp;
 <img src="https://img.shields.io/badge/TypeScript-6.0-3178C6.svg?style=flat-square" alt="TypeScript 6.0" /> &nbsp;
-<a href="https://coveralls.io/github/visgl/loaders.gl?branch=master">
-  <img src="https://coveralls.io/repos/github/visgl/loaders.gl/badge.svg?branch=master" alt="Coverage Status" />
-</a> &nbsp;
+<a href="https://coveralls.io/github/visgl/loaders.gl?branch=master"><img src="https://coveralls.io/repos/github/visgl/loaders.gl/badge.svg?branch=master" alt="Coverage Status" /></a> &nbsp;
 <br />
 <br />
 

--- a/docs/README.mdx
+++ b/docs/README.mdx
@@ -6,6 +6,9 @@ import {FormatLogoGallery} from '@site/src/components/docs/format-logo-gallery';
 <img src="https://img.shields.io/badge/License-MIT-green.svg" /> &nbsp;
 <img src="https://img.shields.io/npm/dm/@loaders.gl/core.svg" />  &nbsp;
 <img src="https://img.shields.io/badge/TypeScript-6.0-3178C6.svg?style=flat-square" alt="TypeScript 6.0" /> &nbsp;
+<a href="https://coveralls.io/github/visgl/loaders.gl?branch=master">
+  <img src="https://coveralls.io/repos/github/visgl/loaders.gl/badge.svg?branch=master" alt="Coverage Status" />
+</a> &nbsp;
 <br />
 <br />
 


### PR DESCRIPTION
## Goals

- Make the tracked combined loaders.gl coverage visible from the main documentation landing page.

## Changes

- Add a Coveralls badge to `docs/README.mdx`.
- Link the badge to the `master` branch coverage report, which is populated by merged CI coverage.

## Validation

- `git diff --check`
- Documentation-only change.