### PR TITLE
Add common authentication for geospatial services

### DIFF
--- a/docs/developer-guide/authentication.md
+++ b/docs/developer-guide/authentication.md
@@ -1,0 +1,172 @@
+# Authentication
+
+loaders.gl uses one credential pipeline for files, tiles, service metadata, and the follow-up
+requests made by a source. Applications provide a static token or an asynchronous token callback;
+loaders.gl decides where that credential may be sent and carries it through `load`,
+`createDataSource`, service runtimes, and deck.gl source layers.
+
+The pipeline deliberately does not implement sign-in screens, OAuth redirects, secure storage, or
+provider token issuance. Those remain application responsibilities. Its job begins when the
+application can return a usable token.
+
+## The minimal pattern
+
+Provider presets live in `@loaders.gl/services`. Pass the resulting credential through
+`core.credentials`:
+
+```ts
+import {load} from '@loaders.gl/core';
+import {
+  ArcGISFeatureServerSourceLoader,
+  createArcGISCredential
+} from '@loaders.gl/services';
+
+const credentials = [
+  createArcGISCredential({
+    origins: ['https://services.example.com'],
+    token: arcgisToken
+  })
+];
+
+const source = await load(featureServerUrl, ArcGISFeatureServerSourceLoader, {
+  core: {credentials}
+});
+const features = await source.getFeatures({layers: ['0']});
+```
+
+The exact same option works with `createDataSource` and with loaders that make nested requests.
+Explicit credentials already present on a request URL or in its headers take precedence over a
+configured credential.
+
+## Static tokens and refreshing tokens
+
+A string is appropriate for a token whose lifetime exceeds the source. For expiring credentials,
+provide a callback that returns the current token and refreshes it when asked:
+
+```ts
+import {createBearerTokenCredential} from '@loaders.gl/loader-utils';
+
+let currentToken = await acquireToken();
+
+const credential = createBearerTokenCredential({
+  id: 'private-tiles',
+  origins: ['https://tiles.example.com'],
+  token: async ({reason, response}) => {
+    if (reason === 'refresh') {
+      currentToken = await refreshToken({status: response?.status});
+    }
+    return currentToken;
+  }
+});
+```
+
+Callbacks receive `reason: 'request'` for normal authorization and `reason: 'refresh'` after an
+accepted authentication failure. Refreshes for the same credential are deduplicated. loaders.gl
+replays at most once, and only for an idempotent request with a reusable body. Static tokens are
+never refreshed automatically.
+
+## Provider presets
+
+| Provider | Helper | Placement | Default origin | Notes |
+| --- | --- | --- | --- | --- |
+| ArcGIS REST | `createArcGISCredential` | `token` query parameter | None; required | Includes ArcGIS 498 and 499 refresh statuses |
+| Mapbox | `createMapboxCredential` | `access_token` query parameter | `https://api.mapbox.com` | Suitable for TileJSON and child tile requests |
+| Google Maps Platform | `createGoogleMapsCredential` | `key` query parameter | `https://tile.googleapis.com` | A server-returned 3D Tiles `session` parameter is preserved separately |
+| Cesium ion REST API | `createCesiumIonCredential` | Bearer header | `https://api.cesium.com` | Authorizes ion discovery and endpoint bootstrap |
+
+Every helper accepts an async token callback. `origins` replaces a helper's default allowlist when
+the service is reached through a proxy or another provider host.
+
+### Mapbox tiles
+
+```ts
+import {createDataSource} from '@loaders.gl/core';
+import {MVTSourceLoader} from '@loaders.gl/mvt';
+import {createMapboxCredential} from '@loaders.gl/services';
+
+const source = createDataSource(tileJSONUrl, [MVTSourceLoader], {
+  core: {
+    credentials: [createMapboxCredential({accessToken: mapboxToken})]
+  }
+});
+```
+
+### Google 3D Tiles
+
+```ts
+import {Tiles3DLoader} from '@loaders.gl/3d-tiles';
+import {Tiles3DSource} from '@loaders.gl/tiles';
+import {createGoogleMapsCredential} from '@loaders.gl/services';
+
+const source = new Tiles3DSource(
+  {url: googleTilesetUrl, loader: Tiles3DLoader},
+  {core: {credentials: [createGoogleMapsCredential({apiKey: googleApiKey})]}}
+);
+```
+
+Google's API key authorizes the request. The `session` query parameter returned in tileset content
+URLs is request state, not another application credential; `Tiles3DSource` preserves both values
+without replacing an explicit child parameter.
+
+### Cesium ion
+
+```ts
+import {load} from '@loaders.gl/core';
+import {CesiumIonLoader} from '@loaders.gl/3d-tiles';
+
+const tileset = await load('https://assets.cesium.com/123/tileset.json', CesiumIonLoader, {
+  'cesium-ion': {accessToken: ionAccessToken, assetId: 123}
+});
+```
+
+The Cesium ion loader uses the account token only with `api.cesium.com`, resolves the asset
+endpoint, and installs the returned endpoint token only for that endpoint's exact origin. The
+legacy `cesium-ion.accessToken` option remains the shortest Cesium-specific entry point;
+`createCesiumIonCredential` is useful when the ion REST request shares a larger application
+credential registry.
+
+## deck.gl layers
+
+Pass credentials inside the usual `loadOptions`. `SourceLayer`, `Tile3DSourceLayer`, and their
+nested sources retain them for metadata, tiles, external tilesets, and other dependent resources:
+
+```ts
+const layer = new SourceLayer({
+  id: 'secured-service',
+  data: serviceUrl,
+  loaders: SERVICE_LOADERS,
+  loadOptions: {core: {credentials}}
+});
+```
+
+For a source created before the layer, put `core.credentials` in the source's options instead.
+
+## Security model
+
+- Credentials are sent only when `URL.origin` exactly matches an allowlisted origin. Paths and
+  wildcard subdomains are intentionally unsupported.
+- Use separate credentials when APIs and asset hosts have different trust boundaries.
+- Credential query parameters are redacted from `ServiceRuntime` telemetry and normalized request
+  errors. Applications should apply the same policy to custom fetch logging.
+- Prefer headers when the provider supports them: query parameters can appear in browser history,
+  intermediary logs, and copied URLs.
+- loaders.gl keeps tokens in memory only through the values and callbacks supplied by the
+  application. It does not persist them.
+
+## Cookies, proxies, and custom transports
+
+Cookie-authenticated services still use standard fetch configuration:
+
+```ts
+const source = createDataSource(url, loaders, {
+  core: {fetch: {credentials: 'include'}}
+});
+```
+
+The server must permit the browser origin and credentials through CORS. For signed URLs, complex
+request signing, service workers, or application gateways, provide `core.fetch`; the common
+credential wrapper composes with that function. Avoid configuring both a custom signer and a
+loaders.gl credential for the same field unless explicit request values are intended to win.
+
+See the [request credential API](/docs/modules/loader-utils/api-reference/request-credentials) for
+the generic constructors and callback contract.

--- a/docs/docs-sidebar.json
+++ b/docs/docs-sidebar.json
@@ -75,6 +75,7 @@
     "label": "Services",
     "items": [
       "modules/services/README",
+      "developer-guide/authentication",
       "modules/wms/formats/csw",
       "modules/wms/formats/wcs",
       "modules/wms/formats/wfs",
@@ -276,6 +277,7 @@
           "modules/loader-utils/api-reference/request-cache",
           "modules/loader-utils/api-reference/range-request-scheduler",
           "modules/loader-utils/api-reference/range-request-cache",
+          "modules/loader-utils/api-reference/request-credentials",
           "modules/loader-utils/api-reference/parse-with-context"
         ]
       },

--- a/docs/modules/3d-tiles/api-reference/cesium-ion-loader.md
+++ b/docs/modules/3d-tiles/api-reference/cesium-ion-loader.md
@@ -1,73 +1,54 @@
 # CesiumIonLoader
 
-<p class="badges">
-  <img src="https://img.shields.io/badge/From-v1.0-blue.svg?style=flat-square" alt="From-v1.0" />
-</p>
-
-> Extends from `Tiles3DLoader`, inherits all the options and share the same resolved `Tileset` and `Tile` format.
-> Along with the support of resolving tileset metadata and authorization from Cesium ion server.
-
-Parse [3D tile](https://github.com/AnalyticalGraphicsInc/3d-tiles) fetched from Cesium ion server.
+`CesiumIonLoader` extends `Tiles3DLoader` with Cesium ion asset discovery and authentication. It
+uses an application access token to resolve an asset endpoint, then scopes the endpoint token
+returned by ion to the resolved asset origin. Nested tiles, external tilesets, and deck.gl
+`Tile3DSourceLayer` requests retain that credential.
 
 ## Usage
 
-Load a tileset file from Cesium ion server.
-
-```typescript
+```ts
 import {load} from '@loaders.gl/core';
 import {CesiumIonLoader} from '@loaders.gl/3d-tiles';
-import {WebMercatorViewport} from '@deck.gl/core';
-const tilesetUrl = 'https://assets.ion.cesium.com/69380/tileset.json';
-const ION_ACCESS_TOKEN = ''; // your own ion access token
 
-const options = {ion: {loadGLTF: true}};
-// resolve the authorizations used for requesting tiles from Cesium ion server
-const metadata = CesiumIonLoader.preload(tilesetUrl, {accessToken: ION_ACCESS_TOKEN});
-console.log(metadata);
-
-const tilesetJson = await load(tilesetUrl, CesiumIonLoader, {...options, ...metadata});
-
-// If your tileset doesn't have .json extension, set options['cesium-ion'].isTileset to true
-const tilesetJson = await load(tilesetUrl, CesiumIonLoader, {
-  ...options,
-  ...metadata,
-  isTileset: true
-});
-
-const viewport = new WebMercatorViewport({latitude, longitude, zoom});
-tileset3d.selectTiles(viewport);
-
-// visible tiles
-const visibleTiles = tileset3d.tiles.filter((tile) => tile.selected);
-// Note that visibleTiles will likely not immediately include all tiles
-// tiles will keep loading and file `onTileLoad` callbacks
+const tileset = await load(
+  'https://assets.cesium.com/123/tileset.json',
+  CesiumIonLoader,
+  {
+    'cesium-ion': {
+      assetId: 123,
+      accessToken: ionAccessToken
+    }
+  }
+);
 ```
+
+The URL identifies the asset after bootstrap; `assetId` identifies the ion API resource. If
+`assetId` is omitted, the loader can infer it from a conventional `/<id>/tileset.json` URL or use
+the first visible `3DTILES` asset.
+
+## Authentication lifecycle
+
+1. The application access token is sent as a bearer token only to `https://api.cesium.com`.
+2. The ion asset and endpoint documents are fetched.
+3. The returned endpoint URL becomes the tileset URL.
+4. The returned endpoint token is installed as an exact-origin credential for tileset and tile
+   requests.
+
+This prevents either token from leaking when a tileset contains a resource on another origin. To
+use an async account-token provider, create a `createCesiumIonCredential` preset and pass it via
+`core.credentials`. See the [authentication guide](/docs/developer-guide/authentication#cesium-ion).
 
 ## Options
 
-Inherit all the options from `Tiles3DLoader`.
+`CesiumIonLoader` inherits all [`Tiles3DLoader` options](./tiles-3d-loader).
 
-| Option                     | Type           | Default | Description                                                                                                                                                                                                               |
-| -------------------------- | -------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `['cesium-ion'].isTileset` | Bool or `auto` | `auto`  | Whether to load a `Tileset` file. If `auto`, will infer based on url extension.                                                                                                                                           |
-| `['cesium-ion'].headers`   | Object         | `null`  | Used to load data from server                                                                                                                                                                                             |
-| `['cesium-ion'].tileset`   | `Object`       | `null`  | `Tileset` object loaded by `Tiles3DLoader` or follow the data format specified in [Tileset Object](/docs/modules/3d-tiles/api-reference/tiles-3d-loader#tileset-object). It is required when loading i3s geometry content |
-| `['cesium-ion'].tile`      | `Object`       | `null`  | `Tile` object loaded by `Tiles3DLoader` or follow the data format [Tile Object](/docs/modules/3d-tiles/api-reference/tiles-3d-loader#tile-object). It is required when loading i3s geometry content                       |
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `cesium-ion.accessToken` | `string` | `null` | Cesium ion application access token |
+| `cesium-ion.assetId` | `number \| string` | inferred | Asset resolved through the ion REST API |
+| `cesium-ion.onError` | `(error) => void` | `null` | Called when endpoint bootstrap fails; the error is still thrown |
+| `cesium-ion.isTileset` | `boolean \| 'auto'` | `'auto'` | Inherited content-category assertion |
+| `cesium-ion.loadGLTF` | `boolean` | `true` | Fetch and parse linked glTF resources |
 
-Point cloud tie options
-
-| Option                                   | Type      | Default | Description                          |
-| ---------------------------------------- | --------- | ------- | ------------------------------------ |
-| `['cesium-ion'].decodeQuantizedPosition` | `Boolean` | `false` | Pre-decode quantized position on CPU |
-
-For i3dm and b3dm tiles:
-
-| Option                    | Type    | Default | Description                           |
-| ------------------------- | ------- | ------- | ------------------------------------- |
-| `['cesium-ion'].loadGLTF` | Boolean | `true`  | Fetch and parse any linked glTF files |
-
-If `options['cesium-ion'].loadGLTF` is `true`, GLTF loading can be controlled by providing [`GLTFLoader` options](/docs/modules/gltf/api-reference/gltf-loader) via the `options.gltf` sub options.
-
-## Data formats
-
-The same as `Tiles3DLoader`.
+The parsed data formats are identical to `Tiles3DLoader`.

--- a/docs/modules/3d-tiles/concepts/resource-resolution-and-content-detection.md
+++ b/docs/modules/3d-tiles/concepts/resource-resolution-and-content-detection.md
@@ -74,6 +74,11 @@ This cache stores strings only. It does not cache response bodies, decoded conte
 
 The invalidation rule is important for rotating tokens and session changes: a derived URL must never survive after its source query value changes. Applications should still avoid embedding long-lived secrets in logs or diagnostics.
 
+For Google Photorealistic 3D Tiles, configure the API `key` with
+`createGoogleMapsCredential`. The credential pipeline scopes it to `tile.googleapis.com`, while
+the resource resolver independently preserves the server-issued `session` parameter on child
+tiles. See [authentication](/docs/developer-guide/authentication#google-3d-tiles).
+
 ## Nested and archived tilesets
 
 A loaded resource is considered a nested tileset when its parsed result has the normalized `tileset3d` shape. The URL no longer needs to contain `.json`. Nested roots therefore work through signed endpoints and content-addressed storage.

--- a/docs/modules/loader-utils/api-reference/request-credentials.md
+++ b/docs/modules/loader-utils/api-reference/request-credentials.md
@@ -1,0 +1,47 @@
+# Request credentials
+
+`@loaders.gl/loader-utils` exposes transport-level building blocks for scoped query and header
+credentials. Most application code should use the provider presets in `@loaders.gl/services` and
+pass the result as [`core.credentials`](/docs/developer-guide/authentication).
+
+## `createQueryParameterCredential(options)`
+
+Creates a `RequestCredential` that adds a query parameter to requests matching an exact origin.
+
+| Option | Type | Description |
+| --- | --- | --- |
+| `id` | `string` | Stable, non-secret diagnostic name |
+| `origins` | `string[]` | Exact HTTP(S) origins allowed to receive the token |
+| `parameterName` | `string` | Query parameter receiving the token |
+| `token` | `string \| TokenProvider` | Static token or application callback |
+| `refreshStatusCodes` | `number[]` | Statuses allowing one refresh and replay; defaults to 401 and 403 |
+
+## `createBearerTokenCredential(options)`
+
+Creates a header credential. The default header is `Authorization` and the default prefix is
+`Bearer `; `headerName` and `prefix` can customize both.
+
+## `TokenProvider`
+
+```ts
+type TokenProvider = (context: {
+  url: string;
+  reason: 'request' | 'refresh';
+  response?: {status: number; headers: Headers};
+}) => string | null | Promise<string | null>;
+```
+
+The URL is supplied before the credential is attached. The refresh response intentionally exposes
+only status and headers. Returning `null` skips the credential or declines a replay.
+
+## `createAuthenticatedFetch(options)`
+
+Wraps a `FetchLike` implementation. Matching credentials compose, explicit URL parameters and
+headers win, abort signals are preserved, concurrent refreshes are deduplicated, and at most one
+safe replay is attempted.
+
+## `redactCredentialURL(url, credentials)`
+
+Replaces configured credential query values with `[REDACTED]` for diagnostics. Header credentials
+do not affect URLs. This utility does not sanitize arbitrary secrets unknown to the supplied
+credential registry.

--- a/docs/modules/mvt/api-reference/mvt-source-loader.md
+++ b/docs/modules/mvt/api-reference/mvt-source-loader.md
@@ -23,6 +23,13 @@ const source = createDataSource(url, [MVTSourceLoader]);
 const tile = await source.getTile(...);
 ```
 
+## Authentication
+
+`core.credentials` applies to both the TileJSON request and every resolved tile URL. For Mapbox,
+use `createMapboxCredential` from `@loaders.gl/services`; explicit `access_token` values in a
+TileJSON URL or template take precedence. See the
+[authentication guide](/docs/developer-guide/authentication#mapbox-tiles).
+
 ## Options
 
 | Option                    | Type      | Default | Description                                                                                                                          |

--- a/docs/modules/services/README.md
+++ b/docs/modules/services/README.md
@@ -84,17 +84,26 @@ objects until the application chooses a record, band, color ramp, and NoData tre
 
 ## Authentication and request customization
 
-ArcGIS tokens already present in a service URL are preserved on metadata and data requests.
-Headers, credentials, cancellation, proxies, and custom transports use standard loaders.gl fetch
-options:
+Use `createArcGISCredential` to scope a token to the exact ArcGIS Online, Enterprise, or proxy
+origin. The credential follows metadata, feature, image, tile, and deck.gl requests:
 
 ```ts
+import {createArcGISCredential} from '@loaders.gl/services';
+
 const source = await load(serviceUrl, SERVICE_LOADERS, {
-  fetch: {
-    headers: {Authorization: `Bearer ${token}`}
+  core: {
+    credentials: [
+      createArcGISCredential({origins: [new URL(serviceUrl).origin], token})
+    ]
   }
 });
 ```
+
+ArcGIS tokens already present in a service URL are preserved and take precedence. Bearer headers,
+cookies, cancellation, proxies, and custom transports continue to use standard loaders.gl fetch
+options. Async token callbacks support one deduplicated refresh after 401, 403, 498, or 499.
+See the [authentication guide](/docs/developer-guide/authentication) for the common model and
+security boundaries.
 
 Service-specific options can add ArcGIS request parameters without bypassing the source API. See
 the individual service pages for the supported option names.

--- a/docs/modules/services/arcgis-feature-server.md
+++ b/docs/modules/services/arcgis-feature-server.md
@@ -93,8 +93,9 @@ const source = createDataSource(featureServerUrl, [ArcGISFeatureServerSourceLoad
 });
 ```
 
-Use the standard `fetch` option for bearer tokens or gateways. Tokens already encoded in the URL
-are forwarded to metadata and query requests.
+For a scoped query token, pass `createArcGISCredential` through `core.credentials`. Tokens already
+encoded in the URL win and are forwarded to metadata and query requests. Bearer gateways and
+cookies continue to use `core.fetch`. See [authentication](/docs/developer-guide/authentication).
 
 ## deck.gl integration
 

--- a/docs/modules/services/arcgis-image-server.md
+++ b/docs/modules/services/arcgis-image-server.md
@@ -24,6 +24,12 @@ an `ImageSource` for viewport exports and a `TileSource` for tiled visualization
 | Authentication | Supported | Supported | URL tokens and standard fetch options are preserved |
 | deck.gl rendering | First class for images | First class for image tiles | Analytical LERC requires an application-selected visualization |
 
+## Authentication
+
+`createArcGISCredential` applies one exact-origin token to metadata, exports, cached tiles, and
+LERC requests. Configure it in `core.credentials`; explicit URL tokens take precedence. See the
+[authentication guide](/docs/developer-guide/authentication).
+
 ## Viewport images
 
 ```ts

--- a/docs/modules/services/arcgis-map-server.md
+++ b/docs/modules/services/arcgis-map-server.md
@@ -24,6 +24,12 @@ ArcGIS MapServer services expose cached map tiles, dynamically rendered maps, or
 | Feature queries | Not provided | Use FeatureServer for vector queries or WMS `GetFeatureInfo` when available |
 | deck.gl rendering | First class | `SourceLayer` consumes the `TileSource` directly |
 
+## Authentication
+
+`createArcGISCredential` applies one exact-origin token to metadata, cached tiles, and dynamic
+exports, including requests issued through `SourceLayer`. Explicit URL tokens take precedence. See
+the [authentication guide](/docs/developer-guide/authentication).
+
 ## Cached tiles
 
 ```ts

--- a/docs/modules/services/arcgis-scene-server.md
+++ b/docs/modules/services/arcgis-scene-server.md
@@ -29,8 +29,11 @@ const source = new ArcGISSceneServerSource(SCENE_SERVER_URL, {
 ```
 
 The source accepts custom fetch implementations through the normal `core.loadOptions` mechanism.
-Tokens can be supplied through `arcgis-scene-server.token` or `i3s.token`. Point profiles are
-reported as unsupported; mesh and Point Cloud profiles are selected automatically.
+For new integrations, configure `createArcGISCredential` in
+`core.loadOptions.core.credentials`; it follows metadata and I3S resource requests without being
+sent to unrelated origins. The existing `arcgis-scene-server.token` and `i3s.token` options remain
+supported. See [authentication](/docs/developer-guide/authentication). Point profiles are reported
+as unsupported; mesh and Point Cloud profiles are selected automatically.
 
 ## API
 

--- a/docs/modules/services/arcgis-vector-tile-server.md
+++ b/docs/modules/services/arcgis-vector-tile-server.md
@@ -25,6 +25,12 @@ loaders.gl `VectorTileSource` contract.
 | Authentication | Supported | URL tokens and standard fetch options are preserved for all resources |
 | deck.gl rendering | First class | `SourceLayer` consumes decoded vector tiles directly |
 
+## Authentication
+
+`createArcGISCredential` applies one exact-origin token to service metadata, styles, sprites, raw
+tiles, and decoded tile requests. Explicit URL tokens take precedence. See the
+[authentication guide](/docs/developer-guide/authentication).
+
 ## Raw and decoded tiles
 
 ```ts

--- a/docs/modules/wms/README.md
+++ b/docs/modules/wms/README.md
@@ -108,6 +108,10 @@ All sources inherit loaders.gl fetch configuration. Applications can provide hea
 request middleware, proxies, and custom fetch functions without protocol-specific wrappers.
 Abort signals are accepted by data requests that may be long-running.
 
+Pass exact-origin query or bearer credentials through `core.credentials`, or configure them once
+on `ServiceRuntime`. They are propagated to the concrete source and redacted from runtime telemetry
+and normalized errors. See the [authentication guide](/docs/developer-guide/authentication).
+
 Protocol errors are checked before parsing. WMS and related XML service exceptions use dedicated
 error parsers; focused adapters report the operation and HTTP status.
 

--- a/modules/3d-tiles/package.json
+++ b/modules/3d-tiles/package.json
@@ -43,6 +43,11 @@
       "import": "./dist/subtree-zod-schema.js",
       "require": "./dist/subtree-zod-schema.cjs"
     },
+    "./cesium-ion-loader-with-parser": {
+      "types": "./dist/cesium-ion-loader-with-parser.d.ts",
+      "import": "./dist/cesium-ion-loader-with-parser.js",
+      "require": "./dist/cesium-ion-loader-with-parser.cjs"
+    },
     "./bundled": {
       "types": "./dist/bundled.d.ts",
       "import": "./dist/bundled.js"

--- a/modules/3d-tiles/src/cesium-ion-loader-with-parser.ts
+++ b/modules/3d-tiles/src/cesium-ion-loader-with-parser.ts
@@ -2,7 +2,13 @@
 // SPDX-License-Identifier: MIT
 // Copyright vis.gl contributors
 
-import type {StrictLoaderOptions, LoaderWithParser} from '@loaders.gl/loader-utils';
+import type {
+  FetchLike,
+  LoaderContext,
+  StrictLoaderOptions,
+  LoaderWithParser
+} from '@loaders.gl/loader-utils';
+import {createAuthenticatedFetch} from '@loaders.gl/loader-utils';
 import {Tiles3DLoaderWithParser} from './tiles-3d-loader-with-parser';
 import {getIonTilesetMetadata} from './lib/ion/ion';
 import {CesiumIonLoader as CesiumIonLoaderMetadata} from './cesium-ion-loader';
@@ -10,18 +16,25 @@ import {CesiumIonLoader as CesiumIonLoaderMetadata} from './cesium-ion-loader';
 const {preload: _CesiumIonLoaderPreload, ...CesiumIonLoaderMetadataWithoutPreload} =
   CesiumIonLoaderMetadata;
 
-async function preload(url, options = {}) {
-  options = options['cesium-ion'] || {};
-  // @ts-ignore
-  const {accessToken, onError} = options;
-  // @ts-ignore
-  let assetId = options.assetId;
+/** Resolves a Cesium ion asset before the parser requests its root tileset. */
+async function preload(url: string, options: StrictLoaderOptions = {}) {
+  const cesiumIonOptions = options['cesium-ion'] || {};
+  const {accessToken, onError} = cesiumIonOptions;
+  let {assetId} = cesiumIonOptions;
   if (!Number.isFinite(assetId)) {
     const matched = url.match(/\/([0-9]+)\/tileset.json/);
     assetId = matched && matched[1];
   }
   try {
-    return await getIonTilesetMetadata(accessToken, assetId);
+    const fetchFunction = createAuthenticatedFetch({
+      fetch: getBaseFetch(options),
+      credentials: options.core?.credentials || []
+    });
+    return await getIonTilesetMetadata(
+      typeof accessToken === 'string' ? accessToken : null,
+      typeof assetId === 'string' || typeof assetId === 'number' ? assetId : null,
+      {fetch: fetchFunction}
+    );
   } catch (error) {
     if (typeof onError === 'function') {
       onError(error);
@@ -30,12 +43,56 @@ async function preload(url, options = {}) {
   }
 }
 
+/** Resolves Cesium ion's custom fetch function or static request defaults. */
+function getBaseFetch(options: StrictLoaderOptions): FetchLike {
+  const fetchOption = (options.fetch ?? options.core?.fetch) as
+    | FetchLike
+    | RequestInit
+    | null
+    | undefined;
+  if (typeof fetchOption === 'function') return fetchOption;
+  if (fetchOption) {
+    return (url, requestOptions) => {
+      const headers = new Headers(fetchOption.headers);
+      new Headers(requestOptions?.headers).forEach((value, key) => headers.set(key, value));
+      return fetch(url, {...fetchOption, ...requestOptions, headers});
+    };
+  }
+  return (url, requestOptions) => fetch(url, requestOptions);
+}
+
+/** Resolves, fetches, and parses a Cesium ion URL through the provider bootstrap flow. */
+async function parseUrl(url: string, options: StrictLoaderOptions = {}, context?: LoaderContext) {
+  const metadata = await preload(url, options);
+  const credentials = [...(options.core?.credentials || []), ...metadata.credentials];
+  const fetchFunction = createAuthenticatedFetch({fetch: getBaseFetch(options), credentials});
+  const response = await fetchFunction(metadata.url);
+  if (!response.ok) {
+    throw new Error(response.statusText || `Cesium ion asset request failed: ${response.status}`);
+  }
+  const resolvedURL = new URL(metadata.url);
+  const parserOptions = {
+    ...options,
+    core: {...options.core, credentials},
+    '3d-tiles': options['cesium-ion']
+  };
+  const loaderContext = {
+    ...context,
+    url: metadata.url,
+    baseUrl: metadata.url.slice(0, metadata.url.lastIndexOf('/')),
+    queryString: resolvedURL.search.slice(1),
+    fetch: fetchFunction
+  } as LoaderContext;
+  return Tiles3DLoaderWithParser.parse(await response.arrayBuffer(), parserOptions, loaderContext);
+}
+
 /**
  * Loader for 3D tiles from Cesium ION
  */
 export const CesiumIonLoaderWithParser = {
   ...CesiumIonLoaderMetadataWithoutPreload,
   preload,
+  parseUrl,
   parse: async (data, options?, context?) => {
     options = {...options};
     options['3d-tiles'] = options['cesium-ion'];

--- a/modules/3d-tiles/src/cesium-ion-loader.ts
+++ b/modules/3d-tiles/src/cesium-ion-loader.ts
@@ -13,7 +13,8 @@ export const CesiumIonLoader = {
   id: 'cesium-ion',
   name: 'Cesium Ion',
   /** Loads the parser-bearing Cesium ion loader implementation. */
-  preload: async () => (await import('./cesium-ion-loader-with-parser')).CesiumIonLoaderWithParser,
+  preload: async () =>
+    (await import('@loaders.gl/3d-tiles/cesium-ion-loader-with-parser')).CesiumIonLoaderWithParser,
   options: {
     'cesium-ion': {
       ...Tiles3DLoader.options['3d-tiles'],

--- a/modules/3d-tiles/src/cesium-ion-loader.ts
+++ b/modules/3d-tiles/src/cesium-ion-loader.ts
@@ -12,10 +12,13 @@ export const CesiumIonLoader = {
   ...Tiles3DLoader,
   id: 'cesium-ion',
   name: 'Cesium Ion',
+  /** Loads the parser-bearing Cesium ion loader implementation. */
+  preload: async () => (await import('./cesium-ion-loader-with-parser')).CesiumIonLoaderWithParser,
   options: {
     'cesium-ion': {
       ...Tiles3DLoader.options['3d-tiles'],
       accessToken: null,
+      assetId: null,
       onError: null
     }
   }

--- a/modules/3d-tiles/src/lib/ion/ion.ts
+++ b/modules/3d-tiles/src/lib/ion/ion.ts
@@ -2,78 +2,134 @@
 // SPDX-License-Identifier: MIT
 // Copyright vis.gl contributors
 
-// Minimal support to load tilsets from the Cesium ION services
-
-import {assert} from '@loaders.gl/loader-utils';
+import type {FetchLike, RequestCredential} from '@loaders.gl/loader-utils';
+import {
+  assert,
+  createAuthenticatedFetch,
+  createBearerTokenCredential
+} from '@loaders.gl/loader-utils';
 
 const CESIUM_ION_URL = 'https://api.cesium.com/v1/assets';
+const CESIUM_ION_ORIGIN = 'https://api.cesium.com';
 
-// Returns `{url, headers, type, attributions}` for an ion tileset
-export async function getIonTilesetMetadata(accessToken, assetId) {
-  // Step 1, if no asset id, look for first 3DTILES asset associated with this token.
-  if (!assetId) {
-    const assets = await getIonAssets(accessToken);
-    for (const item of assets.items) {
-      if (item.type === '3DTILES') {
-        assetId = item.id;
-      }
-    }
+/** Cesium ion asset summary returned by the assets endpoint. */
+export type CesiumIonAsset = {
+  /** Asset identifier. */
+  id: number;
+  /** Asset type, such as `3DTILES`. */
+  type: string;
+  /** Additional provider metadata. */
+  [key: string]: unknown;
+};
+
+/** Cesium ion asset listing. */
+export type CesiumIonAssets = {
+  /** Assets visible to the supplied credential. */
+  items: CesiumIonAsset[];
+};
+
+/** Resolved Cesium ion endpoint metadata. */
+export type CesiumIonTilesetMetadata = Record<string, unknown> & {
+  /** Resolved 3D Tiles endpoint URL. */
+  url: string;
+  /** Resolved asset type. */
+  type: string;
+  /** Legacy endpoint headers retained for direct integrations. */
+  headers: HeadersInit;
+  /** Exact-origin endpoint credential preferred by loaders.gl integrations. */
+  credentials: readonly RequestCredential[];
+};
+
+/** Optional transport for Cesium ion API requests. */
+export type CesiumIonRequestOptions = {
+  /** Credential-aware custom fetch implementation. */
+  fetch?: FetchLike;
+};
+
+/** Resolves a Cesium ion asset URL and its endpoint-scoped bearer credential. */
+export async function getIonTilesetMetadata(
+  accessToken: string | null | undefined,
+  assetId?: number | string | null,
+  options: CesiumIonRequestOptions = {}
+): Promise<CesiumIonTilesetMetadata> {
+  const ionFetch = getIonFetch(accessToken, options.fetch);
+  let resolvedAssetId = assetId;
+  if (!resolvedAssetId) {
+    const assets = await getIonAssets(accessToken, ionFetch);
+    resolvedAssetId = assets.items.find(item => item.type === '3DTILES')?.id;
   }
 
-  // Step 2: Query metdatadata for this asset.
-  const ionAssetMetadata = await getIonAssetMetadata(accessToken, assetId);
-  const type = ionAssetMetadata.type;
-  // As of Oct 2024 ion service now returns the resource URL in an options object
-  const url = ionAssetMetadata.options?.url || ionAssetMetadata.url;
+  if (resolvedAssetId === undefined || resolvedAssetId === null) {
+    throw new Error('Cesium ion did not return a 3D Tiles asset.');
+  }
+  const ionAssetMetadata = await getIonAssetMetadata(accessToken, resolvedAssetId, ionFetch);
+  const type = String(ionAssetMetadata.type || '');
+  const endpointOptions = ionAssetMetadata.options as {url?: string} | undefined;
+  const url = endpointOptions?.url || String(ionAssetMetadata.url || '');
   assert(type === '3DTILES' && url);
 
-  // Prepare a headers object for fetch
-  ionAssetMetadata.headers = {
-    // Use provided accessToken if a new token is not provided in the ion response
-    Authorization: `Bearer ${ionAssetMetadata.accessToken || accessToken}`
+  const endpointToken = String(ionAssetMetadata.accessToken || accessToken || '');
+  assert(endpointToken);
+  const endpointCredential = createBearerTokenCredential({
+    id: `cesium-ion-asset-${resolvedAssetId}`,
+    origins: [new URL(url).origin],
+    token: endpointToken
+  });
+
+  return {
+    ...ionAssetMetadata,
+    type,
+    url,
+    headers: {Authorization: `Bearer ${endpointToken}`},
+    credentials: [endpointCredential]
   };
-  return ionAssetMetadata;
 }
 
-// Return a list of all assets associated with accessToken
-export async function getIonAssets(accessToken) {
-  assert(accessToken);
-  const url = CESIUM_ION_URL;
-  const headers = {Authorization: `Bearer ${accessToken}`};
-  const response = await fetch(url, {headers});
+/** Returns the Cesium ion assets visible to an access token. */
+export async function getIonAssets(
+  accessToken: string | null | undefined,
+  fetchFunction?: FetchLike
+): Promise<CesiumIonAssets> {
+  const response = await (fetchFunction || getIonFetch(accessToken))(CESIUM_ION_URL);
   if (!response.ok) {
-    throw new Error(response.statusText);
+    throw new Error(response.statusText || `Cesium ion request failed: ${response.status}`);
   }
-  return await response.json();
+  return (await response.json()) as CesiumIonAssets;
 }
 
-// Return metadata for a specific asset associated with token
-export async function getIonAssetMetadata(accessToken, assetId) {
-  assert(accessToken, assetId);
-  const headers = {Authorization: `Bearer ${accessToken}`};
-
+/** Returns combined Cesium ion asset and endpoint metadata. */
+export async function getIonAssetMetadata(
+  accessToken: string | null | undefined,
+  assetId: number | string,
+  fetchFunction?: FetchLike
+): Promise<Record<string, unknown>> {
+  assert(assetId);
+  const ionFetch = fetchFunction || getIonFetch(accessToken);
   const url = `${CESIUM_ION_URL}/${assetId}`;
-  // https://cesium.com/docs/rest-api/#operation/getAsset
-  // Retrieves metadata information about a specific asset.
-  let response = await fetch(`${url}`, {headers});
+  let response = await ionFetch(url);
   if (!response.ok) {
-    throw new Error(response.statusText);
+    throw new Error(response.statusText || `Cesium ion request failed: ${response.status}`);
   }
-  let metadata = await response.json();
+  const metadata = (await response.json()) as Record<string, unknown>;
 
-  // https://cesium.com/docs/rest-api/#operation/getAssetEndpoint
-  // Retrieves information and credentials that allow you to access the tiled asset data for visualization and analysis.
-  response = await fetch(`${url}/endpoint`, {headers});
+  response = await ionFetch(`${url}/endpoint`);
   if (!response.ok) {
-    throw new Error(response.statusText);
+    throw new Error(response.statusText || `Cesium ion request failed: ${response.status}`);
   }
-  const tilesetInfo = await response.json();
+  const endpoint = (await response.json()) as Record<string, unknown>;
+  return {...metadata, ...endpoint};
+}
 
-  // extract dataset description
-  metadata = {
-    ...metadata,
-    ...tilesetInfo
-  };
-
-  return metadata;
+/** Creates an exact-origin transport for Cesium ion REST requests. */
+function getIonFetch(accessToken: string | null | undefined, fetchFunction?: FetchLike): FetchLike {
+  const credentials = accessToken
+    ? [
+        createBearerTokenCredential({
+          id: 'cesium-ion-access-token',
+          origins: [CESIUM_ION_ORIGIN],
+          token: accessToken
+        })
+      ]
+    : [];
+  return createAuthenticatedFetch({fetch: fetchFunction, credentials});
 }

--- a/modules/3d-tiles/test/cesium-ion-authentication.spec.ts
+++ b/modules/3d-tiles/test/cesium-ion-authentication.spec.ts
@@ -1,0 +1,99 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright vis.gl contributors
+
+import {describe, expect, test} from 'vitest';
+import {createAuthenticatedFetch, type FetchLike} from '@loaders.gl/loader-utils';
+import {load} from '@loaders.gl/core';
+import {
+  CesiumIonLoader,
+  _getIonTilesetMetadata as getIonTilesetMetadata
+} from '@loaders.gl/3d-tiles';
+
+describe('Cesium ion authentication', () => {
+  test('scopes the account token and derived endpoint token to their exact origins', async () => {
+    const requests: Array<{url: string; authorization: string | null}> = [];
+    const fetchFunction: FetchLike = async (url, options) => {
+      requests.push({
+        url,
+        authorization: new Headers(options?.headers).get('authorization')
+      });
+      if (url.endsWith('/endpoint')) {
+        return Response.json({
+          type: '3DTILES',
+          url: 'https://assets.cesium.com/123/tileset.json',
+          accessToken: 'endpoint-token'
+        });
+      }
+      return Response.json({id: 123, type: '3DTILES'});
+    };
+
+    const metadata = await getIonTilesetMetadata('account-token', 123, {fetch: fetchFunction});
+    expect(requests).toEqual([
+      {
+        url: 'https://api.cesium.com/v1/assets/123',
+        authorization: 'Bearer account-token'
+      },
+      {
+        url: 'https://api.cesium.com/v1/assets/123/endpoint',
+        authorization: 'Bearer account-token'
+      }
+    ]);
+
+    const endpointFetch = createAuthenticatedFetch({
+      fetch: fetchFunction,
+      credentials: metadata.credentials
+    });
+    await endpointFetch(metadata.url);
+    await endpointFetch('https://example.com/tileset.json');
+
+    expect(requests.slice(2)).toEqual([
+      {
+        url: 'https://assets.cesium.com/123/tileset.json',
+        authorization: 'Bearer endpoint-token'
+      },
+      {url: 'https://example.com/tileset.json', authorization: null}
+    ]);
+  });
+
+  test('loads an ion asset through bootstrap with the public metadata loader', async () => {
+    const requestedURLs: string[] = [];
+    const fetchFunction: FetchLike = async url => {
+      requestedURLs.push(url);
+      if (url.endsWith('/endpoint')) {
+        return Response.json({
+          type: '3DTILES',
+          url: 'https://assets.cesium.com/123/tileset.json',
+          accessToken: 'endpoint-token'
+        });
+      }
+      if (url === 'https://api.cesium.com/v1/assets/123') {
+        return Response.json({id: 123, type: '3DTILES'});
+      }
+      return Response.json({
+        asset: {version: '1.1'},
+        geometricError: 1,
+        root: {
+          boundingVolume: {sphere: [0, 0, 0, 1]},
+          geometricError: 0,
+          refine: 'ADD'
+        }
+      });
+    };
+
+    const tileset = await load('https://assets.cesium.com/123/tileset.json', CesiumIonLoader, {
+      core: {fetch: fetchFunction},
+      'cesium-ion': {accessToken: 'account-token', assetId: 123}
+    });
+
+    expect(tileset).toMatchObject({
+      shape: 'tileset3d',
+      url: 'https://assets.cesium.com/123/tileset.json'
+    });
+    expect(requestedURLs).toEqual([
+      'https://api.cesium.com/v1/assets/123',
+      'https://api.cesium.com/v1/assets/123/endpoint',
+      'https://assets.cesium.com/123/tileset.json'
+    ]);
+  });
+});

--- a/modules/core/src/lib/loader-utils/get-fetch-function.ts
+++ b/modules/core/src/lib/loader-utils/get-fetch-function.ts
@@ -3,7 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import type {LoaderContext, LoaderOptions, FetchLike} from '@loaders.gl/loader-utils';
-import {isObject} from '@loaders.gl/loader-utils';
+import {createAuthenticatedFetch, isObject} from '@loaders.gl/loader-utils';
 import {fetchFile} from '../fetch/fetch-file';
 import {getGlobalLoaderOptions} from './option-utils';
 
@@ -21,22 +21,33 @@ export function getFetchFunction(
 
   const loaderOptions = options || globalOptions;
   const fetchOption = loaderOptions.fetch ?? loaderOptions.core?.fetch;
+  let fetchFunction: FetchLike;
 
   // options.fetch can be a function
   if (typeof fetchOption === 'function') {
-    return fetchOption;
+    fetchFunction = fetchOption;
+  } else if (isObject(fetchOption)) {
+    fetchFunction = (url, requestOptions) =>
+      fetchFile(url, mergeFetchOptions(fetchOption as RequestInit, requestOptions));
+  } else if (context?.fetch) {
+    fetchFunction = context.fetch;
+  } else {
+    fetchFunction = fetchFile;
   }
 
-  // options.fetch can be an options object
-  if (isObject(fetchOption)) {
-    return url => fetchFile(url, fetchOption as RequestInit);
-  }
+  return createAuthenticatedFetch({
+    fetch: fetchFunction,
+    credentials: loaderOptions.core?.credentials || []
+  });
+}
 
-  // else refer to context (from parent loader) if available
-  if (context?.fetch) {
-    return context?.fetch;
+/** Combines static and per-request fetch options without replacing either header collection. */
+function mergeFetchOptions(defaultOptions: RequestInit, requestOptions?: RequestInit): RequestInit {
+  const options = {...defaultOptions, ...requestOptions};
+  if (defaultOptions.headers || requestOptions?.headers) {
+    const headers = new Headers(defaultOptions.headers);
+    new Headers(requestOptions?.headers).forEach((value, key) => headers.set(key, value));
+    options.headers = headers;
   }
-
-  // else return the default fetch function
-  return fetchFile;
+  return options;
 }

--- a/modules/core/test/lib/loader-utils/get-fetch-function.spec.ts
+++ b/modules/core/test/lib/loader-utils/get-fetch-function.spec.ts
@@ -1,0 +1,34 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright vis.gl contributors
+
+import {describe, expect, test} from 'vitest';
+import {createBearerTokenCredential} from '@loaders.gl/loader-utils';
+import {getFetchFunction} from '../../../src/lib/loader-utils/get-fetch-function';
+
+describe('getFetchFunction', () => {
+  test('composes core credentials with custom fetch options', async () => {
+    const requests: Array<{url: string; headers: Headers}> = [];
+    const fetchFunction = getFetchFunction({
+      core: {
+        fetch: async (url, options) => {
+          requests.push({url, headers: new Headers(options?.headers)});
+          return new Response('ok');
+        },
+        credentials: [
+          createBearerTokenCredential({
+            id: 'private-api',
+            origins: ['https://example.com'],
+            token: 'secret'
+          })
+        ]
+      }
+    });
+
+    await fetchFunction('https://example.com/data', {headers: {Accept: 'application/json'}});
+
+    expect(requests[0].url).toBe('https://example.com/data');
+    expect(requests[0].headers.get('authorization')).toBe('Bearer secret');
+    expect(requests[0].headers.get('accept')).toBe('application/json');
+  });
+});

--- a/modules/deck-layers/src/data-driven-tile-3d-layer.ts
+++ b/modules/deck-layers/src/data-driven-tile-3d-layer.ts
@@ -6,6 +6,7 @@ import {Tile3DLayer, type Tile3DLayerProps} from '@deck.gl/geo-layers';
 import type {DefaultProps, UpdateParameters, Viewport} from '@deck.gl/core';
 import {TILE_TYPE, Tile3D, Tileset3D} from '@loaders.gl/tiles';
 import {load} from '@loaders.gl/core';
+import type {RequestCredential} from '@loaders.gl/loader-utils';
 
 /** Color ramp configuration applied to tile content using a numeric feature attribute. */
 export type ColorsByAttribute = {
@@ -134,7 +135,13 @@ export class DataDrivenTile3DLayer<
     if (loader.preload) {
       const preloadOptions = await loader.preload(tilesetUrl, loadOptions);
 
-      if (preloadOptions.headers) {
+      const credentials = preloadOptions.credentials as readonly RequestCredential[] | undefined;
+      if (credentials?.length) {
+        options.loadOptions.core = {
+          ...options.loadOptions.core,
+          credentials: [...(options.loadOptions.core?.credentials || []), ...credentials]
+        };
+      } else if (preloadOptions.headers) {
         options.loadOptions.fetch = {
           ...options.loadOptions.fetch,
           headers: preloadOptions.headers

--- a/modules/deck-layers/src/data-driven-tile-3d-source-layer.ts
+++ b/modules/deck-layers/src/data-driven-tile-3d-source-layer.ts
@@ -4,7 +4,7 @@
 
 import {DataDrivenTile3DLayer} from './data-driven-tile-3d-layer';
 import {Tileset3D, type Tileset3DProps} from '@loaders.gl/tiles';
-import type {LoaderOptions, LoaderWithParser} from '@loaders.gl/loader-utils';
+import type {LoaderOptions, LoaderWithParser, RequestCredential} from '@loaders.gl/loader-utils';
 import {createSource} from './tile-3d-source-layer';
 
 /**
@@ -49,7 +49,13 @@ export class SourceDataDrivenTile3DLayer<
         actualTilesetUrl = preloadOptions.url;
       }
 
-      if (preloadOptions.headers) {
+      const credentials = preloadOptions.credentials as readonly RequestCredential[] | undefined;
+      if (credentials?.length) {
+        options.loadOptions.core = {
+          ...options.loadOptions.core,
+          credentials: [...(options.loadOptions.core?.credentials || []), ...credentials]
+        };
+      } else if (preloadOptions.headers) {
         options.loadOptions.fetch = {
           ...options.loadOptions.fetch,
           headers: preloadOptions.headers

--- a/modules/deck-layers/src/tile-3d-source-layer.ts
+++ b/modules/deck-layers/src/tile-3d-source-layer.ts
@@ -157,13 +157,14 @@ export function createSource(
   loadOptions: LoaderOptions,
   injectedCoreApi = coreApi
 ): Tiles3DSource | I3SSource {
+  const sourceLoader = getSourceLoader(loader);
   const lowerCaseUrl = typeof url === 'string' ? url.toLowerCase() : '';
 
-  if (loader.id === 'slpk' || lowerCaseUrl.endsWith('.slpk')) {
+  if (sourceLoader.id === 'slpk' || lowerCaseUrl.endsWith('.slpk')) {
     const archiveConfig =
-      loader.id === 'slpk'
+      sourceLoader.id === 'slpk'
         ? createSLPKArchiveResolver(url)
-        : createSLPKArchiveResolver(url, loader);
+        : createSLPKArchiveResolver(url, sourceLoader);
     return new I3SSource(
       {
         url,
@@ -176,11 +177,11 @@ export function createSource(
     );
   }
 
-  if (loader.id === '3tz' || lowerCaseUrl.endsWith('.3tz')) {
+  if (sourceLoader.id === '3tz' || lowerCaseUrl.endsWith('.3tz')) {
     const archiveConfig =
-      loader.id === '3tz'
+      sourceLoader.id === '3tz'
         ? createTiles3DArchiveResolver(url)
-        : createTiles3DArchiveResolver(url, loader);
+        : createTiles3DArchiveResolver(url, sourceLoader);
     return new Tiles3DSource(
       {
         url,
@@ -193,9 +194,20 @@ export function createSource(
     );
   }
 
-  if (loader.id === 'i3s') {
-    return new I3SSource({url, loader, coreApi: injectedCoreApi}, loadOptions);
+  if (sourceLoader.id === 'i3s') {
+    return new I3SSource({url, loader: sourceLoader, coreApi: injectedCoreApi}, loadOptions);
   }
 
-  return new Tiles3DSource({url, loader, coreApi: injectedCoreApi}, loadOptions);
+  return new Tiles3DSource({url, loader: sourceLoader, coreApi: injectedCoreApi}, loadOptions);
+}
+
+/** Removes the provider bootstrap hook before a resolved service loader is used for child tiles. */
+function getSourceLoader(loader: LoaderWithParser): LoaderWithParser {
+  if (loader.id !== 'cesium-ion') {
+    return loader;
+  }
+
+  const loaderWithProviderHooks = loader as LoaderWithParser & {parseUrl?: unknown};
+  const {parseUrl: _parseUrl, preload: _preload, ...sourceLoader} = loaderWithProviderHooks;
+  return sourceLoader as LoaderWithParser;
 }

--- a/modules/deck-layers/src/tile-3d-source-layer.ts
+++ b/modules/deck-layers/src/tile-3d-source-layer.ts
@@ -12,7 +12,7 @@ import {
   type Tileset3DSource
 } from '@loaders.gl/tiles';
 import {coreApi, preload, selectLoader} from '@loaders.gl/core';
-import type {LoaderOptions, LoaderWithParser} from '@loaders.gl/loader-utils';
+import type {LoaderOptions, LoaderWithParser, RequestCredential} from '@loaders.gl/loader-utils';
 import {createSLPKArchiveResolver, createTiles3DArchiveResolver} from './archive-source-resolver';
 
 /**
@@ -110,7 +110,13 @@ export class Tile3DSourceLayer<
         actualTilesetUrl = preloadOptions.url;
       }
 
-      if (preloadOptions.headers) {
+      const credentials = preloadOptions.credentials as readonly RequestCredential[] | undefined;
+      if (credentials?.length) {
+        options.loadOptions.core = {
+          ...options.loadOptions.core,
+          credentials: [...(options.loadOptions.core?.credentials || []), ...credentials]
+        };
+      } else if (preloadOptions.headers) {
         options.loadOptions.fetch = {
           ...options.loadOptions.fetch,
           headers: preloadOptions.headers

--- a/modules/loader-utils/src/index.ts
+++ b/modules/loader-utils/src/index.ts
@@ -152,6 +152,23 @@ export type {
 } from './lib/request-utils/request-cache';
 export {parseContentType} from './lib/request-utils/parse-content-type';
 export {
+  createAuthenticatedFetch,
+  createBearerTokenCredential,
+  createQueryParameterCredential,
+  redactCredentialURL
+} from './lib/request-utils/request-credentials';
+export type {
+  AuthenticatedFetchOptions,
+  BearerTokenCredentialOptions,
+  QueryParameterCredentialOptions,
+  RequestCredential,
+  TokenProvider,
+  TokenProviderContext,
+  TokenProviderReason,
+  TokenProviderResponse,
+  TokenValue
+} from './lib/request-utils/request-credentials';
+export {
   RangeRequestScheduler,
   createRangeStats,
   fetchHttpRange,

--- a/modules/loader-utils/src/lib/request-utils/request-credentials.ts
+++ b/modules/loader-utils/src/lib/request-utils/request-credentials.ts
@@ -1,0 +1,316 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {FetchLike} from '../../types';
+
+/** Reason an application token provider is being invoked. */
+export type TokenProviderReason = 'request' | 'refresh';
+
+/** Safe response metadata supplied when refreshing an expired credential. */
+export type TokenProviderResponse = Readonly<{
+  /** HTTP response status. */
+  status: number;
+  /** HTTP response headers. */
+  headers: Headers;
+}>;
+
+/** Context supplied to an application token provider. */
+export type TokenProviderContext = Readonly<{
+  /** Credential-free request URL before authorization is applied. */
+  url: string;
+  /** Whether the token is needed for an initial request or one refresh attempt. */
+  reason: TokenProviderReason;
+  /** Failed response metadata, when refreshing. */
+  response?: TokenProviderResponse;
+}>;
+
+/** Returns a current token or refreshes it after an authentication failure. */
+export type TokenProvider = (
+  context: TokenProviderContext
+) => string | null | Promise<string | null>;
+
+/** Static token or application-managed asynchronous token provider. */
+export type TokenValue = string | TokenProvider;
+
+/** Request credential understood by the loaders.gl authentication pipeline. */
+export type RequestCredential = Readonly<{
+  /** Stable diagnostic identifier that never contains the token itself. */
+  id: string;
+  /** Exact URL origins authorized to receive this credential. */
+  origins: readonly string[];
+  /** Credential placement. */
+  type: 'query-parameter' | 'header';
+  /** Query parameter or header name. */
+  name: string;
+  /** Optional header value prefix, such as `Bearer `. */
+  prefix?: string;
+  /** Static token or application token callback. */
+  token: TokenValue;
+  /** Status codes that permit one refresh and replay. */
+  refreshStatusCodes: readonly number[];
+}>;
+
+/** Options for a query-parameter credential. */
+export type QueryParameterCredentialOptions = {
+  /** Stable diagnostic identifier. */
+  id: string;
+  /** Exact URL origins authorized to receive this credential. */
+  origins: readonly string[];
+  /** Query parameter name. */
+  parameterName: string;
+  /** Static token or application token callback. */
+  token: TokenValue;
+  /** Status codes that permit one refresh and replay. Defaults to 401 and 403. */
+  refreshStatusCodes?: readonly number[];
+};
+
+/** Options for a bearer credential. */
+export type BearerTokenCredentialOptions = {
+  /** Stable diagnostic identifier. */
+  id: string;
+  /** Exact URL origins authorized to receive this credential. */
+  origins: readonly string[];
+  /** Static token or application token callback. */
+  token: TokenValue;
+  /** Header name. Defaults to `Authorization`. */
+  headerName?: string;
+  /** Header prefix. Defaults to `Bearer `. */
+  prefix?: string;
+  /** Status codes that permit one refresh and replay. Defaults to 401 and 403. */
+  refreshStatusCodes?: readonly number[];
+};
+
+/** Options for creating a credential-aware fetch function. */
+export type AuthenticatedFetchOptions = {
+  /** Fetch implementation wrapped by the credential pipeline. Defaults to global fetch. */
+  fetch?: FetchLike;
+  /** Credentials applied to matching request origins. */
+  credentials: readonly RequestCredential[];
+};
+
+type ResolvedCredential = {credential: RequestCredential; token: string};
+
+const DEFAULT_REFRESH_STATUS_CODES = [401, 403] as const;
+const AUTHENTICATED_FETCH = Symbol('loaders.gl.authenticated-fetch');
+const refreshPromises = new WeakMap<RequestCredential, Promise<string | null>>();
+
+/** Creates a token credential placed in a URL query parameter. */
+export function createQueryParameterCredential(
+  options: QueryParameterCredentialOptions
+): RequestCredential {
+  return {
+    id: options.id,
+    origins: normalizeOrigins(options.origins),
+    type: 'query-parameter',
+    name: options.parameterName,
+    token: options.token,
+    refreshStatusCodes: options.refreshStatusCodes || DEFAULT_REFRESH_STATUS_CODES
+  };
+}
+
+/** Creates a token credential placed in an HTTP bearer header. */
+export function createBearerTokenCredential(
+  options: BearerTokenCredentialOptions
+): RequestCredential {
+  return {
+    id: options.id,
+    origins: normalizeOrigins(options.origins),
+    type: 'header',
+    name: options.headerName || 'Authorization',
+    prefix: options.prefix ?? 'Bearer ',
+    token: options.token,
+    refreshStatusCodes: options.refreshStatusCodes || DEFAULT_REFRESH_STATUS_CODES
+  };
+}
+
+/** Wraps a fetch function with exact-origin credential application and one refresh replay. */
+export function createAuthenticatedFetch(options: AuthenticatedFetchOptions): FetchLike {
+  const baseFetch = options.fetch || ((url, requestOptions) => fetch(url, requestOptions));
+  if (!options.credentials.length) return baseFetch;
+
+  const existingMetadata = (
+    baseFetch as FetchLike & {[AUTHENTICATED_FETCH]?: readonly RequestCredential[]}
+  )[AUTHENTICATED_FETCH];
+  if (existingMetadata === options.credentials) return baseFetch;
+
+  const authenticatedFetch: FetchLike = async (url, requestOptions = {}) => {
+    const resolvedURL = parseHTTPURL(url);
+    if (!resolvedURL) return baseFetch(url, requestOptions);
+
+    const authorization = await authorizeRequest(resolvedURL, requestOptions, options.credentials);
+    const response = await baseFetch(authorization.url, authorization.options);
+    const refreshableCredentials = authorization.credentials.filter(
+      ({credential}) =>
+        typeof credential.token === 'function' &&
+        credential.refreshStatusCodes.includes(response.status)
+    );
+    if (!refreshableCredentials.length || !isReplayableRequest(requestOptions)) return response;
+    if (requestOptions.signal?.aborted) throw createAbortError();
+
+    const refreshedTokens = new Map<RequestCredential, string>();
+    await Promise.all(
+      refreshableCredentials.map(async ({credential}) => {
+        const token = await refreshCredential(credential, url, response);
+        if (token) refreshedTokens.set(credential, token);
+      })
+    );
+    if (!refreshedTokens.size) return response;
+
+    await response.body?.cancel().catch(() => {});
+    if (requestOptions.signal?.aborted) throw createAbortError();
+    const replayAuthorization = await authorizeRequest(
+      resolvedURL,
+      requestOptions,
+      options.credentials,
+      refreshedTokens,
+      authorization.credentials
+    );
+    return baseFetch(replayAuthorization.url, replayAuthorization.options);
+  };
+
+  Object.defineProperty(authenticatedFetch, AUTHENTICATED_FETCH, {
+    value: options.credentials
+  });
+  return authenticatedFetch;
+}
+
+/** Redacts credential-bearing query parameters from a URL used in diagnostics. */
+export function redactCredentialURL(
+  url: string,
+  credentials: readonly RequestCredential[]
+): string {
+  const resolvedURL = parseHTTPURL(url);
+  if (!resolvedURL) return url;
+  for (const credential of credentials) {
+    if (
+      credential.type === 'query-parameter' &&
+      credential.origins.includes(resolvedURL.origin) &&
+      resolvedURL.searchParams.has(credential.name)
+    ) {
+      resolvedURL.searchParams.set(credential.name, '[REDACTED]');
+    }
+  }
+  return resolvedURL.toString();
+}
+
+/** Resolves matching tokens and applies them to a fresh URL and header collection. */
+async function authorizeRequest(
+  sourceURL: URL,
+  requestOptions: RequestInit,
+  credentials: readonly RequestCredential[],
+  tokenOverrides: ReadonlyMap<RequestCredential, string> = new Map(),
+  previousCredentials: readonly ResolvedCredential[] = []
+): Promise<{url: string; options: RequestInit; credentials: ResolvedCredential[]}> {
+  const url = new URL(sourceURL);
+  const headers = new Headers(requestOptions.headers);
+  const resolvedCredentials: ResolvedCredential[] = [];
+  const previousTokens = new Map(
+    previousCredentials.map(({credential, token}) => [credential, token] as const)
+  );
+
+  for (const credential of credentials) {
+    if (!credential.origins.includes(url.origin)) continue;
+    const overrideToken = tokenOverrides.get(credential);
+    const previousToken = previousTokens.get(credential);
+    const ownsQueryParameter = credential.type === 'query-parameter' && previousToken !== undefined;
+    const ownsHeader = credential.type === 'header' && previousToken !== undefined;
+    if (
+      (credential.type === 'query-parameter' &&
+        url.searchParams.has(credential.name) &&
+        !ownsQueryParameter) ||
+      (credential.type === 'header' && headers.has(credential.name) && !ownsHeader)
+    ) {
+      continue;
+    }
+    const token =
+      overrideToken ??
+      previousToken ??
+      (await resolveToken(credential.token, {url: sourceURL.toString(), reason: 'request'}));
+    if (!token) continue;
+
+    if (credential.type === 'query-parameter') {
+      url.searchParams.set(credential.name, token);
+    } else {
+      headers.set(credential.name, `${credential.prefix || ''}${token}`);
+    }
+    resolvedCredentials.push({credential, token});
+  }
+
+  return {
+    url: url.toString(),
+    options: {...requestOptions, headers},
+    credentials: resolvedCredentials
+  };
+}
+
+/** Shares one in-flight refresh for concurrent requests using the same credential object. */
+async function refreshCredential(
+  credential: RequestCredential,
+  url: string,
+  response: Response
+): Promise<string | null> {
+  const existingPromise = refreshPromises.get(credential);
+  if (existingPromise) return existingPromise;
+  const tokenProvider = credential.token as TokenProvider;
+  const promise = Promise.resolve(
+    tokenProvider({
+      url,
+      reason: 'refresh',
+      response: {status: response.status, headers: response.headers}
+    })
+  ).finally(() => refreshPromises.delete(credential));
+  refreshPromises.set(credential, promise);
+  return promise;
+}
+
+/** Resolves a static token or invokes an application token provider. */
+async function resolveToken(
+  token: TokenValue,
+  context: TokenProviderContext
+): Promise<string | null> {
+  return typeof token === 'function' ? token(context) : token;
+}
+
+/** Validates and canonicalizes an exact-origin allowlist. */
+function normalizeOrigins(origins: readonly string[]): string[] {
+  if (!origins.length) throw new Error('Request credentials require at least one exact origin.');
+  return origins.map(origin => {
+    const url = new URL(origin);
+    if (
+      !['http:', 'https:'].includes(url.protocol) ||
+      url.pathname !== '/' ||
+      url.search ||
+      url.hash
+    ) {
+      throw new Error(`Credential origin must contain only scheme, host, and port: ${origin}`);
+    }
+    return url.origin;
+  });
+}
+
+/** Parses an HTTP(S) URL without throwing for other fetch-compatible inputs. */
+function parseHTTPURL(url: string): URL | null {
+  try {
+    const parsedURL = new URL(url);
+    return ['http:', 'https:'].includes(parsedURL.protocol) ? parsedURL : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Returns whether a failed request can safely reuse its method and body once. */
+function isReplayableRequest(options: RequestInit): boolean {
+  const method = (options.method || 'GET').toUpperCase();
+  if (!['GET', 'HEAD', 'OPTIONS', 'PUT', 'DELETE'].includes(method)) return false;
+  return !(
+    options.body &&
+    typeof ReadableStream !== 'undefined' &&
+    options.body instanceof ReadableStream
+  );
+}
+
+/** Creates the standard DOM exception used for an aborted fetch. */
+function createAbortError(): DOMException {
+  return new DOMException('The operation was aborted.', 'AbortError');
+}

--- a/modules/loader-utils/src/lib/sources/data-source.ts
+++ b/modules/loader-utils/src/lib/sources/data-source.ts
@@ -9,6 +9,7 @@ import type {RequiredOptions} from '../option-utils/merge-options';
 import {mergeOptions} from '../option-utils/merge-options';
 import {resolvePath} from '../path-utils/file-aliases';
 import {log} from '../log-utils/log';
+import {createAuthenticatedFetch} from '../request-utils/request-credentials';
 
 /** Common properties for all data sources */
 export type DataSourceOptions = Partial<{
@@ -172,21 +173,23 @@ export abstract class DataSource<DataT, OptionsT extends DataSourceOptions> {
  * @param context
  */
 export function getFetchFunction(options?: StrictLoaderOptions) {
-  const fetchFunction = options?.core?.fetch;
+  const fetchOption = options?.fetch ?? options?.core?.fetch;
+  let fetchFunction: (url: string, requestOptions?: RequestInit) => Promise<Response>;
 
   // options.fetch can be a function
-  if (fetchFunction && typeof fetchFunction === 'function') {
-    return (url: string, fetchOptions?: RequestInit) => fetchFunction(url, fetchOptions);
+  if (typeof fetchOption === 'function') {
+    fetchFunction = (url: string, fetchOptions?: RequestInit) => fetchOption(url, fetchOptions);
+  } else if (fetchOption) {
+    fetchFunction = (url, requestOptions) =>
+      fetch(url, mergeFetchOptions(fetchOption, requestOptions));
+  } else {
+    fetchFunction = (url, requestOptions) => fetch(url, requestOptions);
   }
 
-  // options.fetch can be an options object, use global fetch with those options
-  const fetchOptions = options?.fetch;
-  if (fetchOptions && typeof fetchOptions !== 'function') {
-    return (url, requestOptions) => fetch(url, mergeFetchOptions(fetchOptions, requestOptions));
-  }
-
-  // else return the global fetch function
-  return (url, requestOptions) => fetch(url, requestOptions);
+  return createAuthenticatedFetch({
+    fetch: fetchFunction,
+    credentials: options?.core?.credentials || []
+  });
 }
 
 function mergeFetchOptions(fetchOptions: RequestInit, requestOptions?: RequestInit): RequestInit {

--- a/modules/loader-utils/src/lib/sources/utils/utils.ts
+++ b/modules/loader-utils/src/lib/sources/utils/utils.ts
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import type {LoaderOptions} from '@loaders.gl/loader-utils';
+import type {LoaderOptions} from '../../../loader-types';
+import {createAuthenticatedFetch} from '../../request-utils/request-credentials';
 
 /**
  * Gets the current fetch function from options
@@ -12,21 +13,33 @@ import type {LoaderOptions} from '@loaders.gl/loader-utils';
  * @param context
  */
 export function getFetchFunction(options?: LoaderOptions) {
-  const fetchFunction = options?.core?.fetch;
+  const fetchOption = options?.fetch ?? options?.core?.fetch;
+  let fetchFunction: (url: string, requestOptions?: RequestInit) => Promise<Response>;
 
-  // options.fetch can be a function
-  if (fetchFunction && typeof fetchFunction === 'function') {
-    return (url: string, fetchOptions?: RequestInit) => fetchFunction(url, fetchOptions);
+  if (typeof fetchOption === 'function') {
+    fetchFunction = (url: string, requestOptions?: RequestInit) => fetchOption(url, requestOptions);
+  } else if (fetchOption) {
+    fetchFunction = (url, requestOptions) =>
+      fetch(url, mergeFetchOptions(fetchOption, requestOptions));
+  } else {
+    fetchFunction = (url, requestOptions) => fetch(url, requestOptions);
   }
 
-  // options.fetch can be an options object, use global fetch with those options
-  const fetchOptions = options?.fetch;
-  if (fetchOptions && typeof fetchOptions !== 'function') {
-    return url => fetch(url, fetchOptions);
-  }
+  return createAuthenticatedFetch({
+    fetch: fetchFunction,
+    credentials: options?.core?.credentials || []
+  });
+}
 
-  // else return the global fetch function
-  return url => fetch(url);
+/** Combines static and per-request fetch options without replacing either header collection. */
+function mergeFetchOptions(fetchOptions: RequestInit, requestOptions?: RequestInit): RequestInit {
+  const mergedOptions: RequestInit = {...fetchOptions, ...requestOptions};
+  if (fetchOptions.headers || requestOptions?.headers) {
+    const headers = new Headers(fetchOptions.headers);
+    new Headers(requestOptions?.headers).forEach((value, key) => headers.set(key, value));
+    mergedOptions.headers = headers;
+  }
+  return mergedOptions;
 }
 
 export function mergeImageSourceLoaderProps<Props extends {loadOptions?: any}>(

--- a/modules/loader-utils/src/loader-types.ts
+++ b/modules/loader-utils/src/loader-types.ts
@@ -6,6 +6,7 @@ import type {Format} from './format-types';
 import {FetchLike, TransformBatches} from './types';
 import {ReadableFile} from './lib/files/file';
 import type {CoreAPI} from './lib/sources/data-source';
+import type {RequestCredential} from './lib/request-utils/request-credentials';
 
 // LOADERS
 
@@ -18,6 +19,8 @@ export type StrictLoaderOptions = {
     baseUrl?: string;
     /** fetch options or a custom fetch function */
     fetch?: typeof fetch | FetchLike | RequestInit | null;
+    /** Exact-origin credentials applied to top-level and nested requests. */
+    credentials?: readonly RequestCredential[];
     /** Do not throw on errors */
     nothrow?: boolean;
     /** Shared default shape for loaders that support shape selection. Loader-scoped `shape` options override this default. */

--- a/modules/loader-utils/test/lib/request-utils/request-credentials.spec.ts
+++ b/modules/loader-utils/test/lib/request-utils/request-credentials.spec.ts
@@ -1,0 +1,184 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {describe, expect, test, vi} from 'vitest';
+import {
+  createAuthenticatedFetch,
+  createBearerTokenCredential,
+  createQueryParameterCredential,
+  redactCredentialURL
+} from '@loaders.gl/loader-utils';
+
+describe('request credentials', () => {
+  test('applies query credentials only to exact origins and preserves request headers', async () => {
+    const requests: Array<{url: string; headers: Headers}> = [];
+    const authenticatedFetch = createAuthenticatedFetch({
+      fetch: async (url, options) => {
+        requests.push({url, headers: new Headers(options?.headers)});
+        return new Response('ok');
+      },
+      credentials: [
+        createQueryParameterCredential({
+          id: 'test-key',
+          origins: ['https://tiles.example.com'],
+          parameterName: 'key',
+          token: 'secret'
+        })
+      ]
+    });
+
+    await authenticatedFetch('https://tiles.example.com/data?session=abc', {
+      headers: {Accept: 'application/json'}
+    });
+    await authenticatedFetch('https://other.example.com/data');
+
+    expect(requests[0].url).toBe('https://tiles.example.com/data?session=abc&key=secret');
+    expect(requests[0].headers.get('accept')).toBe('application/json');
+    expect(requests[1].url).toBe('https://other.example.com/data');
+  });
+
+  test('preserves explicit query and header credentials', async () => {
+    const requests: Array<{url: string; authorization: string | null}> = [];
+    const authenticatedFetch = createAuthenticatedFetch({
+      fetch: async (url, options) => {
+        requests.push({
+          url,
+          authorization: new Headers(options?.headers).get('authorization')
+        });
+        return new Response('ok');
+      },
+      credentials: [
+        createQueryParameterCredential({
+          id: 'query',
+          origins: ['https://example.com'],
+          parameterName: 'token',
+          token: 'configured-query'
+        }),
+        createBearerTokenCredential({
+          id: 'bearer',
+          origins: ['https://example.com'],
+          token: 'configured-header'
+        })
+      ]
+    });
+
+    await authenticatedFetch('https://example.com/data?token=explicit-query', {
+      headers: {Authorization: 'Bearer explicit-header'}
+    });
+
+    expect(requests).toEqual([
+      {
+        url: 'https://example.com/data?token=explicit-query',
+        authorization: 'Bearer explicit-header'
+      }
+    ]);
+  });
+
+  test('refreshes an asynchronous credential and replays once', async () => {
+    const reasons: string[] = [];
+    const requestedTokens: (string | null)[] = [];
+    const credential = createBearerTokenCredential({
+      id: 'refreshing-bearer',
+      origins: ['https://example.com'],
+      token: context => {
+        reasons.push(context.reason);
+        return context.reason === 'refresh' ? 'fresh' : 'expired';
+      }
+    });
+    const authenticatedFetch = createAuthenticatedFetch({
+      fetch: async (_url, options) => {
+        const token = new Headers(options?.headers).get('authorization');
+        requestedTokens.push(token);
+        return new Response('', {status: token === 'Bearer fresh' ? 200 : 401});
+      },
+      credentials: [credential]
+    });
+
+    const response = await authenticatedFetch('https://example.com/data');
+
+    expect(response.status).toBe(200);
+    expect(reasons).toEqual(['request', 'refresh']);
+    expect(requestedTokens).toEqual(['Bearer expired', 'Bearer fresh']);
+  });
+
+  test('deduplicates concurrent refresh callbacks', async () => {
+    let releaseRefresh: (token: string) => void = () => {};
+    const refreshToken = new Promise<string>(resolve => {
+      releaseRefresh = resolve;
+    });
+    const tokenProvider = vi.fn(async ({reason}: {reason: string}) =>
+      reason === 'refresh' ? refreshToken : 'expired'
+    );
+    const credential = createBearerTokenCredential({
+      id: 'shared-refresh',
+      origins: ['https://example.com'],
+      token: tokenProvider
+    });
+    const authenticatedFetch = createAuthenticatedFetch({
+      fetch: async (_url, options) =>
+        new Response('', {
+          status:
+            new Headers(options?.headers).get('authorization') === 'Bearer refreshed' ? 200 : 401
+        }),
+      credentials: [credential]
+    });
+
+    const firstRequest = authenticatedFetch('https://example.com/first');
+    const secondRequest = authenticatedFetch('https://example.com/second');
+    await vi.waitFor(() =>
+      expect(
+        tokenProvider.mock.calls.filter(([context]) => context.reason === 'refresh')
+      ).toHaveLength(1)
+    );
+    releaseRefresh('refreshed');
+
+    expect((await firstRequest).status).toBe(200);
+    expect((await secondRequest).status).toBe(200);
+  });
+
+  test('does not replay non-idempotent requests', async () => {
+    const tokenProvider = vi.fn(() => 'expired');
+    const fetch = vi.fn(async () => new Response('', {status: 401}));
+    const authenticatedFetch = createAuthenticatedFetch({
+      fetch,
+      credentials: [
+        createBearerTokenCredential({
+          id: 'post-token',
+          origins: ['https://example.com'],
+          token: tokenProvider
+        })
+      ]
+    });
+
+    const response = await authenticatedFetch('https://example.com/data', {method: 'POST'});
+
+    expect(response.status).toBe(401);
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(tokenProvider).toHaveBeenCalledTimes(1);
+  });
+
+  test('redacts configured query credentials from diagnostic URLs', () => {
+    const credential = createQueryParameterCredential({
+      id: 'private-token',
+      origins: ['https://example.com'],
+      parameterName: 'token',
+      token: 'secret'
+    });
+
+    expect(redactCredentialURL('https://example.com/data?token=secret&f=json', [credential])).toBe(
+      'https://example.com/data?token=%5BREDACTED%5D&f=json'
+    );
+  });
+
+  test('rejects origins containing paths or query parameters', () => {
+    expect(() =>
+      createQueryParameterCredential({
+        id: 'invalid-origin',
+        origins: ['https://example.com/private'],
+        parameterName: 'token',
+        token: 'secret'
+      })
+    ).toThrow(/only scheme, host, and port/);
+  });
+});

--- a/modules/mvt/test/mvt-source-cancellation.spec.ts
+++ b/modules/mvt/test/mvt-source-cancellation.spec.ts
@@ -4,6 +4,7 @@
 
 import {expect, test} from 'vitest';
 import type {CoreAPI} from '@loaders.gl/loader-utils';
+import {createQueryParameterCredential} from '@loaders.gl/loader-utils';
 import type {MVTLoaderOptions} from '../src/mvt-loader';
 import {MVTTileSource} from '../src/mvt-source-loader';
 
@@ -59,4 +60,39 @@ test('MVTTileSource#getVectorTile forwards requested layers to the decoder', asy
     layerProperty: 'sourceLayer',
     layers: ['roads']
   });
+});
+
+test('MVTTileSource applies credentials to TileJSON and descendant tile requests', async () => {
+  const requestedURLs: string[] = [];
+  const source = new MVTTileSource('https://api.mapbox.com/v4/example.tiles', {
+    mvt: {extension: '.mvt'},
+    core: {
+      loadOptions: {
+        core: {
+          credentials: [
+            createQueryParameterCredential({
+              id: 'mapbox-token',
+              origins: ['https://api.mapbox.com'],
+              parameterName: 'access_token',
+              token: 'public-token'
+            })
+          ],
+          fetch: async url => {
+            requestedURLs.push(String(url));
+            return String(url).includes('tilejson.json')
+              ? new Response(null, {status: 404})
+              : new Response(new Uint8Array([1]));
+          }
+        }
+      }
+    }
+  });
+
+  await source.metadata;
+  await source.getTile({x: 2, y: 1, z: 3});
+
+  expect(requestedURLs).toEqual([
+    'https://api.mapbox.com/v4/example.tiles/tilejson.json?access_token=public-token',
+    'https://api.mapbox.com/v4/example.tiles/3/2/1.mvt?access_token=public-token'
+  ]);
 });

--- a/modules/services/src/authentication.ts
+++ b/modules/services/src/authentication.ts
@@ -1,0 +1,83 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {RequestCredential, TokenValue} from '@loaders.gl/loader-utils';
+import {
+  createBearerTokenCredential,
+  createQueryParameterCredential
+} from '@loaders.gl/loader-utils';
+
+/** Shared options for provider credential presets with known public API origins. */
+export type ServiceCredentialOptions = {
+  /** Replaces the provider's default exact-origin allowlist. */
+  origins?: readonly string[];
+};
+
+/** Options for an ArcGIS REST service credential. */
+export type ArcGISCredentialOptions = {
+  /** ArcGIS token or application-managed token callback. */
+  token: TokenValue;
+  /** Exact ArcGIS Online or Enterprise origins authorized to receive the token. */
+  origins: readonly string[];
+};
+
+/** Options for a Mapbox API credential. */
+export type MapboxCredentialOptions = ServiceCredentialOptions & {
+  /** Mapbox public access token or application-managed token callback. */
+  accessToken: TokenValue;
+};
+
+/** Options for a Google Maps Platform credential. */
+export type GoogleMapsCredentialOptions = ServiceCredentialOptions & {
+  /** Google Maps Platform API key or application-managed key callback. */
+  apiKey: TokenValue;
+};
+
+/** Options for a Cesium ion API credential. */
+export type CesiumIonCredentialOptions = ServiceCredentialOptions & {
+  /** Cesium ion access token or application-managed token callback. */
+  accessToken: TokenValue;
+};
+
+/** Creates an exact-origin ArcGIS `token` query credential. */
+export function createArcGISCredential(options: ArcGISCredentialOptions): RequestCredential {
+  return createQueryParameterCredential({
+    id: 'arcgis-token',
+    origins: options.origins,
+    parameterName: 'token',
+    token: options.token,
+    refreshStatusCodes: [401, 403, 498, 499]
+  });
+}
+
+/** Creates a Mapbox `access_token` query credential. */
+export function createMapboxCredential(options: MapboxCredentialOptions): RequestCredential {
+  return createQueryParameterCredential({
+    id: 'mapbox-access-token',
+    origins: options.origins || ['https://api.mapbox.com'],
+    parameterName: 'access_token',
+    token: options.accessToken
+  });
+}
+
+/** Creates a Google Maps Platform `key` query credential. */
+export function createGoogleMapsCredential(
+  options: GoogleMapsCredentialOptions
+): RequestCredential {
+  return createQueryParameterCredential({
+    id: 'google-maps-api-key',
+    origins: options.origins || ['https://tile.googleapis.com'],
+    parameterName: 'key',
+    token: options.apiKey
+  });
+}
+
+/** Creates a bearer credential for the Cesium ion REST API. */
+export function createCesiumIonCredential(options: CesiumIonCredentialOptions): RequestCredential {
+  return createBearerTokenCredential({
+    id: 'cesium-ion-access-token',
+    origins: options.origins || ['https://api.cesium.com'],
+    token: options.accessToken
+  });
+}

--- a/modules/services/src/index.ts
+++ b/modules/services/src/index.ts
@@ -71,3 +71,17 @@ export type {ArcGISSceneServerSourceOptions} from './arcgis/arcgis-scene-server-
 
 export type {ServiceLoader} from './service-registry';
 export {SERVICE_LOADERS, getServiceLoader} from './service-registry';
+
+export {
+  createArcGISCredential,
+  createCesiumIonCredential,
+  createGoogleMapsCredential,
+  createMapboxCredential
+} from './authentication';
+export type {
+  ArcGISCredentialOptions,
+  CesiumIonCredentialOptions,
+  GoogleMapsCredentialOptions,
+  MapboxCredentialOptions,
+  ServiceCredentialOptions
+} from './authentication';

--- a/modules/services/test/arcgis/arcgis-vector-tile-server-source.spec.ts
+++ b/modules/services/test/arcgis/arcgis-vector-tile-server-source.spec.ts
@@ -1,5 +1,5 @@
-import {expect, test} from 'vitest';
-import {ArcGISVectorTileServerSourceLoader} from '@loaders.gl/services';
+import {afterEach, expect, test, vi} from 'vitest';
+import {ArcGISVectorTileServerSourceLoader, createArcGISCredential} from '@loaders.gl/services';
 
 const VECTOR_TILE_SERVER_URL = 'https://example.com/arcgis/rest/services/World/VectorTileServer';
 
@@ -16,6 +16,8 @@ const SERVICE_METADATA = {
   },
   fullExtent: {xmin: -20037508, ymin: -20037508, xmax: 20037508, ymax: 20037508}
 };
+
+afterEach(() => vi.unstubAllGlobals());
 
 test('ArcGISVectorTileServerSource exposes tile metadata and resources', async () => {
   const source = ArcGISVectorTileServerSourceLoader.createDataSource(VECTOR_TILE_SERVER_URL, {});
@@ -64,6 +66,36 @@ test('ArcGISVectorTileServerSource fetches raw PBF tiles', async () => {
   };
   const result = await source.getTile({z: 2, x: 4, y: 5}, new AbortController().signal);
   expect(new Uint8Array(result!)).toEqual(tileBytes);
+});
+
+test('ArcGISVectorTileServerSource applies core credentials to metadata and tiles', async () => {
+  const requestedURLs: string[] = [];
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async url => {
+      requestedURLs.push(String(url));
+      return String(url).includes('f=pjson')
+        ? new Response(JSON.stringify(SERVICE_METADATA))
+        : new Response(new Uint8Array([1, 2, 3]));
+    })
+  );
+  const source = ArcGISVectorTileServerSourceLoader.createDataSource(VECTOR_TILE_SERVER_URL, {
+    core: {
+      loadOptions: {
+        core: {
+          credentials: [createArcGISCredential({token: 'secret', origins: ['https://example.com']})]
+        }
+      }
+    }
+  });
+
+  await source.getMetadata();
+  await source.getTile({z: 2, x: 4, y: 5});
+
+  expect(requestedURLs).toEqual([
+    `${VECTOR_TILE_SERVER_URL}?f=pjson&token=secret`,
+    `${VECTOR_TILE_SERVER_URL}/tile/2/5/4.pbf?token=secret`
+  ]);
 });
 
 test('ArcGISVectorTileServerSource decodes deck.gl tile data to WGS84', async () => {

--- a/modules/services/test/authentication.spec.ts
+++ b/modules/services/test/authentication.spec.ts
@@ -1,0 +1,40 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {describe, expect, test} from 'vitest';
+import {
+  createArcGISCredential,
+  createCesiumIonCredential,
+  createGoogleMapsCredential,
+  createMapboxCredential
+} from '@loaders.gl/services';
+
+describe('service authentication presets', () => {
+  test('uses provider-specific credential placement and origins', () => {
+    expect(
+      createArcGISCredential({token: 'arcgis', origins: ['https://enterprise.example.com']})
+    ).toMatchObject({
+      type: 'query-parameter',
+      name: 'token',
+      origins: ['https://enterprise.example.com'],
+      refreshStatusCodes: [401, 403, 498, 499]
+    });
+    expect(createMapboxCredential({accessToken: 'mapbox'})).toMatchObject({
+      type: 'query-parameter',
+      name: 'access_token',
+      origins: ['https://api.mapbox.com']
+    });
+    expect(createGoogleMapsCredential({apiKey: 'google'})).toMatchObject({
+      type: 'query-parameter',
+      name: 'key',
+      origins: ['https://tile.googleapis.com']
+    });
+    expect(createCesiumIonCredential({accessToken: 'ion'})).toMatchObject({
+      type: 'header',
+      name: 'Authorization',
+      prefix: 'Bearer ',
+      origins: ['https://api.cesium.com']
+    });
+  });
+});

--- a/modules/tiles/test/tileset/tileset-3d-source.spec.ts
+++ b/modules/tiles/test/tileset/tileset-3d-source.spec.ts
@@ -4,6 +4,7 @@
 
 import {expect, test} from 'vitest';
 import {coreApi} from '@loaders.gl/core';
+import {createQueryParameterCredential, type LoaderWithParser} from '@loaders.gl/loader-utils';
 import {I3SLoader} from '@loaders.gl/i3s';
 import {Tiles3DLoader} from '@loaders.gl/3d-tiles';
 import {
@@ -165,6 +166,66 @@ test('Tiles3DSource initializes metadata and merges source query parameters', as
   expect(source.getTileUrl('data:application/octet-stream;base64,AA==')).toBe(
     'data:application/octet-stream;base64,AA=='
   );
+});
+test('Tiles3DSource applies an API key while preserving Google 3D Tiles sessions', async () => {
+  const requestedURLs: string[] = [];
+  let parseCount = 0;
+  const loader = {
+    id: 'credential-tiles',
+    name: 'Credential test tiles',
+    module: 'tiles',
+    version: '0.0.0',
+    extensions: [],
+    mimeTypes: [],
+    options: {},
+    parse: async () => {
+      parseCount++;
+      return parseCount === 1
+        ? {
+            shape: 'tileset3d',
+            type: 'TILES3D',
+            asset: {version: '1.1'},
+            root: {refine: 'ADD'},
+            lodMetricType: 'geometricError',
+            lodMetricValue: 16
+          }
+        : {shape: 'tile3d'};
+    }
+  } as unknown as LoaderWithParser;
+  const source = new Tiles3DSource(
+    {
+      url: 'https://tile.googleapis.com/v1/3dtiles/root.json',
+      loader,
+      coreApi
+    },
+    {
+      core: {
+        credentials: [
+          createQueryParameterCredential({
+            id: 'google-maps-key',
+            origins: ['https://tile.googleapis.com'],
+            parameterName: 'key',
+            token: 'api-key'
+          })
+        ],
+        fetch: async url => {
+          requestedURLs.push(String(url));
+          return new Response(new Uint8Array([1]));
+        }
+      }
+    }
+  );
+
+  await source.initialize();
+  await source.loadTileContent({
+    contentUrl:
+      'https://tile.googleapis.com/v1/3dtiles/datasets/example/tile.glb?session=session-id'
+  } as Tile3D);
+
+  expect(requestedURLs).toEqual([
+    'https://tile.googleapis.com/v1/3dtiles/root.json?key=api-key',
+    'https://tile.googleapis.com/v1/3dtiles/datasets/example/tile.glb?session=session-id&key=api-key'
+  ]);
 });
 test('I3SSource initializes promised roots and appends auth tokens to tile urls', async () => {
   const source = new I3SSource(

--- a/modules/wms/src/service-runtime.ts
+++ b/modules/wms/src/service-runtime.ts
@@ -2,7 +2,15 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import type {CoreAPI, DataSource, DataSourceOptions, SourceLoader} from '@loaders.gl/loader-utils';
+import type {
+  CoreAPI,
+  DataSource,
+  DataSourceOptions,
+  FetchLike,
+  RequestCredential,
+  SourceLoader
+} from '@loaders.gl/loader-utils';
+import {createAuthenticatedFetch, redactCredentialURL} from '@loaders.gl/loader-utils';
 import {CSWSourceLoader} from './csw-source-loader';
 import {WMSSourceLoader} from './wms-source-loader';
 import {WMTSSourceLoader} from './wmts-source-loader';
@@ -23,6 +31,8 @@ export type ServiceRuntimeOptions = {
   coreApi?: CoreAPI;
   /** Default request headers, including authorization headers. */
   headers?: HeadersInit;
+  /** Exact-origin credentials applied to service and source requests. */
+  credentials?: readonly RequestCredential[];
   /** Number of retries after retryable failures. */
   retries?: number;
   /** Delay between retries in milliseconds. */
@@ -90,6 +100,7 @@ export class ServiceRuntime {
   readonly options: ServiceRuntimeOptions &
     Required<Pick<ServiceRuntimeOptions, 'loaders' | 'retries' | 'retryDelay' | 'cacheTTL'>>;
   private readonly _sources = new Map<string, CachedSource>();
+  private readonly _fetch: FetchLike;
 
   /** Creates a universal service runtime. */
   constructor(options: ServiceRuntimeOptions = {}) {
@@ -100,6 +111,7 @@ export class ServiceRuntime {
       retryDelay: options.retryDelay ?? 100,
       cacheTTL: options.cacheTTL ?? 300_000
     };
+    this._fetch = createAuthenticatedFetch({credentials: options.credentials || []});
   }
 
   /** Detects a source type and creates a cached protocol source for a URL. */
@@ -117,17 +129,18 @@ export class ServiceRuntime {
   /** Requests a URL with shared headers, cancellation, retry, and telemetry behavior. */
   async request(url: string, requestInit: RequestInit = {}): Promise<Response> {
     const startedAt = Date.now();
+    const diagnosticURL = redactCredentialURL(url, this.options.credentials || []);
     for (let attempt = 1; attempt <= this.options.retries + 1; attempt++) {
-      this.options.onTelemetry?.({phase: 'start', url, attempt});
+      this.options.onTelemetry?.({phase: 'start', url: diagnosticURL, attempt});
       try {
-        const response = await fetch(url, {
+        const response = await this._fetch(url, {
           ...requestInit,
           headers: mergeHeaders(this.options.headers, requestInit.headers)
         });
-        if (!response.ok) throw new ServiceRequestError(url, attempt, response.status);
+        if (!response.ok) throw new ServiceRequestError(diagnosticURL, attempt, response.status);
         this.options.onTelemetry?.({
           phase: 'success',
-          url,
+          url: diagnosticURL,
           attempt,
           elapsed: Date.now() - startedAt
         });
@@ -137,7 +150,7 @@ export class ServiceRuntime {
         const normalizedError =
           error instanceof ServiceRequestError
             ? error
-            : new ServiceRequestError(url, attempt, undefined, error);
+            : new ServiceRequestError(diagnosticURL, attempt, undefined, error);
         if (
           attempt > this.options.retries ||
           !isRetryableError(normalizedError) ||
@@ -145,7 +158,7 @@ export class ServiceRuntime {
         ) {
           this.options.onTelemetry?.({
             phase: 'error',
-            url,
+            url: diagnosticURL,
             attempt,
             elapsed: Date.now() - startedAt,
             error: normalizedError
@@ -155,7 +168,7 @@ export class ServiceRuntime {
         await delay(this.options.retryDelay * 2 ** (attempt - 1));
       }
     }
-    throw new ServiceRequestError(url, this.options.retries + 1);
+    throw new ServiceRequestError(diagnosticURL, this.options.retries + 1);
   }
 
   /** Clears cached source instances, optionally limiting invalidation to one URL. */
@@ -165,12 +178,23 @@ export class ServiceRuntime {
   }
 
   private _getSourceOptions(options: DataSourceOptions): DataSourceOptions {
-    if (!this.options.headers) return options;
+    if (!this.options.headers && !this.options.credentials?.length) return options;
+    const loadOptions = options.core?.loadOptions || {};
     return {
       ...options,
       core: {
         ...options.core,
-        loadOptions: {...options.core?.loadOptions, fetch: {headers: this.options.headers}}
+        loadOptions: {
+          ...loadOptions,
+          core: {
+            ...loadOptions.core,
+            credentials: [
+              ...(loadOptions.core?.credentials || []),
+              ...(this.options.credentials || [])
+            ]
+          },
+          fetch: this.options.headers ? {headers: this.options.headers} : loadOptions.fetch
+        }
       }
     };
   }

--- a/modules/wms/test/service-runtime.spec.ts
+++ b/modules/wms/test/service-runtime.spec.ts
@@ -10,6 +10,7 @@ import {
   ServiceRuntime,
   discoverServiceGraph
 } from '@loaders.gl/wms';
+import {createQueryParameterCredential} from '@loaders.gl/loader-utils';
 
 afterEach(() => vi.unstubAllGlobals());
 
@@ -92,6 +93,63 @@ describe('ServiceRuntime', () => {
       })
     ).rejects.toBeInstanceOf(ServiceRequestError);
     expect(attempts).toBe(1);
+  });
+
+  test('applies credentials and redacts telemetry URLs', async () => {
+    const requestedURLs: string[] = [];
+    const telemetryURLs: string[] = [];
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async url => {
+        requestedURLs.push(String(url));
+        return new Response('ok');
+      })
+    );
+    const credential = createQueryParameterCredential({
+      id: 'service-token',
+      origins: ['https://secure.example.com'],
+      parameterName: 'token',
+      token: 'secret'
+    });
+    const runtime = new ServiceRuntime({
+      credentials: [credential],
+      onTelemetry: event => telemetryURLs.push(event.url)
+    });
+
+    await runtime.request('https://secure.example.com/wms?token=legacy');
+
+    expect(requestedURLs).toEqual(['https://secure.example.com/wms?token=legacy']);
+    expect(telemetryURLs).toEqual([
+      'https://secure.example.com/wms?token=%5BREDACTED%5D',
+      'https://secure.example.com/wms?token=%5BREDACTED%5D'
+    ]);
+  });
+
+  test('propagates runtime credentials to created sources', async () => {
+    const requestedURLs: string[] = [];
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async url => {
+        requestedURLs.push(String(url));
+        return new Response('ok');
+      })
+    );
+    const runtime = new ServiceRuntime({
+      credentials: [
+        createQueryParameterCredential({
+          id: 'source-token',
+          origins: ['https://secure.example.com'],
+          parameterName: 'token',
+          token: 'secret'
+        })
+      ]
+    });
+    const source = runtime.getSource('https://secure.example.com/wms?service=WMS');
+    const resourceURL = 'https://secure.example.com/resource';
+
+    await source.fetch(resourceURL);
+
+    expect(requestedURLs).toEqual(['https://secure.example.com/resource?token=secret']);
   });
 });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -97,6 +97,9 @@
       "@loaders.gl/3d-tiles": [
         "modules/3d-tiles/src"
       ],
+      "@loaders.gl/3d-tiles/cesium-ion-loader-with-parser": [
+        "modules/3d-tiles/src/cesium-ion-loader-with-parser"
+      ],
       "@loaders.gl/3d-tiles/test": [
         "modules/3d-tiles/test"
       ],


### PR DESCRIPTION
## Goals

- Provide one minimal, secure authentication model for loaders.gl requests and nested service resources.
- Support application-managed static and refreshable tokens without implementing OAuth login or token storage.
- Make authenticated services work consistently through `load`, sources, service runtime, and deck.gl layers.
- Document provider-specific behavior and safe origin scoping for v5.0.

## Changes

- Add `core.credentials` and the loader-utils credential pipeline for exact-origin query/header credentials, async refresh callbacks, refresh deduplication, one safe replay, explicit-value precedence, abort handling, and URL redaction.
- Add `@loaders.gl/services` presets for ArcGIS, Mapbox, Google Maps Platform, and Cesium ion.
- Propagate credentials through core fetch selection, `DataSource`, WMS `ServiceRuntime`, MVT/ArcGIS sources, 3D Tiles sources, and deck.gl source-backed layers.
- Refactor Cesium ion bootstrap to keep account and endpoint tokens scoped to their respective origins, including `load(CesiumIonLoader, ...)` support.
- Add focused unit and integration coverage for refresh, origin isolation, redaction, provider URLs, nested resources, and public loader entry points.
- Add the high-level authentication guide, loader-utils API reference, provider-specific service notes, Cesium ion lifecycle documentation, sidebar entries, and Google session/key guidance.

## Validation

- `yarn build`
- `yarn build-workers`
- `yarn test-node` — 361 passed, 6 skipped
- `yarn test-headless` — 3,235 passed, 39 skipped
- Focused authentication/integration suite — 46 passed
- `yarn test-audit` — 0 violations
- `yarn lint fix`
- `cd website && yarn && yarn build` — successful; existing unrelated Docusaurus warnings remain
- Combined coverage test bodies completed — 3,596 passed, 45 skipped; V8 report generation was interrupted before the final browser summary was written
