### PR TITLE
perf(parquet): accelerate TypeScript decoding

### DIFF
--- a/docs/modules/compression/README.md
+++ b/docs/modules/compression/README.md
@@ -168,6 +168,7 @@ These imports bypass the default selection policy and pin one backend.
 | Zstandard | `ZstdFzstdDecompressor` | `zstd-decompressor-fzstd` | Compact synchronous JavaScript |
 | Zstandard | `ZstdCompressUtilsDecompressor` | `zstd-decompressor-compress-utils` | Incremental operation |
 | Snappy | `SnappyJSDecompressor` | `snappy-decompressor-snappyjs` | Compact JavaScript |
+| Snappy | `SnappyHysnappyDecompressor` | `snappy-decompressor-hysnappy` | Small synchronous embedded-WASM decoder |
 | Snappy | `SnappyCompressUtilsDecompressor` | `snappy-decompressor-compress-utils` | Snappy decoding |
 | LZ4 frame | `LZ4JSDecompressor` | `lz4-decompressor-lz4js` | Compact JavaScript |
 | LZ4 frame | `LZ4CompressUtilsDecompressor` | `lz4-decompressor-compress-utils` | LZ4 frame decoding |
@@ -185,6 +186,13 @@ streams, initialize optional modules, and work with WASM-backed implementations.
   synchronous codec. Some compatibility codecs require `await preload()` before a sync call.
 - A codec with genuine streaming support emits output incrementally. The base classes otherwise
   concatenate the input and yield one result.
+
+Built-in streams are not automatically the fastest choice for every workload. Creating a
+`CompressionStream` or `DecompressionStream` and scheduling its asynchronous reads has a fixed
+cost. That cost is usually amortized for large payloads and genuine streams, but it can dominate
+formats such as Parquet that process many small, independently compressed blocks. For block-based
+formats, benchmark a cached synchronous JavaScript codec as well as the built-in stream path;
+`useNative: false` selects that path on the balanced GZIP, DEFLATE, Brotli, and Zstandard classes.
 
 `compress-utils`, Pako, `lz4js`, and `zstd-codec` are optional peer dependencies. Only install an
 optional package when importing its adapter. `compress-utils` uses direction-specific algorithm

--- a/docs/modules/compression/api-reference/snappy.md
+++ b/docs/modules/compression/api-reference/snappy.md
@@ -19,6 +19,13 @@ synchronous one-shot operation.
 | Backend | Compressor subpath | Decompressor subpath |
 | --- | --- | --- |
 | snappyjs | `snappy-compressor-snappyjs` | `snappy-decompressor-snappyjs` |
+| hysnappy | — | `snappy-decompressor-hysnappy` |
 | compress-utils | `snappy-compressor-compress-utils` | `snappy-decompressor-compress-utils` |
 
-The default is normally the best size/performance balance. See the [live benchmarks](/docs/modules/compression/benchmarks) before pinning another backend.
+`SnappyHysnappyDecompressor` uses a small embedded WebAssembly decoder. Its asynchronous
+`preload()` method instantiates one decoder per JavaScript realm, after which `decompressSync()` is
+available. This can be a better fit for formats such as Parquet that decode many independent blocks
+and already know each block's uncompressed size.
+
+The default is normally the best size/performance balance. See the
+[live benchmarks](/docs/modules/compression/benchmarks) before pinning another backend.

--- a/docs/modules/parquet/api-reference/parquet-loader.md
+++ b/docs/modules/parquet/api-reference/parquet-loader.md
@@ -228,31 +228,8 @@ Set `core.worker: false` to decode on the calling thread. `ParquetJSLoader` alwa
 
 ## Live Benchmarks
 
-These benchmarks compare maintained JavaScript and WebAssembly Arrow-table decode paths on common,
-checked-in fixtures. They are a reproducible baseline for finding optimization opportunities in the
-loaders.gl TypeScript backend, not a ranking of projects.
-
-The suite runs entirely in your browser. Fixture download and parser initialization happen before
-timing; each implementation is warmed up and must return the same row count. The matrix covers
-nullable primitives, nested and repeated data, dictionary and delta encodings, compression, and
-column projection. It focuses on Arrow output and retains one object-row control to expose
-row-materialization cost. `N/A` means an implementation is intentionally excluded from a scenario;
-`Failed` means a selected implementation threw or could not complete; and `Incorrect` means it
-completed but returned a different row count from the validated result. A green
-marker identifies the fastest completed value in each row. Results depend on the browser, hardware,
-thermal state, and whether this tab remains focused.
-
-The throughput cases emphasize sustained work rather than two-row initialization effects: the main
-fixtures span 1,000 to 40,000 rows, up to 66 columns, and multiple row groups. The compression matrix
-covers SNAPPY, GZIP, ZSTD, LZ4_RAW, and legacy LZ4 framing in addition to uncompressed data. Scenario
-labels show their row and top-level column counts so results from differently shaped files are not
-mistaken for equivalent workloads.
-
-The live suite includes `ParquetLoader` plus the browser-oriented `parquet-wasm` and `hyparquet`
-packages. External package versions are displayed in the table headers and pinned in the repository
-lockfile. The hyparquet compression cases use the separately pinned `hyparquet-compressors` 1.1.1
-package. The corresponding Node suite covers additional codecs and projections with
-`yarn bench parquet`.
+Live Arrow decode throughput on representative, checked-in Parquet fixtures. Exact external package
+versions appear in the table headers.
 
 <BrowserOnly fallback={<p>Loading browser benchmarks...</p>}>
   {() => {
@@ -260,6 +237,28 @@ package. The corresponding Node suite covers additional codecs and projections w
     return <ParquetBenchmarksApp />;
   }}
 </BrowserOnly>
+
+- 🟢 marks the fastest completed result in each row.
+- `N/A` is excluded, `Failed` is a runtime error, and `Incorrect` is a row-count mismatch.
+- Results vary by browser and hardware; keep this tab focused while the suite runs.
+
+<details>
+  <summary>Methodology and coverage</summary>
+
+  - Downloads and parser initialization are excluded from timing; each implementation is warmed up.
+  - Results must match the validated row count. Projection rows include extra work when an
+    implementation returns the complete fixture table.
+  - The primarily Arrow-focused matrix covers nullable, nested, repeated, dictionary, delta,
+    projection, and compression cases, plus one object-row control.
+  - Main fixtures span 1,000–40,000 rows, up to 66 columns, and multiple row groups. Scenario labels
+    show row and top-level column counts.
+  - External versions are pinned in the lockfile. Compression support for `hyparquet` uses
+    `hyparquet-compressors` 1.1.1.
+  - Run `yarn bench parquet` for the broader Node benchmark suite.
+
+  This is a reproducible optimization baseline across maintained JavaScript and WebAssembly paths,
+  not a ranking of projects.
+</details>
 
 ## Remarks
 

--- a/modules/compression/package.json
+++ b/modules/compression/package.json
@@ -194,6 +194,10 @@
       "types": "./dist/snappy-decompressor-snappyjs.d.ts",
       "import": "./dist/snappy-decompressor-snappyjs.js"
     },
+    "./snappy-decompressor-hysnappy": {
+      "types": "./dist/snappy-decompressor-hysnappy.d.ts",
+      "import": "./dist/snappy-decompressor-hysnappy.js"
+    },
     "./lz4-lz4js": {
       "types": "./dist/lz4-lz4js.d.ts",
       "import": "./dist/lz4-lz4js.js"
@@ -303,6 +307,7 @@
     "@loaders.gl/worker-utils": "5.0.0-alpha.2",
     "fflate": "0.7.4",
     "fzstd": "0.1.1",
+    "hysnappy": "^1.1.1",
     "snappyjs": "^0.6.1"
   },
   "devDependencies": {

--- a/modules/compression/src/lib/lz4-compression.ts
+++ b/modules/compression/src/lib/lz4-compression.ts
@@ -100,15 +100,21 @@ export class LZ4Compression extends Compression {
       let uncompressed = new Uint8Array(maxSize);
       const hadoopSize = this.decodeHadoopBlocks(inputArray, uncompressed);
       if (hadoopSize !== null) {
-        return toArrayBuffer(uncompressed.slice(0, hadoopSize));
+        return toArrayBuffer(
+          hadoopSize === uncompressed.byteLength
+            ? uncompressed
+            : uncompressed.subarray(0, hadoopSize)
+        );
       }
       const uncompressedSize = this.decodeBlock(inputArray, uncompressed);
       if (uncompressedSize < 0 || uncompressedSize > maxSize) {
         throw new Error(`Invalid LZ4 block at byte ${Math.abs(uncompressedSize)}`);
       }
-      uncompressed = uncompressed.slice(0, uncompressedSize);
-
-      return toArrayBuffer(uncompressed);
+      return toArrayBuffer(
+        uncompressedSize === uncompressed.byteLength
+          ? uncompressed
+          : uncompressed.subarray(0, uncompressedSize)
+      );
     } catch (error) {
       throw this.improveError(error);
     }
@@ -243,12 +249,20 @@ export class LZ4Compression extends Compression {
    * @param input
    */
   checkMagicNumber(data: ArrayBuffer): boolean {
-    const magic = new Uint32Array(data.slice(0, 4));
-    return magic[0] === LZ4_MAGIC_NUMBER;
+    if (data.byteLength < 4) return false;
+    const bytes = new Uint8Array(data, 0, 4);
+    const magic = (bytes[0] | (bytes[1] << 8) | (bytes[2] << 16) | (bytes[3] << 24)) >>> 0;
+    return magic === LZ4_MAGIC_NUMBER;
   }
 }
 
 /** Reads one unsigned big-endian 32-bit Hadoop block length. */
 function readUInt32BE(data: Uint8Array, offset: number): number {
-  return new DataView(data.buffer, data.byteOffset, data.byteLength).getUint32(offset, false);
+  return (
+    ((data[offset] << 24) |
+      (data[offset + 1] << 16) |
+      (data[offset + 2] << 8) |
+      data[offset + 3]) >>>
+    0
+  );
 }

--- a/modules/compression/src/snappy-decompressor-hysnappy.ts
+++ b/modules/compression/src/snappy-decompressor-hysnappy.ts
@@ -1,0 +1,64 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {toArrayBuffer} from '@loaders.gl/loader-utils';
+import {Decompressor, type CompressionOptions} from './lib/compression';
+
+type SnappyUncompressor = (input: Uint8Array, outputLength: number) => Uint8Array;
+
+/** One synchronously invoked decoder per JavaScript realm avoids recompiling WASM per reader. */
+let sharedSnappyUncompressorPromise: Promise<SnappyUncompressor> | undefined;
+
+/** Snappy decompressor backed by hysnappy's small synchronously instantiated WASM module. */
+export class SnappyHysnappyDecompressor extends Decompressor {
+  /** Compression format name. */
+  readonly name = 'snappy';
+  /** Snappy does not have a standard standalone file extension. */
+  readonly extensions: string[] = [];
+  /** Snappy does not have a standard HTTP content encoding. */
+  readonly contentEncodings: string[] = [];
+  /** Whether the runtime can instantiate the embedded WASM decoder. */
+  readonly isSupported = typeof WebAssembly !== 'undefined';
+
+  /** Cached decoder instantiated by {@link preload}. */
+  private uncompressor?: SnappyUncompressor;
+
+  /** Loads and instantiates the embedded hysnappy WASM module once per JavaScript realm. */
+  async preload(): Promise<void> {
+    if (!this.uncompressor) {
+      sharedSnappyUncompressorPromise ||= import('hysnappy').then(hysnappy =>
+        hysnappy.snappyUncompressor()
+      );
+      this.uncompressor = await sharedSnappyUncompressorPromise;
+    }
+  }
+
+  /** Decompresses one Snappy payload synchronously after preload. */
+  decompressSync(input: ArrayBuffer, size?: number): ArrayBuffer {
+    if (!this.uncompressor) {
+      throw new Error('snappy hysnappy decoder has not been preloaded');
+    }
+    const bytes = new Uint8Array(input);
+    const outputLength = size ?? readSnappyUncompressedLength(bytes);
+    return toArrayBuffer(this.uncompressor(bytes, outputLength));
+  }
+}
+
+/** Reads the uncompressed byte length stored as the leading Snappy varint. */
+function readSnappyUncompressedLength(input: Uint8Array): number {
+  let value = 0;
+  let multiplier = 1;
+  for (let byteIndex = 0; byteIndex < Math.min(input.byteLength, 5); byteIndex++) {
+    const byte = input[byteIndex];
+    value += (byte & 0x7f) * multiplier;
+    if ((byte & 0x80) === 0) {
+      if (!Number.isSafeInteger(value)) throw new Error('invalid Snappy uncompressed length');
+      return value;
+    }
+    multiplier *= 128;
+  }
+  throw new Error('invalid Snappy uncompressed length');
+}
+
+export type {CompressionOptions as SnappyHysnappyDecompressorOptions};

--- a/modules/compression/test/fallback-codecs.spec.ts
+++ b/modules/compression/test/fallback-codecs.spec.ts
@@ -8,6 +8,8 @@ import {BrotliDecode} from '@loaders.gl/compression/brotli-decode';
 import {DeflateCompression} from '@loaders.gl/compression/deflate-compression';
 import {GZipCompression} from '@loaders.gl/compression/gzip-compression';
 import {LZ4Compression} from '@loaders.gl/compression/lz4-compression';
+import {SnappyHysnappyDecompressor} from '@loaders.gl/compression/snappy-decompressor-hysnappy';
+import {SnappyJSCompressor} from '@loaders.gl/compression/snappy-compressor-snappyjs';
 import {
   NATIVE_DECOMPRESSION_FIXTURES,
   NATIVE_DECOMPRESSION_TEST_DATA
@@ -54,6 +56,25 @@ test('LZ4Compression decodes a raw block without loading lz4js', () => {
   } finally {
     restoreLz4();
   }
+});
+
+test('SnappyHysnappyDecompressor decodes Snappy with known and embedded output lengths', async () => {
+  const input = new TextEncoder().encode('small independently compressed parquet page '.repeat(64));
+  const compressor = new SnappyJSCompressor();
+  await compressor.preload();
+  const compressed = compressor.compressSync(input.buffer);
+  const decompressor = new SnappyHysnappyDecompressor();
+  await decompressor.preload();
+
+  expect(new Uint8Array(decompressor.decompressSync(compressed, input.byteLength))).toEqual(input);
+  expect(new Uint8Array(decompressor.decompressSync(compressed))).toEqual(input);
+});
+
+test('SnappyHysnappyDecompressor requires preload before synchronous decoding', () => {
+  const decompressor = new SnappyHysnappyDecompressor();
+  expect(() => decompressor.decompressSync(new Uint8Array([0]).buffer)).toThrow(
+    'snappy hysnappy decoder has not been preloaded'
+  );
 });
 
 /** Concatenates asynchronous output batches. */

--- a/modules/geopackage/test/geopackage-source.spec.ts
+++ b/modules/geopackage/test/geopackage-source.spec.ts
@@ -9,6 +9,13 @@ setLoaderOptions({
   worker: false
 });
 test('GeoPackageSource#createDataSource selects GeoPackage source from URL', () => {
+  expect(GeoPackageSource.testURL?.('data.GPKG?download=1')).toBe(true);
+  expect(GeoPackageSource.testURL?.('data.parquet')).toBe(false);
+  expect(
+    GeoPackageSource.createDataSource(GPKG_RIVERS_MULTI, {geopackage: {}}) instanceof
+      GeoPackageDataSource
+  ).toBe(true);
+
   const dataSource = createDataSource(GPKG_RIVERS_MULTI, [GeoPackageSource], {
     geopackage: {}
   });

--- a/modules/parquet/src/lib/arrow/create-nested-arrow-vector.ts
+++ b/modules/parquet/src/lib/arrow/create-nested-arrow-vector.ts
@@ -416,6 +416,16 @@ function createSelectedPrimitiveData(
   columnData: ParquetColumnChunk,
   selected: SelectedLeafValues
 ): arrow.Data | undefined {
+  const directData = createSelectedPrimitiveArrayView(
+    arrowType,
+    parquetField,
+    columnData,
+    selected
+  );
+  if (directData) {
+    return arrow.makeData({type: arrowType, data: directData, nullCount: 0} as any);
+  }
+
   const data = createNestedPrimitiveArray(arrowType, parquetField, selected.length);
   if (!data) {
     return undefined;
@@ -435,6 +445,75 @@ function createSelectedPrimitiveData(
     nullBitmap: selected.nullBitmap,
     nullCount: selected.nullCount
   } as any);
+}
+
+/** Reuses a contiguous decoded primitive range when nested selection needs no null expansion. */
+function createSelectedPrimitiveArrayView(
+  arrowType: arrow.DataType,
+  parquetField: ParquetField,
+  columnData: ParquetColumnChunk,
+  selected: SelectedLeafValues
+): NestedPrimitiveArrowArray | undefined {
+  if (selected.nullCount || selected.length !== selected.valueCount) {
+    return undefined;
+  }
+  const values = getMatchingNestedPrimitiveArray(arrowType, parquetField, columnData.values);
+  return values?.subarray(
+    selected.firstValueIndex,
+    selected.firstValueIndex + selected.valueCount
+  ) as NestedPrimitiveArrowArray | undefined;
+}
+
+/** Returns decoded nested values when their physical array exactly matches the Arrow type. */
+function getMatchingNestedPrimitiveArray(
+  arrowType: arrow.DataType,
+  parquetField: ParquetField,
+  values: ParquetColumnChunk['values']
+): NestedPrimitiveArrowArray | undefined {
+  if (
+    parquetField.primitiveType === 'FLOAT' &&
+    arrowType instanceof arrow.Float32 &&
+    values instanceof Float32Array
+  ) {
+    return values;
+  }
+  if (
+    parquetField.primitiveType === 'DOUBLE' &&
+    arrowType instanceof arrow.Float64 &&
+    values instanceof Float64Array
+  ) {
+    return values;
+  }
+  if (parquetField.primitiveType === 'INT32') {
+    if (arrowType instanceof arrow.Int8 && values instanceof Int8Array) return values;
+    if (arrowType instanceof arrow.Int16 && values instanceof Int16Array) return values;
+    if (
+      (arrowType instanceof arrow.Int32 ||
+        arrowType instanceof arrow.DateDay ||
+        arrowType instanceof arrow.TimeMillisecond) &&
+      values instanceof Int32Array
+    ) {
+      return values;
+    }
+    if (arrowType instanceof arrow.Uint8 && values instanceof Uint8Array) return values;
+    if (arrowType instanceof arrow.Uint16 && values instanceof Uint16Array) return values;
+    if (arrowType instanceof arrow.Uint32 && values instanceof Uint32Array) return values;
+  }
+  if (parquetField.primitiveType === 'INT64') {
+    if (
+      (arrowType instanceof arrow.Int64 ||
+        arrowType instanceof arrow.TimeMicrosecond ||
+        arrowType instanceof arrow.TimeNanosecond ||
+        arrowType instanceof arrow.TimestampMillisecond ||
+        arrowType instanceof arrow.TimestampMicrosecond ||
+        arrowType instanceof arrow.TimestampNanosecond) &&
+      values instanceof BigInt64Array
+    ) {
+      return values;
+    }
+    if (arrowType instanceof arrow.Uint64 && values instanceof BigUint64Array) return values;
+  }
+  return undefined;
 }
 
 /** Allocates the Arrow array matching an unconverted physical Parquet primitive. */
@@ -517,6 +596,9 @@ function createSelectedByteData(
   if (!supportsNestedByteData(arrowType, parquetField)) {
     return undefined;
   }
+  if (columnData.byteArrayData) {
+    return createSelectedBufferedByteData(arrowType, columnData, selected);
+  }
 
   const byteValues = columnData.values as Uint8Array[];
   const valueOffsets = new Int32Array(selected.length + 1);
@@ -556,6 +638,36 @@ function createSelectedByteData(
   } as any);
 }
 
+/** Creates selected nested Arrow bytes from the decoder's compact physical value buffer. */
+function createSelectedBufferedByteData(
+  arrowType: arrow.DataType,
+  columnData: ParquetColumnChunk,
+  selected: SelectedLeafValues
+): arrow.Data {
+  const byteArrayData = columnData.byteArrayData!;
+  const valueOffsets = new Int32Array(selected.length + 1);
+  let sourceValueIndex = selected.firstValueIndex;
+  let dataByteLength = 0;
+  for (let outputIndex = 0; outputIndex < selected.length; outputIndex++) {
+    if (!selected.nullBitmap || selected.nullBitmap[outputIndex >> 3] & (1 << (outputIndex & 7))) {
+      dataByteLength +=
+        byteArrayData.valueOffsets[sourceValueIndex + 1] -
+        byteArrayData.valueOffsets[sourceValueIndex];
+      sourceValueIndex++;
+    }
+    valueOffsets[outputIndex + 1] = dataByteLength;
+  }
+  const firstByteOffset = byteArrayData.valueOffsets[selected.firstValueIndex];
+  const lastByteOffset = byteArrayData.valueOffsets[selected.firstValueIndex + selected.valueCount];
+  return arrow.makeData({
+    type: arrowType,
+    valueOffsets,
+    data: byteArrayData.data.subarray(firstByteOffset, lastByteOffset),
+    nullBitmap: selected.nullBitmap,
+    nullCount: selected.nullCount
+  } as any);
+}
+
 /** Returns whether one Parquet byte leaf maps directly to Arrow Utf8 or Binary. */
 function supportsNestedByteData(arrowType: arrow.DataType, parquetField: ParquetField): boolean {
   if (arrowType instanceof arrow.Utf8) {
@@ -564,6 +676,10 @@ function supportsNestedByteData(arrowType: arrow.DataType, parquetField: Parquet
   return (
     arrowType instanceof arrow.Binary &&
     (!parquetField.originalType ||
+      parquetField.originalType === 'JSON' ||
+      parquetField.originalType === 'BSON' ||
+      parquetField.originalType === 'INTERVAL' ||
+      parquetField.originalType === 'VARIANT' ||
       parquetField.originalType === 'GEOMETRY' ||
       parquetField.originalType === 'GEOGRAPHY') &&
     (parquetField.primitiveType === 'BYTE_ARRAY' ||

--- a/modules/parquet/src/lib/parsers/parse-parquet-to-arrow-js.ts
+++ b/modules/parquet/src/lib/parsers/parse-parquet-to-arrow-js.ts
@@ -106,6 +106,13 @@ export async function parseParquetFileToArrowWithJs(
   file: ReadableFile,
   options?: ParquetJSLoaderOptions
 ): Promise<ArrowTable> {
+  if (
+    !options?.parquet?.offset &&
+    options?.parquet?.limit === undefined &&
+    options?.parquet?.batchSize === undefined
+  ) {
+    return await parseCompleteParquetFileToArrowWithJs(file, options);
+  }
   const recordBatches: arrow.RecordBatch[] = [];
   let schema: Schema | undefined;
 
@@ -119,6 +126,53 @@ export async function parseParquetFileToArrowWithJs(
     ? new arrow.Table(recordBatches)
     : new arrow.Table(createParquetArrowSchema(schema), []);
   return {shape: 'arrow-table', data: table, schema};
+}
+
+/** Parses complete row groups directly, bypassing batch slicing and wrapper reconstruction. */
+async function parseCompleteParquetFileToArrowWithJs(
+  file: ReadableFile,
+  options?: ParquetJSLoaderOptions
+): Promise<ArrowTable> {
+  await preloadCompressions(options);
+  const reader = new ParquetReader(file, {
+    preserveBinary: options?.parquet?.preserveBinary,
+    int96AsTimestamp: options?.parquet?.int96AsTimestamp ?? true,
+    retainByteArrayViews: true,
+    useTypedValueBuffers: true,
+    useTypedLevelBuffers: true,
+    useArrowByteArrayBuffers: true,
+    verifyFooterSignature: options?.parquet?.verifyFooterSignature,
+    keyRetriever: options?.parquet?.keyRetriever,
+    aadPrefix: options?.parquet?.aadPrefix
+  });
+  const schema = projectSchema(await getSchemaFromParquetReader(reader), options?.parquet?.columns);
+  const arrowSchema = createParquetArrowSchema(schema);
+  const parquetSchema = await reader.getSchema();
+  const recordBatches: arrow.RecordBatch[] = [];
+  let onlyTable: ArrowTable | undefined;
+
+  for await (const rowGroup of reader.rowGroupIterator(getParquetIterationProps(options))) {
+    const table = convertRowGroupSliceToArrow(
+      schema,
+      arrowSchema,
+      parquetSchema,
+      rowGroup,
+      0,
+      rowGroup.rowCount
+    );
+    onlyTable = recordBatches.length === 0 ? table : undefined;
+    recordBatches.push(...table.data.batches);
+  }
+  if (onlyTable && recordBatches.length === onlyTable.data.batches.length) {
+    return onlyTable;
+  }
+  return {
+    shape: 'arrow-table',
+    schema,
+    data: recordBatches.length
+      ? new arrow.Table(recordBatches)
+      : new arrow.Table(createParquetArrowSchema(schema), [])
+  };
 }
 
 /** Reads the projected loaders.gl schema when row selection produces no Arrow record batches. */
@@ -155,6 +209,7 @@ export async function* parseParquetFileToArrowInBatchesWithJs(
     retainByteArrayViews: true,
     useTypedValueBuffers: true,
     useTypedLevelBuffers: true,
+    useArrowByteArrayBuffers: true,
     verifyFooterSignature: options?.parquet?.verifyFooterSignature,
     keyRetriever: options?.parquet?.keyRetriever,
     aadPrefix: options?.parquet?.aadPrefix
@@ -583,6 +638,19 @@ function createRawPrimitiveArrowVector(
     start,
     end
   );
+  const expandedData = directData
+    ? undefined
+    : createExpandedRawPrimitiveArrowArrayView(arrowType, parquetField, columnData, start, end);
+  if (expandedData) {
+    return new arrow.Vector([
+      arrow.makeData({
+        type: arrowType,
+        data: expandedData.data,
+        nullBitmap: expandedData.nullBitmap,
+        nullCount: expandedData.nullCount
+      } as any)
+    ]);
+  }
   const data = directData || createRawPrimitiveArrowArray(arrowType, parquetField, rowCount);
   if (!data) {
     return undefined;
@@ -622,6 +690,58 @@ function createRawPrimitiveArrowVector(
   ]);
 }
 
+/**
+ * Expands a full nullable primitive column in place into the decoder's row-capacity buffer.
+ *
+ * Parquet omits physical values for null rows, but the decoder allocates from the column's level
+ * count. Walking backwards makes the overlapping expansion safe while building Arrow validity.
+ */
+function createExpandedRawPrimitiveArrowArrayView(
+  arrowType: arrow.DataType,
+  parquetField: ParquetField,
+  columnData: ParquetColumnChunk,
+  start: number,
+  end: number
+):
+  | {data: RawPrimitiveArrowArray; nullBitmap: Uint8Array | undefined; nullCount: number}
+  | undefined {
+  if (
+    parquetField.repetitionType !== 'OPTIONAL' ||
+    parquetField.rLevelMax !== 0 ||
+    start !== 0 ||
+    end !== columnData.count
+  ) {
+    return undefined;
+  }
+  const compactData = getMatchingRawPrimitiveArrowArray(arrowType, parquetField, columnData.values);
+  if (!compactData) {
+    return undefined;
+  }
+  if (columnData.nullCount === 0 && compactData.length === end) {
+    return {data: compactData, nullBitmap: undefined, nullCount: 0};
+  }
+  const data = createRawPrimitiveCapacityView(compactData, end);
+  if (!data) {
+    return undefined;
+  }
+
+  const nullBitmap = new Uint8Array(Math.ceil(end / 8));
+  let valueIndex = compactData.length - 1;
+  let nullCount = 0;
+  for (let rowIndex = end - 1; rowIndex >= 0; rowIndex--) {
+    if (columnData.dlevels[rowIndex] === parquetField.dLevelMax) {
+      setRawPrimitiveArrowValue(data, rowIndex, compactData[valueIndex--]);
+      nullBitmap[rowIndex >> 3] |= 1 << (rowIndex & 7);
+    } else {
+      nullCount++;
+    }
+  }
+  if (valueIndex !== -1) {
+    throw new Error(`Parquet column ${parquetField.name} has inconsistent definition levels`);
+  }
+  return {data, nullBitmap: nullCount ? nullBitmap : undefined, nullCount};
+}
+
 /** Reuses a typed decoded column as the Arrow value buffer for required primitive fields. */
 function createRawPrimitiveArrowArrayView(
   arrowType: arrow.DataType,
@@ -633,20 +753,29 @@ function createRawPrimitiveArrowArrayView(
   if (parquetField.repetitionType !== 'REQUIRED') {
     return undefined;
   }
-  const values = columnData.values;
+  const values = getMatchingRawPrimitiveArrowArray(arrowType, parquetField, columnData.values);
+  return values?.subarray(start, end) as RawPrimitiveArrowArray | undefined;
+}
+
+/** Returns a decoded typed value buffer when it exactly matches the target Arrow representation. */
+function getMatchingRawPrimitiveArrowArray(
+  arrowType: arrow.DataType,
+  parquetField: ParquetField,
+  values: ParquetColumnChunk['values']
+): RawPrimitiveArrowArray | undefined {
   if (
     parquetField.primitiveType === 'FLOAT' &&
     arrowType instanceof arrow.Float32 &&
     values instanceof Float32Array
   ) {
-    return values.subarray(start, end);
+    return values;
   }
   if (
     parquetField.primitiveType === 'DOUBLE' &&
     arrowType instanceof arrow.Float64 &&
     values instanceof Float64Array
   ) {
-    return values.subarray(start, end);
+    return values;
   }
   if (
     parquetField.primitiveType === 'INT32' &&
@@ -655,7 +784,7 @@ function createRawPrimitiveArrowArrayView(
       arrowType instanceof arrow.TimeMillisecond) &&
     values instanceof Int32Array
   ) {
-    return values.subarray(start, end);
+    return values;
   }
   if (
     parquetField.primitiveType === 'INT64' &&
@@ -667,16 +796,44 @@ function createRawPrimitiveArrowArrayView(
       arrowType instanceof arrow.TimestampNanosecond) &&
     values instanceof BigInt64Array
   ) {
-    return values.subarray(start, end);
+    return values;
   }
   if (
     parquetField.primitiveType === 'INT96' &&
     arrowType instanceof arrow.TimestampNanosecond &&
     values instanceof BigInt64Array
   ) {
-    return values.subarray(start, end);
+    return values;
   }
   return undefined;
+}
+
+/** Creates a larger view over the unused capacity retained by a compact decoder buffer. */
+function createRawPrimitiveCapacityView(
+  values: RawPrimitiveArrowArray,
+  length: number
+): RawPrimitiveArrowArray | undefined {
+  if (values.buffer.byteLength - values.byteOffset < length * values.BYTES_PER_ELEMENT) {
+    return undefined;
+  }
+  if (values instanceof Float32Array) {
+    return new Float32Array(values.buffer, values.byteOffset, length);
+  }
+  if (values instanceof Float64Array) {
+    return new Float64Array(values.buffer, values.byteOffset, length);
+  }
+  if (values instanceof Int8Array) return new Int8Array(values.buffer, values.byteOffset, length);
+  if (values instanceof Int16Array) return new Int16Array(values.buffer, values.byteOffset, length);
+  if (values instanceof Int32Array) return new Int32Array(values.buffer, values.byteOffset, length);
+  if (values instanceof Uint8Array) return new Uint8Array(values.buffer, values.byteOffset, length);
+  if (values instanceof Uint16Array)
+    return new Uint16Array(values.buffer, values.byteOffset, length);
+  if (values instanceof Uint32Array)
+    return new Uint32Array(values.buffer, values.byteOffset, length);
+  if (values instanceof BigInt64Array) {
+    return new BigInt64Array(values.buffer, values.byteOffset, length);
+  }
+  return new BigUint64Array(values.buffer, values.byteOffset, length);
 }
 
 /** Allocates the Arrow typed array matching an unconverted physical Parquet primitive. */
@@ -763,6 +920,9 @@ function createRawByteArrowVector(
   if (!columnData || !supportsRawByteArrowVector(arrowType, parquetField)) {
     return undefined;
   }
+  if (columnData.byteArrayData) {
+    return createBufferedByteArrowVector(arrowType, parquetField, columnData, start, end);
+  }
 
   const rowCount = end - start;
   const valueOffsets = new Int32Array(rowCount + 1);
@@ -805,17 +965,38 @@ function createRawByteArrowVector(
     }
   }
 
-  const data = new Uint8Array(dataByteLength);
-  let dataOffset = 0;
-  for (let index = firstValueIndex; index < valueIndex; index++) {
-    const bytes = byteValues[index];
-    if (bytes.byteLength <= MAXIMUM_INLINE_BYTE_COPY_LENGTH) {
-      for (let byteIndex = 0; byteIndex < bytes.byteLength; byteIndex++) {
-        data[dataOffset++] = bytes[byteIndex];
+  const contiguousData = getContiguousFixedByteArrayData(
+    parquetField,
+    columnData,
+    byteValues,
+    firstValueIndex,
+    valueIndex,
+    dataByteLength
+  );
+  const data = contiguousData || new Uint8Array(dataByteLength);
+  if (!contiguousData) {
+    const dataView = new DataView(data.buffer, data.byteOffset, data.byteLength);
+    let dataOffset = 0;
+    for (let index = firstValueIndex; index < valueIndex; index++) {
+      const bytes = byteValues[index];
+      if (bytes.byteLength >= 4 && bytes.byteLength <= MAXIMUM_INLINE_BYTE_COPY_LENGTH) {
+        dataView.setUint32(
+          dataOffset,
+          bytes[0] | (bytes[1] << 8) | (bytes[2] << 16) | (bytes[3] << 24),
+          true
+        );
+        dataOffset += 4;
+        for (let byteIndex = 4; byteIndex < bytes.byteLength; byteIndex++) {
+          data[dataOffset++] = bytes[byteIndex];
+        }
+      } else if (bytes.byteLength <= MAXIMUM_INLINE_BYTE_COPY_LENGTH) {
+        for (let byteIndex = 0; byteIndex < bytes.byteLength; byteIndex++) {
+          data[dataOffset++] = bytes[byteIndex];
+        }
+      } else {
+        data.set(bytes, dataOffset);
+        dataOffset += bytes.byteLength;
       }
-    } else {
-      data.set(bytes, dataOffset);
-      dataOffset += bytes.byteLength;
     }
   }
 
@@ -845,6 +1026,105 @@ function createRawByteArrowVector(
   return undefined;
 }
 
+/** Creates a flat Arrow Utf8/Binary vector from the decoder's compact physical byte buffer. */
+function createBufferedByteArrowVector(
+  arrowType: arrow.DataType,
+  parquetField: ParquetField,
+  columnData: ParquetColumnChunk,
+  start: number,
+  end: number
+): arrow.Vector {
+  const byteArrayData = columnData.byteArrayData!;
+  const rowCount = end - start;
+  const nullBitmap = parquetField.dLevelMax ? new Uint8Array(Math.ceil(rowCount / 8)) : undefined;
+  let sourceValueIndex = 0;
+  let nullCount = 0;
+
+  if (!nullBitmap) {
+    sourceValueIndex = start;
+  } else {
+    for (let rowIndex = 0; rowIndex < start; rowIndex++) {
+      if (columnData.dlevels[rowIndex] === parquetField.dLevelMax) sourceValueIndex++;
+    }
+  }
+  const firstValueIndex = sourceValueIndex;
+  const canReuseOffsets = !nullBitmap && start === 0 && end === columnData.count;
+  const valueOffsets = canReuseOffsets ? byteArrayData.valueOffsets : new Int32Array(rowCount + 1);
+  let dataByteLength = 0;
+
+  if (!canReuseOffsets) {
+    for (let rowIndex = 0; rowIndex < rowCount; rowIndex++) {
+      const sourceRowIndex = start + rowIndex;
+      if (!nullBitmap || columnData.dlevels[sourceRowIndex] === parquetField.dLevelMax) {
+        dataByteLength +=
+          byteArrayData.valueOffsets[sourceValueIndex + 1] -
+          byteArrayData.valueOffsets[sourceValueIndex];
+        sourceValueIndex++;
+        if (nullBitmap) nullBitmap[rowIndex >> 3] |= 1 << (rowIndex & 7);
+      } else {
+        nullCount++;
+      }
+      valueOffsets[rowIndex + 1] = dataByteLength;
+    }
+  } else {
+    sourceValueIndex = end;
+    dataByteLength = byteArrayData.valueOffsets[sourceValueIndex];
+  }
+
+  const firstByteOffset = byteArrayData.valueOffsets[firstValueIndex];
+  const lastByteOffset = byteArrayData.valueOffsets[sourceValueIndex];
+  const data = byteArrayData.data.subarray(firstByteOffset, lastByteOffset);
+  return new arrow.Vector([
+    arrow.makeData({
+      type: arrowType,
+      valueOffsets,
+      data,
+      nullBitmap: nullCount ? nullBitmap : undefined,
+      nullCount
+    } as any)
+  ]);
+}
+
+/**
+ * Reuses one PLAIN page's contiguous fixed-width payload as Arrow Binary data.
+ *
+ * A single FIXED_LEN_BYTE_ARRAY page has no length prefixes between physical values. The decoder
+ * retains each value as a view into that page, so Arrow can retain the complete span instead of
+ * allocating and copying every value into another buffer.
+ */
+function getContiguousFixedByteArrayData(
+  parquetField: ParquetField,
+  columnData: ParquetColumnChunk,
+  byteValues: Uint8Array[],
+  firstValueIndex: number,
+  valueEndIndex: number,
+  dataByteLength: number
+): Uint8Array | undefined {
+  const valueCount = valueEndIndex - firstValueIndex;
+  const typeLength = parquetField.typeLength;
+  if (
+    parquetField.primitiveType !== 'FIXED_LEN_BYTE_ARRAY' ||
+    !typeLength ||
+    columnData.pageHeaders.length !== 1 ||
+    valueCount === 0 ||
+    dataByteLength !== valueCount * typeLength
+  ) {
+    return undefined;
+  }
+
+  const firstValue = byteValues[firstValueIndex];
+  const lastValue = byteValues[valueEndIndex - 1];
+  if (
+    firstValue.byteLength !== typeLength ||
+    lastValue.byteLength !== typeLength ||
+    firstValue.buffer !== lastValue.buffer ||
+    lastValue.byteOffset + typeLength !== firstValue.byteOffset + dataByteLength
+  ) {
+    return undefined;
+  }
+  return new Uint8Array(firstValue.buffer, firstValue.byteOffset, dataByteLength);
+}
+
 /** Returns whether one flat Parquet byte column maps directly to Arrow Utf8 or Binary. */
 function supportsRawByteArrowVector(
   arrowType: arrow.DataType,
@@ -856,6 +1136,10 @@ function supportsRawByteArrowVector(
   if (arrowType instanceof arrow.Binary) {
     return (
       (!parquetField.originalType ||
+        parquetField.originalType === 'JSON' ||
+        parquetField.originalType === 'BSON' ||
+        parquetField.originalType === 'INTERVAL' ||
+        parquetField.originalType === 'VARIANT' ||
         parquetField.originalType === 'GEOMETRY' ||
         parquetField.originalType === 'GEOGRAPHY') &&
       (parquetField.primitiveType === 'BYTE_ARRAY' ||

--- a/modules/parquet/src/lib/parsers/parse-parquet-to-json.ts
+++ b/modules/parquet/src/lib/parsers/parse-parquet-to-json.ts
@@ -27,6 +27,10 @@ export async function parseParquetFile(
   const reader = new ParquetReader(file, {
     preserveBinary: options?.parquet?.preserveBinary,
     int96AsTimestamp: options?.parquet?.int96AsTimestamp,
+    retainByteArrayViews: true,
+    useTypedValueBuffers: true,
+    useTypedLevelBuffers: true,
+    useArrowByteArrayBuffers: true,
     verifyFooterSignature: options?.parquet?.verifyFooterSignature,
     keyRetriever: options?.parquet?.keyRetriever,
     aadPrefix: options?.parquet?.aadPrefix
@@ -84,6 +88,10 @@ export async function* parseParquetFileInBatches(
   const reader = new ParquetReader(file, {
     preserveBinary: options?.parquet?.preserveBinary,
     int96AsTimestamp: options?.parquet?.int96AsTimestamp,
+    retainByteArrayViews: true,
+    useTypedValueBuffers: true,
+    useTypedLevelBuffers: true,
+    useArrowByteArrayBuffers: true,
     verifyFooterSignature: options?.parquet?.verifyFooterSignature,
     keyRetriever: options?.parquet?.keyRetriever,
     aadPrefix: options?.parquet?.aadPrefix

--- a/modules/parquet/src/parquetjs/codecs/declare.ts
+++ b/modules/parquet/src/parquetjs/codecs/declare.ts
@@ -17,6 +17,29 @@ export type ParquetValueBuffer =
   | Float32Array
   | Float64Array;
 
+/** Mutable Arrow-compatible destination for compact physical BYTE_ARRAY values. */
+export type ParquetByteArrayOutput = {
+  /** Contiguous bytes copied from decoded physical values. */
+  data: Uint8Array;
+  /** Arrow-compatible offsets for compact non-null physical values. */
+  valueOffsets: Int32Array;
+  /** Number of bytes written to `data`. */
+  byteLength: number;
+};
+
+/** Ensures a compact byte destination can accept an additional physical value. */
+export function reserveParquetByteArrayOutput(
+  output: ParquetByteArrayOutput,
+  additionalByteLength: number
+): void {
+  const requiredByteLength = output.byteLength + additionalByteLength;
+  if (requiredByteLength <= output.data.byteLength) return;
+  const nextByteLength = Math.max(requiredByteLength, output.data.byteLength * 2, 1024);
+  const data = new Uint8Array(nextByteLength);
+  data.set(output.data.subarray(0, output.byteLength));
+  output.data = data;
+}
+
 export interface CursorBuffer {
   buffer: Uint8Array;
   offset: number;
@@ -35,6 +58,8 @@ export interface ParquetCodecOptions {
   outputOffset?: number;
   /** Optional dictionary resolved while decoding dictionary indices. */
   dictionary?: readonly unknown[];
+  /** Optional compact destination used by PLAIN BYTE_ARRAY decoding. */
+  byteArrayOutput?: ParquetByteArrayOutput;
   /** Preserve decoded INT64 values as bigint instead of converting them to number. */
   int64AsBigInt?: boolean;
   /** Decode legacy INT96 physical values as epoch nanoseconds instead of raw numbers. */

--- a/modules/parquet/src/parquetjs/codecs/delta.ts
+++ b/modules/parquet/src/parquetjs/codecs/delta.ts
@@ -7,6 +7,7 @@ import type {PrimitiveType} from '../schema/declare';
 import {concatUint8Arrays, copyUint8Array, toUint8Array} from '../utils/binary-utils';
 import {
   getParquetValueOutput,
+  reserveParquetByteArrayOutput,
   type CursorBuffer,
   type ParquetCodecOptions,
   type ParquetValueBuffer
@@ -15,6 +16,8 @@ import {
 const DELTA_BLOCK_SIZE = 128;
 const DELTA_MINI_BLOCK_COUNT = 4;
 const DELTA_VALUES_PER_MINI_BLOCK = DELTA_BLOCK_SIZE / DELTA_MINI_BLOCK_COUNT;
+const UINT32_BASE = 0x1_0000_0000;
+const IS_LITTLE_ENDIAN = new Uint8Array(new Uint16Array([1]).buffer)[0] === 1;
 
 /** Encodes INT32 or INT64 values using Parquet DELTA_BINARY_PACKED. */
 export function encodeDeltaBinaryPackedValues(
@@ -264,6 +267,31 @@ function decodeDeltaBinaryPackedInt32Values(
   while (outputIndex < count) {
     const minimumDelta = readZigZagVarInt32(cursor);
     const bitWidths = readBitWidths(cursor, miniBlockCount, 32);
+    const activeMiniBlockCount = Math.min(
+      miniBlockCount,
+      Math.ceil((count - outputIndex) / valuesPerMiniBlock)
+    );
+    // Writers commonly select one width for every mini-block in a block. Fuse that contiguous
+    // bitstream so the decoder pays call/state setup once instead of once per 32 values.
+    if (haveEqualBitWidths(bitWidths, activeMiniBlockCount)) {
+      const bitWidth = bitWidths[0];
+      const valueCount = Math.min(valuesPerMiniBlock * activeMiniBlockCount, count - outputIndex);
+      const packedByteLength = (valuesPerMiniBlock * activeMiniBlockCount * bitWidth) / 8;
+      assertReadable(cursor, packedByteLength);
+      value = decodeInt32MiniBlock(
+        cursor.buffer,
+        cursor.offset,
+        bitWidth,
+        valueCount,
+        minimumDelta,
+        value,
+        output,
+        outputOffset + outputIndex
+      );
+      outputIndex += valueCount;
+      cursor.offset += packedByteLength;
+      continue;
+    }
     for (const bitWidth of bitWidths) {
       const packedOffset = cursor.offset;
       const packedByteLength = (valuesPerMiniBlock * bitWidth) / 8;
@@ -310,6 +338,26 @@ function decodeInt32MiniBlock(
     return value;
   }
 
+  if (bitWidth <= 24) {
+    // Bitwise reservoirs stay exact through 24 bits and are substantially cheaper than the
+    // division-based reservoir required for wider INT32 deltas.
+    const mask = 2 ** bitWidth - 1;
+    let packedBits = 0;
+    let packedBitCount = 0;
+    let byteOffset = packedOffset;
+    for (let index = 0; index < count; index++) {
+      while (packedBitCount < bitWidth) {
+        packedBits |= buffer[byteOffset++] << packedBitCount;
+        packedBitCount += 8;
+      }
+      value = (value + minimumDelta + (packedBits & mask)) | 0;
+      output[outputOffset + index] = value;
+      packedBits >>>= bitWidth;
+      packedBitCount -= bitWidth;
+    }
+    return value;
+  }
+
   const divisor = 2 ** bitWidth;
   let packedBits = 0;
   let packedBitCount = 0;
@@ -337,6 +385,21 @@ function decodeDeltaBinaryPackedInt64Values(
   options: ParquetCodecOptions
 ): ParquetValueBuffer {
   const {output, outputOffset} = getParquetValueOutput(options, count);
+  if (options.int64AsBigInt && output instanceof BigInt64Array) {
+    // BigInt arithmetic per value is expensive in V8. Decode into the two uint32 words backing
+    // Arrow Int64 instead; modulo-64 addition preserves every signed INT64 bit pattern exactly.
+    const state = new Uint32Array(2);
+    readZigZagVarIntWords(cursor, state);
+    return decodeDeltaBinaryPackedInt64ArrowValues(
+      cursor,
+      count,
+      miniBlockCount,
+      valuesPerMiniBlock,
+      output,
+      outputOffset,
+      state
+    );
+  }
   let value = readZigZagVarInt(cursor);
   let outputIndex = 0;
   writeInt64Output(output, outputOffset + outputIndex++, value, options.int64AsBigInt);
@@ -369,6 +432,254 @@ function decodeDeltaBinaryPackedInt64Values(
   }
 
   return output;
+}
+
+/** Decodes INT64 directly into Arrow storage with modulo-64 two-word arithmetic. */
+function decodeDeltaBinaryPackedInt64ArrowValues(
+  cursor: CursorBuffer,
+  count: number,
+  miniBlockCount: number,
+  valuesPerMiniBlock: number,
+  output: BigInt64Array,
+  outputOffset: number,
+  state: Uint32Array
+): BigInt64Array {
+  const outputWords = new Uint32Array(output.buffer, output.byteOffset, output.length * 2);
+  const minimumDeltaWords = new Uint32Array(2);
+  let outputIndex = 0;
+  writeInt64Words(outputWords, outputOffset + outputIndex++, state[0], state[1]);
+
+  while (outputIndex < count) {
+    readZigZagVarIntWords(cursor, minimumDeltaWords);
+    const bitWidths = readBitWidths(cursor, miniBlockCount, 64);
+    const activeMiniBlockCount = Math.min(
+      miniBlockCount,
+      Math.ceil((count - outputIndex) / valuesPerMiniBlock)
+    );
+    // Preserve the equal-width fusion used by the wide-column benchmark. Splitting this back into
+    // four mini-block calls repeats state loads/stores and loses measurable throughput.
+    if (haveEqualBitWidths(bitWidths, activeMiniBlockCount)) {
+      const bitWidth = bitWidths[0];
+      const valueCount = Math.min(valuesPerMiniBlock * activeMiniBlockCount, count - outputIndex);
+      const packedByteLength = (valuesPerMiniBlock * activeMiniBlockCount * bitWidth) / 8;
+      assertReadable(cursor, packedByteLength);
+      decodeInt64ArrowMiniBlock(
+        cursor.buffer,
+        cursor.offset,
+        bitWidth,
+        valueCount,
+        minimumDeltaWords[0],
+        minimumDeltaWords[1],
+        state,
+        outputWords,
+        outputOffset + outputIndex
+      );
+      outputIndex += valueCount;
+      cursor.offset += packedByteLength;
+      continue;
+    }
+    for (const bitWidth of bitWidths) {
+      const packedOffset = cursor.offset;
+      const packedByteLength = (valuesPerMiniBlock * bitWidth) / 8;
+      assertReadable(cursor, packedByteLength);
+      const valueCount = Math.min(valuesPerMiniBlock, count - outputIndex);
+      decodeInt64ArrowMiniBlock(
+        cursor.buffer,
+        packedOffset,
+        bitWidth,
+        valueCount,
+        minimumDeltaWords[0],
+        minimumDeltaWords[1],
+        state,
+        outputWords,
+        outputOffset + outputIndex
+      );
+      outputIndex += valueCount;
+      cursor.offset += packedByteLength;
+      if (outputIndex === count) break;
+    }
+  }
+  return output;
+}
+
+/** Returns whether all mini-blocks in one DELTA_BINARY_PACKED block use one bit width. */
+function haveEqualBitWidths(bitWidths: Uint8Array, count: number): boolean {
+  const firstBitWidth = bitWidths[0];
+  for (let index = 1; index < count; index++) {
+    if (bitWidths[index] !== firstBitWidth) return false;
+  }
+  return true;
+}
+
+/** Decodes one INT64 mini-block directly into the two 32-bit words backing Arrow Int64. */
+function decodeInt64ArrowMiniBlock(
+  buffer: Uint8Array,
+  packedOffset: number,
+  bitWidth: number,
+  count: number,
+  minimumDeltaLow: number,
+  minimumDeltaHigh: number,
+  state: Uint32Array,
+  outputWords: Uint32Array,
+  outputOffset: number
+): void {
+  let stateLow = state[0];
+  let stateHigh = state[1];
+  const lowWordOffset = IS_LITTLE_ENDIAN ? 0 : 1;
+  const highWordOffset = IS_LITTLE_ENDIAN ? 1 : 0;
+
+  if (bitWidth === 0) {
+    for (let index = 0; index < count; index++) {
+      const lowSum = stateLow + minimumDeltaLow;
+      stateLow = lowSum >>> 0;
+      // V8 strength-reduces division by this constant; explicit carry branches benchmark slower.
+      stateHigh = (stateHigh + minimumDeltaHigh + Math.floor(lowSum / UINT32_BASE)) >>> 0;
+      const wordOffset = (outputOffset + index) * 2;
+      outputWords[wordOffset + lowWordOffset] = stateLow;
+      outputWords[wordOffset + highWordOffset] = stateHigh;
+    }
+    state[0] = stateLow;
+    state[1] = stateHigh;
+    return;
+  }
+
+  if (bitWidth <= 24) {
+    decodeNarrowInt64ArrowMiniBlock(
+      buffer,
+      packedOffset,
+      bitWidth,
+      count,
+      minimumDeltaLow,
+      minimumDeltaHigh,
+      state,
+      outputWords,
+      outputOffset
+    );
+    return;
+  }
+
+  if (bitWidth <= 45) {
+    const divisor = 2 ** bitWidth;
+    let packedBits = 0;
+    let packedBitCount = 0;
+    let byteOffset = packedOffset;
+    for (let index = 0; index < count; index++) {
+      while (packedBitCount < bitWidth) {
+        packedBits += buffer[byteOffset++] * 2 ** packedBitCount;
+        packedBitCount += 8;
+      }
+      const packedDelta = packedBits % divisor;
+      packedBits = Math.floor(packedBits / divisor);
+      packedBitCount -= bitWidth;
+      const packedDeltaLow = packedDelta >>> 0;
+      const packedDeltaHigh = Math.floor(packedDelta / UINT32_BASE);
+      const lowSum = stateLow + minimumDeltaLow + packedDeltaLow;
+      stateLow = lowSum >>> 0;
+      // V8 strength-reduces division by this constant; explicit carry branches benchmark slower.
+      stateHigh =
+        (stateHigh + minimumDeltaHigh + packedDeltaHigh + Math.floor(lowSum / UINT32_BASE)) >>> 0;
+      const wordOffset = (outputOffset + index) * 2;
+      outputWords[wordOffset + lowWordOffset] = stateLow;
+      outputWords[wordOffset + highWordOffset] = stateHigh;
+    }
+    state[0] = stateLow;
+    state[1] = stateHigh;
+    return;
+  }
+
+  const highBitWidth = bitWidth - 32;
+  const highMask = highBitWidth === 32 ? 0xffff_ffff : 2 ** highBitWidth - 1;
+  for (let index = 0; index < count; index++) {
+    const packedBitOffset = index * bitWidth;
+    const byteOffset = packedOffset + Math.floor(packedBitOffset / 8);
+    const shift = packedBitOffset & 7;
+    const lowerWord = readUint32LELoose(buffer, byteOffset);
+    const middleWord = readUint32LELoose(buffer, byteOffset + 4);
+    let packedDeltaLow: number;
+    let packedDeltaHigh: number;
+    if (shift === 0) {
+      packedDeltaLow = lowerWord;
+      packedDeltaHigh = middleWord & highMask;
+    } else {
+      const upperByte = buffer[byteOffset + 8] ?? 0;
+      packedDeltaLow = ((lowerWord >>> shift) | (middleWord << (32 - shift))) >>> 0;
+      packedDeltaHigh = ((middleWord >>> shift) | (upperByte << (32 - shift))) & highMask;
+    }
+    const lowSum = stateLow + minimumDeltaLow + packedDeltaLow;
+    stateLow = lowSum >>> 0;
+    // V8 strength-reduces division by this constant; explicit carry branches benchmark slower.
+    stateHigh =
+      (stateHigh + minimumDeltaHigh + packedDeltaHigh + Math.floor(lowSum / UINT32_BASE)) >>> 0;
+    const wordOffset = (outputOffset + index) * 2;
+    outputWords[wordOffset + lowWordOffset] = stateLow;
+    outputWords[wordOffset + highWordOffset] = stateHigh;
+  }
+  state[0] = stateLow;
+  state[1] = stateHigh;
+}
+
+/** Decodes an INT64 mini-block whose packed deltas fit a 32-bit bit reservoir. */
+function decodeNarrowInt64ArrowMiniBlock(
+  buffer: Uint8Array,
+  packedOffset: number,
+  bitWidth: number,
+  count: number,
+  minimumDeltaLow: number,
+  minimumDeltaHigh: number,
+  state: Uint32Array,
+  outputWords: Uint32Array,
+  outputOffset: number
+): void {
+  const mask = 2 ** bitWidth - 1;
+  const lowWordOffset = IS_LITTLE_ENDIAN ? 0 : 1;
+  const highWordOffset = IS_LITTLE_ENDIAN ? 1 : 0;
+  let stateLow = state[0];
+  let stateHigh = state[1];
+  let packedBits = 0;
+  let packedBitCount = 0;
+  let byteOffset = packedOffset;
+
+  for (let index = 0; index < count; index++) {
+    while (packedBitCount < bitWidth) {
+      packedBits |= buffer[byteOffset++] << packedBitCount;
+      packedBitCount += 8;
+    }
+    const packedDelta = packedBits & mask;
+    packedBits >>>= bitWidth;
+    packedBitCount -= bitWidth;
+    const lowSum = stateLow + minimumDeltaLow + packedDelta;
+    stateLow = lowSum >>> 0;
+    // V8 strength-reduces division by this constant; explicit carry branches benchmark slower.
+    stateHigh = (stateHigh + minimumDeltaHigh + Math.floor(lowSum / UINT32_BASE)) >>> 0;
+    const wordOffset = (outputOffset + index) * 2;
+    outputWords[wordOffset + lowWordOffset] = stateLow;
+    outputWords[wordOffset + highWordOffset] = stateHigh;
+  }
+  state[0] = stateLow;
+  state[1] = stateHigh;
+}
+
+/** Reads an unaligned little-endian word, treating bytes beyond a mini-block as zero. */
+function readUint32LELoose(buffer: Uint8Array, offset: number): number {
+  return (
+    ((buffer[offset] ?? 0) |
+      ((buffer[offset + 1] ?? 0) << 8) |
+      ((buffer[offset + 2] ?? 0) << 16) |
+      ((buffer[offset + 3] ?? 0) << 24)) >>>
+    0
+  );
+}
+
+/** Writes one pair of 32-bit words into a platform-endian BigInt64Array backing buffer. */
+function writeInt64Words(
+  outputWords: Uint32Array,
+  outputIndex: number,
+  low: number,
+  high: number
+): void {
+  const wordOffset = outputIndex * 2;
+  outputWords[wordOffset + (IS_LITTLE_ENDIAN ? 0 : 1)] = low;
+  outputWords[wordOffset + (IS_LITTLE_ENDIAN ? 1 : 0)] = high;
 }
 
 /** Decodes one INT64 mini-block, using numbers whenever the packed value remains exact. */
@@ -457,12 +768,47 @@ export function decodeDeltaLengthByteArrayValues(
   options: ParquetCodecOptions
 ): ParquetValueBuffer {
   assertByteArrayType(type, 'DELTA_LENGTH_BYTE_ARRAY');
-  const lengths = decodeDeltaBinaryPackedValues('INT32', cursor, count, {});
+  const lengths = new Int32Array(count);
+  decodeDeltaBinaryPackedValues('INT32', cursor, count, {output: lengths});
+  if (options.byteArrayOutput) {
+    return decodeDeltaLengthByteArraysToContiguousOutput(cursor, lengths, options);
+  }
   const {output, outputOffset} = getParquetValueOutput(options, count);
   for (let index = 0; index < count; index++) {
-    output[outputOffset + index] = readByteArray(cursor, Number(lengths[index]));
+    output[outputOffset + index] = readByteArray(cursor, lengths[index]);
   }
   return output;
+}
+
+/** Copies DELTA_LENGTH_BYTE_ARRAY's contiguous payload directly into an Arrow byte buffer. */
+function decodeDeltaLengthByteArraysToContiguousOutput(
+  cursor: CursorBuffer,
+  lengths: Int32Array,
+  options: ParquetCodecOptions
+): ParquetValueBuffer {
+  const byteArrayOutput = options.byteArrayOutput!;
+  const outputOffset = options.outputOffset || 0;
+  let payloadByteLength = 0;
+  for (const length of lengths) {
+    if (length < 0) {
+      throw new Error(`Invalid delta byte-array length ${length}`);
+    }
+    payloadByteLength += length;
+  }
+  assertReadable(cursor, payloadByteLength);
+  reserveParquetByteArrayOutput(byteArrayOutput, payloadByteLength);
+
+  let byteOffset = byteArrayOutput.byteLength;
+  byteArrayOutput.valueOffsets[outputOffset] = byteOffset;
+  const payloadEnd = cursor.offset + payloadByteLength;
+  byteArrayOutput.data.set(cursor.buffer.subarray(cursor.offset, payloadEnd), byteOffset);
+  cursor.offset = payloadEnd;
+  for (let valueIndex = 0; valueIndex < lengths.length; valueIndex++) {
+    byteOffset += lengths[valueIndex];
+    byteArrayOutput.valueOffsets[outputOffset + valueIndex + 1] = byteOffset;
+  }
+  byteArrayOutput.byteLength = byteOffset;
+  return options.output || [];
 }
 
 /** Decodes prefix lengths and delta-length suffixes into complete byte-array values. */
@@ -473,17 +819,25 @@ export function decodeDeltaByteArrayValues(
   options: ParquetCodecOptions
 ): ParquetValueBuffer {
   assertByteArrayType(type, 'DELTA_BYTE_ARRAY');
-  const prefixLengths = decodeDeltaBinaryPackedValues('INT32', cursor, count, {});
-  const suffixes = decodeDeltaLengthByteArrayValues(type, cursor, count, {});
+  // One combined allocation is faster than separate prefix/suffix buffers in V8. Keep the two
+  // subarray views: reusing Arrow offsets as scratch storage deoptimizes reconstruction.
+  const lengths = new Int32Array(count * 2);
+  const prefixLengths = lengths.subarray(0, count);
+  const suffixLengths = lengths.subarray(count);
+  decodeDeltaBinaryPackedValues('INT32', cursor, count, {output: prefixLengths});
+  decodeDeltaBinaryPackedValues('INT32', cursor, count, {output: suffixLengths});
+  if (options.byteArrayOutput) {
+    return decodeDeltaByteArraysToContiguousOutput(cursor, prefixLengths, suffixLengths, options);
+  }
   const {output, outputOffset} = getParquetValueOutput(options, count);
   let previousValue: Uint8Array | undefined;
 
   for (let index = 0; index < count; index++) {
-    const prefixLength = Number(prefixLengths[index]);
-    const suffix = suffixes[index] as Uint8Array;
+    const prefixLength = prefixLengths[index];
     if (prefixLength < 0 || (prefixLength > 0 && prefixLength > (previousValue?.length || 0))) {
       throw new Error(`Invalid DELTA_BYTE_ARRAY prefix length ${prefixLength}`);
     }
+    const suffix = readByteArray(cursor, suffixLengths[index]);
     if (prefixLength === 0) {
       output[outputOffset + index] = suffix;
       previousValue = suffix;
@@ -499,6 +853,76 @@ export function decodeDeltaByteArrayValues(
   return output;
 }
 
+/** Reconstructs DELTA_BYTE_ARRAY values directly in one Arrow-compatible byte buffer. */
+function decodeDeltaByteArraysToContiguousOutput(
+  cursor: CursorBuffer,
+  prefixLengths: Int32Array,
+  suffixLengths: Int32Array,
+  options: ParquetCodecOptions
+): ParquetValueBuffer {
+  const byteArrayOutput = options.byteArrayOutput!;
+  const outputOffset = options.outputOffset || 0;
+  let byteOffset = byteArrayOutput.byteLength;
+  let previousValueOffset = byteOffset;
+  let previousValueLength = 0;
+  byteArrayOutput.valueOffsets[outputOffset] = byteOffset;
+
+  let requiredByteLength = 0;
+  let requiredSuffixByteLength = 0;
+  for (let valueIndex = 0; valueIndex < prefixLengths.length; valueIndex++) {
+    const prefixLength = prefixLengths[valueIndex];
+    const suffixLength = suffixLengths[valueIndex];
+    if (prefixLength < 0 || prefixLength > previousValueLength) {
+      throw new Error(`Invalid DELTA_BYTE_ARRAY prefix length ${prefixLength}`);
+    }
+    if (suffixLength < 0) {
+      throw new Error(`Invalid delta byte-array length ${suffixLength}`);
+    }
+    previousValueLength = prefixLength + suffixLength;
+    requiredByteLength += previousValueLength;
+    requiredSuffixByteLength += suffixLength;
+  }
+  assertReadable(cursor, requiredSuffixByteLength);
+  reserveParquetByteArrayOutput(byteArrayOutput, requiredByteLength);
+
+  const data = byteArrayOutput.data;
+  const valueOffsets = byteArrayOutput.valueOffsets;
+  const inputBuffer = cursor.buffer;
+  let inputOffset = cursor.offset;
+  previousValueLength = 0;
+  for (let valueIndex = 0; valueIndex < prefixLengths.length; valueIndex++) {
+    const prefixLength = prefixLengths[valueIndex];
+    const suffixLength = suffixLengths[valueIndex];
+    const valueLength = prefixLength + suffixLength;
+    if (prefixLength > 0) {
+      if (prefixLength <= 15) {
+        for (let byteIndex = 0; byteIndex < prefixLength; byteIndex++) {
+          data[byteOffset + byteIndex] = data[previousValueOffset + byteIndex];
+        }
+      } else {
+        data.copyWithin(byteOffset, previousValueOffset, previousValueOffset + prefixLength);
+      }
+    }
+    const suffixEnd = inputOffset + suffixLength;
+    if (suffixLength <= 15) {
+      let suffixOutputOffset = byteOffset + prefixLength;
+      while (inputOffset < suffixEnd) {
+        data[suffixOutputOffset++] = inputBuffer[inputOffset++];
+      }
+    } else {
+      data.set(inputBuffer.subarray(inputOffset, suffixEnd), byteOffset + prefixLength);
+      inputOffset = suffixEnd;
+    }
+    previousValueOffset = byteOffset;
+    previousValueLength = valueLength;
+    byteOffset += valueLength;
+    valueOffsets[outputOffset + valueIndex + 1] = byteOffset;
+  }
+  cursor.offset = inputOffset;
+  byteArrayOutput.byteLength = byteOffset;
+  return options.output || [];
+}
+
 /** Reads and validates a sequence of one-byte mini-block bit widths. */
 function readBitWidths(cursor: CursorBuffer, count: number, maximumBitWidth: number): Uint8Array {
   assertReadable(cursor, count);
@@ -510,6 +934,42 @@ function readBitWidths(cursor: CursorBuffer, count: number, maximumBitWidth: num
     }
   }
   return bitWidths;
+}
+
+/** Reads one signed zig-zag INT64 directly into its low and high two's-complement words. */
+function readZigZagVarIntWords(cursor: CursorBuffer, words: Uint32Array): void {
+  let low = 0;
+  let high = 0;
+  for (let byteIndex = 0; byteIndex < 10; byteIndex++) {
+    assertReadable(cursor, 1);
+    const byte = cursor.buffer[cursor.offset++];
+    const payload = byte & 0x7f;
+    const bitOffset = byteIndex * 7;
+    if (byteIndex === 9 && payload > 1) {
+      throw new Error('Invalid Parquet variable-length integer');
+    }
+    if (bitOffset < 32) {
+      low |= payload << bitOffset;
+      if (bitOffset > 25) {
+        high |= payload >>> (32 - bitOffset);
+      }
+    } else {
+      high |= payload << (bitOffset - 32);
+    }
+    if ((byte & 0x80) === 0) {
+      const negative = low & 1;
+      let decodedLow = ((low >>> 1) | ((high & 1) << 31)) >>> 0;
+      let decodedHigh = high >>> 1;
+      if (negative) {
+        decodedLow = ~decodedLow >>> 0;
+        decodedHigh = ~decodedHigh >>> 0;
+      }
+      words[0] = decodedLow;
+      words[1] = decodedHigh;
+      return;
+    }
+  }
+  throw new Error('Invalid Parquet variable-length integer');
 }
 
 /** Reads an unsigned base-128 variable-length integer. */

--- a/modules/parquet/src/parquetjs/codecs/plain.ts
+++ b/modules/parquet/src/parquetjs/codecs/plain.ts
@@ -8,6 +8,7 @@
 import type {PrimitiveType} from '../schema/declare';
 import {
   getParquetValueOutput,
+  reserveParquetByteArrayOutput,
   type CursorBuffer,
   type ParquetCodecOptions,
   type ParquetValueBuffer
@@ -28,6 +29,9 @@ const JULIAN_DAY_UNIX_EPOCH = 2440588n;
 const NANOSECONDS_PER_DAY = 86_400_000_000_000n;
 const INT64_MIN = -(1n << 63n);
 const INT64_MAX = (1n << 63n) - 1n;
+const IS_LITTLE_ENDIAN = new Uint8Array(new Uint16Array([1]).buffer)[0] === 1;
+/** Largest byte value copied inline to avoid a temporary TypedArray view. */
+const MAXIMUM_INLINE_BYTE_COPY_LENGTH = 7;
 
 export function encodeValues(
   type: PrimitiveType,
@@ -123,6 +127,9 @@ function decodeValues_INT32(
   options: ParquetCodecOptions
 ): ParquetValueBuffer {
   const {output, outputOffset} = getParquetValueOutput(options, count);
+  if (output instanceof Int32Array && copyPlainTypedValues(cursor, output, outputOffset, count)) {
+    return output;
+  }
   const dataView = getCursorDataView(cursor);
   for (let i = 0; i < count; i++) {
     output[outputOffset + i] = dataView.getInt32(cursor.offset, true);
@@ -145,6 +152,13 @@ function decodeValues_INT64(
   options: ParquetCodecOptions
 ): ParquetValueBuffer {
   const {output, outputOffset} = getParquetValueOutput(options, count);
+  if (
+    options.int64AsBigInt &&
+    output instanceof BigInt64Array &&
+    copyPlainTypedValues(cursor, output, outputOffset, count)
+  ) {
+    return output;
+  }
   const dataView = getCursorDataView(cursor);
   for (let i = 0; i < count; i++) {
     const value = dataView.getBigInt64(cursor.offset, true);
@@ -232,6 +246,9 @@ function decodeValues_FLOAT(
   options: ParquetCodecOptions
 ): ParquetValueBuffer {
   const {output, outputOffset} = getParquetValueOutput(options, count);
+  if (output instanceof Float32Array && copyPlainTypedValues(cursor, output, outputOffset, count)) {
+    return output;
+  }
   const dataView = getCursorDataView(cursor);
   for (let i = 0; i < count; i++) {
     output[outputOffset + i] = dataView.getFloat32(cursor.offset, true);
@@ -254,6 +271,9 @@ function decodeValues_DOUBLE(
   options: ParquetCodecOptions
 ): ParquetValueBuffer {
   const {output, outputOffset} = getParquetValueOutput(options, count);
+  if (output instanceof Float64Array && copyPlainTypedValues(cursor, output, outputOffset, count)) {
+    return output;
+  }
   const dataView = getCursorDataView(cursor);
   for (let i = 0; i < count; i++) {
     output[outputOffset + i] = dataView.getFloat64(cursor.offset, true);
@@ -285,6 +305,9 @@ function decodeValues_BYTE_ARRAY(
   count: number,
   options: ParquetCodecOptions
 ): ParquetValueBuffer {
+  if (options.byteArrayOutput) {
+    return decodeByteArraysToContiguousOutput(cursor, count, options);
+  }
   const {output, outputOffset} = getParquetValueOutput(options, count);
   const dataView = getCursorDataView(cursor);
   for (let i = 0; i < count; i++) {
@@ -293,6 +316,47 @@ function decodeValues_BYTE_ARRAY(
     output[outputOffset + i] = readByteArray(cursor, len, options.retainByteArrayViews);
   }
   return output;
+}
+
+/** Decodes length-prefixed PLAIN values directly into one Arrow-compatible byte buffer. */
+function decodeByteArraysToContiguousOutput(
+  cursor: CursorBuffer,
+  count: number,
+  options: ParquetCodecOptions
+): ParquetValueBuffer {
+  const byteArrayOutput = options.byteArrayOutput!;
+  const outputOffset = options.outputOffset || 0;
+  const dataView = getCursorDataView(cursor);
+  let byteOffset = byteArrayOutput.byteLength;
+  byteArrayOutput.valueOffsets[outputOffset] = byteOffset;
+  const remainingByteLength = (cursor.size ?? cursor.buffer.byteLength) - cursor.offset;
+  if (remainingByteLength < 0) {
+    throw new Error('PLAIN BYTE_ARRAY cursor exceeds the page buffer');
+  }
+  // PLAIN's remaining encoded bytes are an upper bound for its decoded payload because each value
+  // drops a four-byte length prefix. Reserve once per page instead of checking capacity per value.
+  reserveParquetByteArrayOutput(byteArrayOutput, remainingByteLength);
+  for (let valueIndex = 0; valueIndex < count; valueIndex++) {
+    const byteLength = dataView.getUint32(cursor.offset, true);
+    cursor.offset += 4;
+    const sourceEnd = cursor.offset + byteLength;
+    const destinationEnd = byteOffset + byteLength;
+    if (sourceEnd > (cursor.size ?? cursor.buffer.byteLength)) {
+      throw new Error('PLAIN BYTE_ARRAY value exceeds the page buffer');
+    }
+    if (byteLength <= MAXIMUM_INLINE_BYTE_COPY_LENGTH) {
+      for (let byteIndex = 0; byteIndex < byteLength; byteIndex++) {
+        byteArrayOutput.data[byteOffset + byteIndex] = cursor.buffer[cursor.offset + byteIndex];
+      }
+    } else {
+      byteArrayOutput.data.set(cursor.buffer.subarray(cursor.offset, sourceEnd), byteOffset);
+    }
+    cursor.offset = sourceEnd;
+    byteOffset = destinationEnd;
+    byteArrayOutput.valueOffsets[outputOffset + valueIndex + 1] = byteOffset;
+  }
+  byteArrayOutput.byteLength = byteOffset;
+  return options.output || [];
 }
 
 function encodeValues_FIXED_LEN_BYTE_ARRAY(values: any[], opts: ParquetCodecOptions): Uint8Array {
@@ -313,14 +377,51 @@ function decodeValues_FIXED_LEN_BYTE_ARRAY(
   count: number,
   opts: ParquetCodecOptions
 ): ParquetValueBuffer {
-  const {output, outputOffset} = getParquetValueOutput(opts, count);
   if (!opts.typeLength) {
     throw new Error('missing option: typeLength (required for FIXED_LEN_BYTE_ARRAY)');
   }
+  if (opts.byteArrayOutput) {
+    return decodeFixedLengthByteArraysToContiguousOutput(cursor, count, opts.typeLength, opts);
+  }
+  const {output, outputOffset} = getParquetValueOutput(opts, count);
   for (let i = 0; i < count; i++) {
     output[outputOffset + i] = readByteArray(cursor, opts.typeLength, opts.retainByteArrayViews);
   }
   return output;
+}
+
+/** Exposes one fixed-width PLAIN payload directly as Arrow-compatible bytes and offsets. */
+function decodeFixedLengthByteArraysToContiguousOutput(
+  cursor: CursorBuffer,
+  count: number,
+  typeLength: number,
+  options: ParquetCodecOptions
+): ParquetValueBuffer {
+  const byteArrayOutput = options.byteArrayOutput!;
+  const outputOffset = options.outputOffset || 0;
+  const payloadByteLength = count * typeLength;
+  const inputEnd = cursor.offset + payloadByteLength;
+  if (inputEnd > (cursor.size ?? cursor.buffer.byteLength)) {
+    throw new Error('PLAIN FIXED_LEN_BYTE_ARRAY values exceed the page buffer');
+  }
+
+  let byteOffset = byteArrayOutput.byteLength;
+  byteArrayOutput.valueOffsets[outputOffset] = byteOffset;
+  if (byteOffset === 0) {
+    // The common single-page case can retain the original Parquet bytes without allocating either
+    // one view per value or a second payload buffer. A later page falls back to append-and-copy.
+    byteArrayOutput.data = cursor.buffer.subarray(cursor.offset, inputEnd);
+  } else {
+    reserveParquetByteArrayOutput(byteArrayOutput, payloadByteLength);
+    byteArrayOutput.data.set(cursor.buffer.subarray(cursor.offset, inputEnd), byteOffset);
+  }
+  cursor.offset = inputEnd;
+  for (let valueIndex = 0; valueIndex < count; valueIndex++) {
+    byteOffset += typeLength;
+    byteArrayOutput.valueOffsets[outputOffset + valueIndex + 1] = byteOffset;
+  }
+  byteArrayOutput.byteLength = byteOffset;
+  return options.output || [];
 }
 
 /** Reads one byte-array value, optionally retaining a view into the decoded page buffer. */
@@ -337,6 +438,31 @@ function readByteArray(
 /** Creates one reusable DataView for all primitive reads from a codec cursor. */
 function getCursorDataView(cursor: CursorBuffer): DataView {
   return new DataView(cursor.buffer.buffer, cursor.buffer.byteOffset, cursor.buffer.byteLength);
+}
+
+/** Copies little-endian PLAIN values directly into an identical typed destination. */
+function copyPlainTypedValues(
+  cursor: CursorBuffer,
+  output: Int32Array | BigInt64Array | Float32Array | Float64Array,
+  outputOffset: number,
+  count: number
+): boolean {
+  if (!IS_LITTLE_ENDIAN) {
+    return false;
+  }
+  const byteLength = count * output.BYTES_PER_ELEMENT;
+  const inputEnd = cursor.offset + byteLength;
+  if (inputEnd > (cursor.size ?? cursor.buffer.length) || outputOffset + count > output.length) {
+    throw new Error('Unexpected end of Parquet PLAIN values');
+  }
+  const outputBytes = new Uint8Array(
+    output.buffer,
+    output.byteOffset + outputOffset * output.BYTES_PER_ELEMENT,
+    byteLength
+  );
+  outputBytes.set(cursor.buffer.subarray(cursor.offset, inputEnd));
+  cursor.offset = inputEnd;
+  return true;
 }
 
 function toPrimitiveBytes(value: any): Uint8Array {

--- a/modules/parquet/src/parquetjs/codecs/rle.ts
+++ b/modules/parquet/src/parquetjs/codecs/rle.ts
@@ -316,14 +316,269 @@ function decodeUint32BitPackedRun(
   outputOffset: number,
   dictionary?: readonly unknown[]
 ): void {
+  if (!dictionary && bitWidth <= 4) {
+    decodeNarrowUnsignedBitPackedRun(buffer, packedOffset, count, bitWidth, output, outputOffset);
+    return;
+  }
+  if (dictionary && bitWidth <= 4) {
+    decodeNarrowDictionaryBitPackedRun(
+      buffer,
+      packedOffset,
+      count,
+      bitWidth,
+      output,
+      outputOffset,
+      dictionary
+    );
+    return;
+  }
+  if (dictionary && bitWidth === 10) {
+    decode10BitDictionaryRun(buffer, packedOffset, count, output, outputOffset, dictionary);
+    return;
+  }
+  if (dictionary && bitWidth === 12) {
+    decode12BitDictionaryRun(buffer, packedOffset, count, output, outputOffset, dictionary);
+    return;
+  }
   if (bitWidth === 8) {
+    if (dictionary) {
+      for (let valueIndex = 0; valueIndex < count; valueIndex++) {
+        const value = buffer[packedOffset + valueIndex] ?? 0;
+        if (value >= dictionary.length) {
+          throw new Error(`Invalid Parquet dictionary index ${value}`);
+        }
+        output[outputOffset + valueIndex] = dictionary[value];
+      }
+      return;
+    }
     for (let valueIndex = 0; valueIndex < count; valueIndex++) {
-      const value = buffer[packedOffset + valueIndex] ?? 0;
-      output[outputOffset + valueIndex] = resolveDictionaryValue(value, dictionary);
+      output[outputOffset + valueIndex] = buffer[packedOffset + valueIndex] ?? 0;
     }
     return;
   }
 
+  const mask = 2 ** bitWidth - 1;
+  let packedBits = 0;
+  let packedBitCount = 0;
+  let byteOffset = packedOffset;
+  if (dictionary) {
+    for (let valueIndex = 0; valueIndex < count; valueIndex++) {
+      while (packedBitCount < bitWidth) {
+        packedBits |= (buffer[byteOffset++] ?? 0) << packedBitCount;
+        packedBitCount += 8;
+      }
+      const value = packedBits & mask;
+      if (value >= dictionary.length) {
+        throw new Error(`Invalid Parquet dictionary index ${value}`);
+      }
+      output[outputOffset + valueIndex] = dictionary[value];
+      packedBits >>>= bitWidth;
+      packedBitCount -= bitWidth;
+    }
+    return;
+  }
+  for (let valueIndex = 0; valueIndex < count; valueIndex++) {
+    while (packedBitCount < bitWidth) {
+      packedBits |= (buffer[byteOffset++] ?? 0) << packedBitCount;
+      packedBitCount += 8;
+    }
+    const value = packedBits & mask;
+    output[outputOffset + valueIndex] = value;
+    packedBits >>>= bitWidth;
+    packedBitCount -= bitWidth;
+  }
+}
+
+/** Decodes complete groups of eight narrow unsigned values without a per-value reservoir. */
+function decodeNarrowUnsignedBitPackedRun(
+  buffer: Uint8Array,
+  packedOffset: number,
+  count: number,
+  bitWidth: number,
+  output: ParquetValueBuffer,
+  outputOffset: number
+): void {
+  if (bitWidth === 1) {
+    decode1BitUnsignedRun(buffer, packedOffset, count, output, outputOffset);
+    return;
+  }
+  if (bitWidth === 2) {
+    decode2BitUnsignedRun(buffer, packedOffset, count, output, outputOffset);
+    return;
+  }
+  const mask = 2 ** bitWidth - 1;
+  let byteOffset = packedOffset;
+  let valueIndex = 0;
+  while (valueIndex < count) {
+    const packedBits =
+      (buffer[byteOffset] ?? 0) |
+      ((buffer[byteOffset + 1] ?? 0) << 8) |
+      ((buffer[byteOffset + 2] ?? 0) << 16) |
+      ((buffer[byteOffset + 3] ?? 0) << 24);
+    const groupValueCount = Math.min(8, count - valueIndex);
+    for (let groupIndex = 0; groupIndex < groupValueCount; groupIndex++) {
+      output[outputOffset + valueIndex + groupIndex] =
+        (packedBits >>> (groupIndex * bitWidth)) & mask;
+    }
+    byteOffset += bitWidth;
+    valueIndex += groupValueCount;
+  }
+}
+
+/** Expands byte-aligned groups of eight one-bit level values. */
+function decode1BitUnsignedRun(
+  buffer: Uint8Array,
+  packedOffset: number,
+  count: number,
+  output: ParquetValueBuffer,
+  outputOffset: number
+): void {
+  let byteOffset = packedOffset;
+  let valueIndex = 0;
+  while (valueIndex + 8 <= count) {
+    const packedBits = buffer[byteOffset++] ?? 0;
+    output[outputOffset + valueIndex] = packedBits & 1;
+    output[outputOffset + valueIndex + 1] = (packedBits >>> 1) & 1;
+    output[outputOffset + valueIndex + 2] = (packedBits >>> 2) & 1;
+    output[outputOffset + valueIndex + 3] = (packedBits >>> 3) & 1;
+    output[outputOffset + valueIndex + 4] = (packedBits >>> 4) & 1;
+    output[outputOffset + valueIndex + 5] = (packedBits >>> 5) & 1;
+    output[outputOffset + valueIndex + 6] = (packedBits >>> 6) & 1;
+    output[outputOffset + valueIndex + 7] = packedBits >>> 7;
+    valueIndex += 8;
+  }
+  const packedBits = buffer[byteOffset] ?? 0;
+  for (let tailIndex = 0; valueIndex + tailIndex < count; tailIndex++) {
+    output[outputOffset + valueIndex + tailIndex] = (packedBits >>> tailIndex) & 1;
+  }
+}
+
+/** Expands two-byte groups of eight two-bit level values. */
+function decode2BitUnsignedRun(
+  buffer: Uint8Array,
+  packedOffset: number,
+  count: number,
+  output: ParquetValueBuffer,
+  outputOffset: number
+): void {
+  let byteOffset = packedOffset;
+  let valueIndex = 0;
+  while (valueIndex + 8 <= count) {
+    const packedBits = (buffer[byteOffset] ?? 0) | ((buffer[byteOffset + 1] ?? 0) << 8);
+    output[outputOffset + valueIndex] = packedBits & 3;
+    output[outputOffset + valueIndex + 1] = (packedBits >>> 2) & 3;
+    output[outputOffset + valueIndex + 2] = (packedBits >>> 4) & 3;
+    output[outputOffset + valueIndex + 3] = (packedBits >>> 6) & 3;
+    output[outputOffset + valueIndex + 4] = (packedBits >>> 8) & 3;
+    output[outputOffset + valueIndex + 5] = (packedBits >>> 10) & 3;
+    output[outputOffset + valueIndex + 6] = (packedBits >>> 12) & 3;
+    output[outputOffset + valueIndex + 7] = (packedBits >>> 14) & 3;
+    byteOffset += 2;
+    valueIndex += 8;
+  }
+  const packedBits = (buffer[byteOffset] ?? 0) | ((buffer[byteOffset + 1] ?? 0) << 8);
+  for (let tailIndex = 0; valueIndex + tailIndex < count; tailIndex++) {
+    output[outputOffset + valueIndex + tailIndex] = (packedBits >>> (tailIndex * 2)) & 3;
+  }
+}
+
+/** Resolves aligned groups of four 10-bit dictionary indices from five input bytes. */
+function decode10BitDictionaryRun(
+  buffer: Uint8Array,
+  packedOffset: number,
+  count: number,
+  output: ParquetValueBuffer,
+  outputOffset: number,
+  dictionary: readonly unknown[]
+): void {
+  let byteOffset = packedOffset;
+  let valueIndex = 0;
+  while (valueIndex + 4 <= count) {
+    const byte0 = buffer[byteOffset] ?? 0;
+    const byte1 = buffer[byteOffset + 1] ?? 0;
+    const byte2 = buffer[byteOffset + 2] ?? 0;
+    const byte3 = buffer[byteOffset + 3] ?? 0;
+    const byte4 = buffer[byteOffset + 4] ?? 0;
+    const index0 = byte0 | ((byte1 & 0x03) << 8);
+    const index1 = (byte1 >>> 2) | ((byte2 & 0x0f) << 6);
+    const index2 = (byte2 >>> 4) | ((byte3 & 0x3f) << 4);
+    const index3 = (byte3 >>> 6) | (byte4 << 2);
+    if (
+      index0 >= dictionary.length ||
+      index1 >= dictionary.length ||
+      index2 >= dictionary.length ||
+      index3 >= dictionary.length
+    ) {
+      const invalidIndex = [index0, index1, index2, index3].find(
+        dictionaryIndex => dictionaryIndex >= dictionary.length
+      );
+      throw new Error(`Invalid Parquet dictionary index ${invalidIndex}`);
+    }
+    output[outputOffset + valueIndex] = dictionary[index0];
+    output[outputOffset + valueIndex + 1] = dictionary[index1];
+    output[outputOffset + valueIndex + 2] = dictionary[index2];
+    output[outputOffset + valueIndex + 3] = dictionary[index3];
+    byteOffset += 5;
+    valueIndex += 4;
+  }
+  decodeDictionaryBitPackedTail(
+    buffer,
+    byteOffset,
+    count - valueIndex,
+    10,
+    output,
+    outputOffset + valueIndex,
+    dictionary
+  );
+}
+
+/** Resolves aligned pairs of 12-bit dictionary indices from three input bytes. */
+function decode12BitDictionaryRun(
+  buffer: Uint8Array,
+  packedOffset: number,
+  count: number,
+  output: ParquetValueBuffer,
+  outputOffset: number,
+  dictionary: readonly unknown[]
+): void {
+  let byteOffset = packedOffset;
+  let valueIndex = 0;
+  while (valueIndex + 2 <= count) {
+    const byte0 = buffer[byteOffset] ?? 0;
+    const byte1 = buffer[byteOffset + 1] ?? 0;
+    const byte2 = buffer[byteOffset + 2] ?? 0;
+    const index0 = byte0 | ((byte1 & 0x0f) << 8);
+    const index1 = (byte1 >>> 4) | (byte2 << 4);
+    if (index0 >= dictionary.length || index1 >= dictionary.length) {
+      const invalidIndex = index0 >= dictionary.length ? index0 : index1;
+      throw new Error(`Invalid Parquet dictionary index ${invalidIndex}`);
+    }
+    output[outputOffset + valueIndex] = dictionary[index0];
+    output[outputOffset + valueIndex + 1] = dictionary[index1];
+    byteOffset += 3;
+    valueIndex += 2;
+  }
+  decodeDictionaryBitPackedTail(
+    buffer,
+    byteOffset,
+    count - valueIndex,
+    12,
+    output,
+    outputOffset + valueIndex,
+    dictionary
+  );
+}
+
+/** Resolves the byte-aligned remainder after a fixed-width dictionary group. */
+function decodeDictionaryBitPackedTail(
+  buffer: Uint8Array,
+  packedOffset: number,
+  count: number,
+  bitWidth: number,
+  output: ParquetValueBuffer,
+  outputOffset: number,
+  dictionary: readonly unknown[]
+): void {
   const mask = 2 ** bitWidth - 1;
   let packedBits = 0;
   let packedBitCount = 0;
@@ -333,11 +588,247 @@ function decodeUint32BitPackedRun(
       packedBits |= (buffer[byteOffset++] ?? 0) << packedBitCount;
       packedBitCount += 8;
     }
-    const value = packedBits & mask;
-    output[outputOffset + valueIndex] = resolveDictionaryValue(value, dictionary);
+    const dictionaryIndex = packedBits & mask;
+    if (dictionaryIndex >= dictionary.length) {
+      throw new Error(`Invalid Parquet dictionary index ${dictionaryIndex}`);
+    }
+    output[outputOffset + valueIndex] = dictionary[dictionaryIndex];
     packedBits >>>= bitWidth;
     packedBitCount -= bitWidth;
   }
+}
+
+/** Resolves complete groups of eight narrow dictionary indices without a per-value reservoir. */
+function decodeNarrowDictionaryBitPackedRun(
+  buffer: Uint8Array,
+  packedOffset: number,
+  count: number,
+  bitWidth: number,
+  output: ParquetValueBuffer,
+  outputOffset: number,
+  dictionary: readonly unknown[]
+): void {
+  if (bitWidth === 1) {
+    decode1BitDictionaryRun(buffer, packedOffset, count, output, outputOffset, dictionary);
+    return;
+  }
+  if (bitWidth === 2) {
+    decode2BitDictionaryRun(buffer, packedOffset, count, output, outputOffset, dictionary);
+    return;
+  }
+  if (bitWidth === 3) {
+    decode3BitDictionaryRun(buffer, packedOffset, count, output, outputOffset, dictionary);
+    return;
+  }
+  if (bitWidth === 4) {
+    decode4BitDictionaryRun(buffer, packedOffset, count, output, outputOffset, dictionary);
+    return;
+  }
+  const mask = 2 ** bitWidth - 1;
+  let byteOffset = packedOffset;
+  let valueIndex = 0;
+  while (valueIndex < count) {
+    const packedBits =
+      (buffer[byteOffset] ?? 0) |
+      ((buffer[byteOffset + 1] ?? 0) << 8) |
+      ((buffer[byteOffset + 2] ?? 0) << 16) |
+      ((buffer[byteOffset + 3] ?? 0) << 24);
+    const groupValueCount = Math.min(8, count - valueIndex);
+    for (let groupIndex = 0; groupIndex < groupValueCount; groupIndex++) {
+      const dictionaryIndex = (packedBits >>> (groupIndex * bitWidth)) & mask;
+      if (dictionaryIndex >= dictionary.length) {
+        throw new Error(`Invalid Parquet dictionary index ${dictionaryIndex}`);
+      }
+      output[outputOffset + valueIndex + groupIndex] = dictionary[dictionaryIndex];
+    }
+    byteOffset += bitWidth;
+    valueIndex += groupValueCount;
+  }
+}
+
+/** Resolves byte-aligned groups of eight one-bit dictionary indices. */
+function decode1BitDictionaryRun(
+  buffer: Uint8Array,
+  packedOffset: number,
+  count: number,
+  output: ParquetValueBuffer,
+  outputOffset: number,
+  dictionary: readonly unknown[]
+): void {
+  let byteOffset = packedOffset;
+  let valueIndex = 0;
+  while (valueIndex + 8 <= count) {
+    const packedBits = buffer[byteOffset++] ?? 0;
+    if (dictionary.length < 2 && packedBits !== 0) {
+      throw new Error('Invalid Parquet dictionary index 1');
+    }
+    output[outputOffset + valueIndex] = dictionary[packedBits & 1];
+    output[outputOffset + valueIndex + 1] = dictionary[(packedBits >>> 1) & 1];
+    output[outputOffset + valueIndex + 2] = dictionary[(packedBits >>> 2) & 1];
+    output[outputOffset + valueIndex + 3] = dictionary[(packedBits >>> 3) & 1];
+    output[outputOffset + valueIndex + 4] = dictionary[(packedBits >>> 4) & 1];
+    output[outputOffset + valueIndex + 5] = dictionary[(packedBits >>> 5) & 1];
+    output[outputOffset + valueIndex + 6] = dictionary[(packedBits >>> 6) & 1];
+    output[outputOffset + valueIndex + 7] = dictionary[packedBits >>> 7];
+    valueIndex += 8;
+  }
+  decodeDictionaryBitPackedTail(
+    buffer,
+    byteOffset,
+    count - valueIndex,
+    1,
+    output,
+    outputOffset + valueIndex,
+    dictionary
+  );
+}
+
+/** Resolves two-byte groups of eight two-bit dictionary indices. */
+function decode2BitDictionaryRun(
+  buffer: Uint8Array,
+  packedOffset: number,
+  count: number,
+  output: ParquetValueBuffer,
+  outputOffset: number,
+  dictionary: readonly unknown[]
+): void {
+  let byteOffset = packedOffset;
+  let valueIndex = 0;
+  while (valueIndex + 8 <= count) {
+    const packedBits = (buffer[byteOffset] ?? 0) | ((buffer[byteOffset + 1] ?? 0) << 8);
+    const index0 = packedBits & 3;
+    const index1 = (packedBits >>> 2) & 3;
+    const index2 = (packedBits >>> 4) & 3;
+    const index3 = (packedBits >>> 6) & 3;
+    const index4 = (packedBits >>> 8) & 3;
+    const index5 = (packedBits >>> 10) & 3;
+    const index6 = (packedBits >>> 12) & 3;
+    const index7 = packedBits >>> 14;
+    if (
+      index0 >= dictionary.length ||
+      index1 >= dictionary.length ||
+      index2 >= dictionary.length ||
+      index3 >= dictionary.length ||
+      index4 >= dictionary.length ||
+      index5 >= dictionary.length ||
+      index6 >= dictionary.length ||
+      index7 >= dictionary.length
+    ) {
+      throw new Error('Invalid Parquet dictionary index');
+    }
+    output[outputOffset + valueIndex] = dictionary[index0];
+    output[outputOffset + valueIndex + 1] = dictionary[index1];
+    output[outputOffset + valueIndex + 2] = dictionary[index2];
+    output[outputOffset + valueIndex + 3] = dictionary[index3];
+    output[outputOffset + valueIndex + 4] = dictionary[index4];
+    output[outputOffset + valueIndex + 5] = dictionary[index5];
+    output[outputOffset + valueIndex + 6] = dictionary[index6];
+    output[outputOffset + valueIndex + 7] = dictionary[index7];
+    byteOffset += 2;
+    valueIndex += 8;
+  }
+  decodeDictionaryBitPackedTail(
+    buffer,
+    byteOffset,
+    count - valueIndex,
+    2,
+    output,
+    outputOffset + valueIndex,
+    dictionary
+  );
+}
+
+/** Resolves byte-aligned groups of eight three-bit dictionary indices. */
+function decode3BitDictionaryRun(
+  buffer: Uint8Array,
+  packedOffset: number,
+  count: number,
+  output: ParquetValueBuffer,
+  outputOffset: number,
+  dictionary: readonly unknown[]
+): void {
+  let byteOffset = packedOffset;
+  let valueIndex = 0;
+  while (valueIndex + 8 <= count) {
+    const packedBits =
+      (buffer[byteOffset] ?? 0) |
+      ((buffer[byteOffset + 1] ?? 0) << 8) |
+      ((buffer[byteOffset + 2] ?? 0) << 16);
+    const index0 = packedBits & 7;
+    const index1 = (packedBits >>> 3) & 7;
+    const index2 = (packedBits >>> 6) & 7;
+    const index3 = (packedBits >>> 9) & 7;
+    const index4 = (packedBits >>> 12) & 7;
+    const index5 = (packedBits >>> 15) & 7;
+    const index6 = (packedBits >>> 18) & 7;
+    const index7 = (packedBits >>> 21) & 7;
+    if (
+      index0 >= dictionary.length ||
+      index1 >= dictionary.length ||
+      index2 >= dictionary.length ||
+      index3 >= dictionary.length ||
+      index4 >= dictionary.length ||
+      index5 >= dictionary.length ||
+      index6 >= dictionary.length ||
+      index7 >= dictionary.length
+    ) {
+      throw new Error('Invalid Parquet dictionary index');
+    }
+    output[outputOffset + valueIndex] = dictionary[index0];
+    output[outputOffset + valueIndex + 1] = dictionary[index1];
+    output[outputOffset + valueIndex + 2] = dictionary[index2];
+    output[outputOffset + valueIndex + 3] = dictionary[index3];
+    output[outputOffset + valueIndex + 4] = dictionary[index4];
+    output[outputOffset + valueIndex + 5] = dictionary[index5];
+    output[outputOffset + valueIndex + 6] = dictionary[index6];
+    output[outputOffset + valueIndex + 7] = dictionary[index7];
+    byteOffset += 3;
+    valueIndex += 8;
+  }
+  decodeDictionaryBitPackedTail(
+    buffer,
+    byteOffset,
+    count - valueIndex,
+    3,
+    output,
+    outputOffset + valueIndex,
+    dictionary
+  );
+}
+
+/** Resolves pairs of four-bit dictionary indices from each input byte. */
+function decode4BitDictionaryRun(
+  buffer: Uint8Array,
+  packedOffset: number,
+  count: number,
+  output: ParquetValueBuffer,
+  outputOffset: number,
+  dictionary: readonly unknown[]
+): void {
+  let byteOffset = packedOffset;
+  let valueIndex = 0;
+  while (valueIndex + 2 <= count) {
+    const packedByte = buffer[byteOffset++] ?? 0;
+    const index0 = packedByte & 15;
+    const index1 = packedByte >>> 4;
+    if (index0 >= dictionary.length || index1 >= dictionary.length) {
+      throw new Error(
+        `Invalid Parquet dictionary index ${index0 >= dictionary.length ? index0 : index1}`
+      );
+    }
+    output[outputOffset + valueIndex] = dictionary[index0];
+    output[outputOffset + valueIndex + 1] = dictionary[index1];
+    valueIndex += 2;
+  }
+  decodeDictionaryBitPackedTail(
+    buffer,
+    byteOffset,
+    count - valueIndex,
+    4,
+    output,
+    outputOffset + valueIndex,
+    dictionary
+  );
 }
 
 /** Decodes a bit-packed run with an exact number-based bit reservoir. */

--- a/modules/parquet/src/parquetjs/compression.ts
+++ b/modules/parquet/src/parquetjs/compression.ts
@@ -13,12 +13,12 @@ import {
   LZ4Compressor,
   LZ4Decompressor,
   SnappyCompressor,
-  SnappyDecompressor,
   ZstdCompressor,
   ZstdDecompressor,
   type Compressor,
   type Decompressor
 } from '@loaders.gl/compression';
+import {SnappyHysnappyDecompressor} from '@loaders.gl/compression/snappy-decompressor-hysnappy';
 import {registerJSModules} from '@loaders.gl/loader-utils';
 
 import {ParquetCompression} from './schema/declare';
@@ -37,6 +37,9 @@ export const PARQUET_COMPRESSION_METHODS: Partial<Record<ParquetCompression, tru
   LZ4_RAW: true,
   ZSTD: true
 };
+
+/** Reader-scoped function that decompresses one independently encoded Parquet page. */
+export type ParquetPageDecompressor = (value: Uint8Array, size: number) => Promise<Uint8Array>;
 
 /**
  * Registers optional codec modules without eagerly loading codec-backed implementations.
@@ -85,6 +88,24 @@ export async function decompress(
   return toUint8Array(compressedArrayBuffer);
 }
 
+/**
+ * Creates a reusable decoder for the independently compressed pages in one Parquet reader.
+ *
+ * Reusing the lazy codec preserves its selected backend and avoids repeating dynamic import and
+ * preload work for every page while keeping module injection scoped to a reader invocation.
+ */
+export function createParquetPageDecompressor(method: ParquetCompression): ParquetPageDecompressor {
+  const decompressor = method === 'UNCOMPRESSED' ? null : createParquetDecompressor(method);
+  return async (value: Uint8Array, size: number): Promise<Uint8Array> => {
+    const inputArrayBuffer = toArrayBuffer(value);
+    if (!decompressor) {
+      return toUint8Array(inputArrayBuffer);
+    }
+    const decompressedArrayBuffer = await decompressor.decompress(inputArrayBuffer, size);
+    return toUint8Array(decompressedArrayBuffer);
+  };
+}
+
 /** Returns a new lazily selecting compressor for one Parquet method. */
 async function getParquetCompressor(method: ParquetCompression): Promise<Compressor> {
   return createParquetCompressor(method);
@@ -120,7 +141,7 @@ function createParquetDecompressor(method: ParquetCompression): Decompressor {
     case 'GZIP':
       return new GZipDecompressor();
     case 'SNAPPY':
-      return new SnappyDecompressor();
+      return new SnappyHysnappyDecompressor();
     case 'BROTLI':
       return new BrotliDecompressor();
     case 'LZ4':

--- a/modules/parquet/src/parquetjs/compression.ts
+++ b/modules/parquet/src/parquetjs/compression.ts
@@ -13,10 +13,11 @@ import {
   LZ4Compressor,
   LZ4Decompressor,
   SnappyCompressor,
+  SnappyDecompressor,
   ZstdCompressor,
   ZstdDecompressor,
-  type Compressor,
-  type Decompressor
+  Decompressor,
+  type Compressor
 } from '@loaders.gl/compression';
 import {SnappyHysnappyDecompressor} from '@loaders.gl/compression/snappy-decompressor-hysnappy';
 import {registerJSModules} from '@loaders.gl/loader-utils';
@@ -40,6 +41,38 @@ export const PARQUET_COMPRESSION_METHODS: Partial<Record<ParquetCompression, tru
 
 /** Reader-scoped function that decompresses one independently encoded Parquet page. */
 export type ParquetPageDecompressor = (value: Uint8Array, size: number) => Promise<Uint8Array>;
+
+/** Fast Snappy decoder that permanently falls back to snappyjs when WASM is unavailable. */
+class ParquetSnappyDecompressor extends Decompressor {
+  /** Compression format name. */
+  readonly name = 'snappy';
+  /** Snappy does not have a standard standalone file extension. */
+  readonly extensions: string[] = [];
+  /** Snappy does not have a standard HTTP content encoding. */
+  readonly contentEncodings: string[] = [];
+  /** snappyjs keeps this composite decoder available without WebAssembly. */
+  readonly isSupported = true;
+  /** Preferred compact WASM decoder for page-sized frames. */
+  private readonly hysnappy = new SnappyHysnappyDecompressor();
+  /** Always-supported JavaScript decoder. */
+  private readonly snappyjs = new SnappyDecompressor();
+  /** Whether this instance has selected the JavaScript fallback. */
+  private useSnappyjs = !this.hysnappy.isSupported;
+
+  /** Decodes with hysnappy, retaining snappyjs after the first WASM setup or runtime failure. */
+  override async decompress(input: ArrayBuffer, size?: number): Promise<ArrayBuffer> {
+    if (!this.useSnappyjs) {
+      try {
+        return await this.hysnappy.decompress(input, size);
+      } catch {
+        // CSP can reject WebAssembly compilation even when the WebAssembly global exists. Once
+        // that happens, avoid paying the same rejected initialization cost for every Parquet page.
+        this.useSnappyjs = true;
+      }
+    }
+    return await this.snappyjs.decompress(input, size);
+  }
+}
 
 /**
  * Registers optional codec modules without eagerly loading codec-backed implementations.
@@ -141,7 +174,7 @@ function createParquetDecompressor(method: ParquetCompression): Decompressor {
     case 'GZIP':
       return new GZipDecompressor();
     case 'SNAPPY':
-      return new SnappyHysnappyDecompressor();
+      return new ParquetSnappyDecompressor();
     case 'BROTLI':
       return new BrotliDecompressor();
     case 'LZ4':

--- a/modules/parquet/src/parquetjs/parser/decoders.ts
+++ b/modules/parquet/src/parquetjs/parser/decoders.ts
@@ -17,7 +17,7 @@ import {
   SchemaDefinition
 } from '../schema/declare';
 import {CursorBuffer, ParquetCodecOptions, PARQUET_CODECS} from '../codecs/index';
-import type {ParquetValueBuffer} from '../codecs/declare';
+import type {ParquetByteArrayOutput, ParquetValueBuffer} from '../codecs/declare';
 import {
   ConvertedType,
   EdgeInterpolationAlgorithm,
@@ -34,10 +34,14 @@ import {PARQUET_RDLVL_TYPE, PARQUET_RDLVL_ENCODING} from '../../lib/constants';
 import {decodePageHeader, getThriftEnum, getBitWidth} from '../utils/read-utils';
 import {crc32} from '../utils/crc32';
 
+/** Shared empty level storage for required flat columns, whose levels are implicit. */
+const EMPTY_PARQUET_LEVEL_BUFFER = new Uint8Array(0);
+
 /** Preallocated column destination used to bypass page-local value and level arrays. */
 type ParquetPageDecodeTarget = {
   values: ParquetValueBuffer;
   valueOffset: number;
+  byteArrayOutput?: ParquetByteArrayOutput;
   dictionary: readonly unknown[];
   rlevels: ParquetLevelBuffer;
   dlevels: ParquetLevelBuffer;
@@ -71,12 +75,14 @@ export async function decodeDataPages(
   }
 
   const outputCapacity = expectedLevelCount ?? 0;
+  const byteArrayOutput = createArrowByteArrayOutput(buffer, context, outputCapacity);
   const data: ParquetColumnChunk = {
     rlevels: createParquetLevelBuffer(context, outputCapacity, context.rLevelMax),
     dlevels: createParquetLevelBuffer(context, outputCapacity, context.dLevelMax),
-    values: createParquetColumnValueBuffer(context, outputCapacity),
+    values: byteArrayOutput ? [] : createParquetColumnValueBuffer(context, outputCapacity),
     pageHeaders: [],
-    count: 0
+    count: 0,
+    nullCount: 0
   };
 
   let dictionary = context.dictionary || [];
@@ -89,14 +95,19 @@ export async function decodeDataPages(
     (expectedLevelCount === undefined || levelOffset < expectedLevelCount)
   ) {
     // Looks like we have to decode these in sequence due to cursor updates?
-    const page = await decodePage(cursor, context, {
+    const target = {
       values: data.values,
       valueOffset,
+      byteArrayOutput,
       dictionary,
       rlevels: data.rlevels,
       dlevels: data.dlevels,
       levelOffset
-    });
+    };
+    const page =
+      context.compression === 'UNCOMPRESSED'
+        ? decodeUncompressedPage(cursor, context, target)
+        : await decodePage(cursor, context, target);
 
     if (page.dictionary) {
       dictionary = page.dictionary;
@@ -108,6 +119,7 @@ export async function decodeDataPages(
 
     if (page.directValuesWritten !== undefined) {
       valueOffset += page.directValuesWritten;
+      data.nullCount! += page.count - page.directValuesWritten;
     } else {
       const valueEncoding = getThriftEnum(
         Encoding,
@@ -130,9 +142,112 @@ export async function decodeDataPages(
 
   data.rlevels = trimParquetLevelBuffer(data.rlevels, levelOffset);
   data.dlevels = trimParquetLevelBuffer(data.dlevels, levelOffset);
-  data.values = trimParquetValueBuffer(data.values, valueOffset);
+  if (byteArrayOutput) {
+    data.values = [];
+    data.byteArrayData = {
+      data: byteArrayOutput.data.subarray(0, byteArrayOutput.byteLength),
+      valueOffsets: byteArrayOutput.valueOffsets.subarray(0, valueOffset + 1)
+    };
+  } else {
+    data.values = trimParquetValueBuffer(data.values, valueOffset);
+  }
 
   return data;
+}
+
+/**
+ * Decodes an uncompressed column chunk synchronously.
+ *
+ * In-memory Parquet reads use this entry point to avoid one resolved Promise per selected column.
+ */
+export function decodeUncompressedDataPages(
+  buffer: Uint8Array,
+  context: ParquetReaderContext
+): ParquetColumnChunk {
+  const cursor: CursorBuffer = {buffer, offset: 0, size: buffer.length};
+  const expectedLevelCount =
+    context.numValues === undefined ? undefined : Number(context.numValues);
+  if (
+    expectedLevelCount !== undefined &&
+    (!Number.isSafeInteger(expectedLevelCount) || expectedLevelCount < 0)
+  ) {
+    throw new Error(`Invalid Parquet column value count ${expectedLevelCount}`);
+  }
+
+  const outputCapacity = expectedLevelCount ?? 0;
+  const byteArrayOutput = createArrowByteArrayOutput(buffer, context, outputCapacity);
+  const data: ParquetColumnChunk = {
+    rlevels: createParquetLevelBuffer(context, outputCapacity, context.rLevelMax),
+    dlevels: createParquetLevelBuffer(context, outputCapacity, context.dLevelMax),
+    values: byteArrayOutput ? [] : createParquetColumnValueBuffer(context, outputCapacity),
+    pageHeaders: [],
+    count: 0,
+    nullCount: 0
+  };
+  let dictionary = context.dictionary || [];
+  let levelOffset = 0;
+  let valueOffset = 0;
+
+  while (
+    cursor.offset < (cursor.size ?? cursor.buffer.length) &&
+    (expectedLevelCount === undefined || levelOffset < expectedLevelCount)
+  ) {
+    const page = decodeUncompressedPage(cursor, context, {
+      values: data.values,
+      valueOffset,
+      byteArrayOutput,
+      dictionary,
+      rlevels: data.rlevels,
+      dlevels: data.dlevels,
+      levelOffset
+    });
+    if (page.dictionary) {
+      dictionary = page.dictionary;
+      continue;
+    }
+
+    levelOffset += page.count;
+    if (page.directValuesWritten !== undefined) {
+      valueOffset += page.directValuesWritten;
+      data.nullCount! += page.count - page.directValuesWritten;
+    } else {
+      const valueEncoding = getThriftEnum(
+        Encoding,
+        page.pageHeader.data_page_header?.encoding ?? page.pageHeader.data_page_header_v2?.encoding!
+      ) as ParquetCodec;
+      const usesDictionary =
+        dictionary.length &&
+        (valueEncoding === 'PLAIN_DICTIONARY' || valueEncoding === 'RLE_DICTIONARY');
+      for (let index = 0; index < page.values.length; index++) {
+        const value = usesDictionary ? dictionary[Number(page.values[index])] : page.values[index];
+        if (value !== undefined) data.values[valueOffset++] = value;
+      }
+    }
+    data.count += page.count;
+    data.pageHeaders.push(page.pageHeader);
+  }
+
+  data.rlevels = trimParquetLevelBuffer(data.rlevels, levelOffset);
+  data.dlevels = trimParquetLevelBuffer(data.dlevels, levelOffset);
+  if (byteArrayOutput) {
+    data.values = [];
+    data.byteArrayData = {
+      data: byteArrayOutput.data.subarray(0, byteArrayOutput.byteLength),
+      valueOffsets: byteArrayOutput.valueOffsets.subarray(0, valueOffset + 1)
+    };
+  } else {
+    data.values = trimParquetValueBuffer(data.values, valueOffset);
+  }
+  return data;
+}
+
+/** Decodes a dictionary page from an uncompressed in-memory column chunk. */
+export function decodeUncompressedDictionaryBuffer(
+  buffer: Uint8Array,
+  context: ParquetReaderContext
+): unknown[] {
+  const cursor: CursorBuffer = {buffer, offset: 0, size: buffer.length};
+  return decodeUncompressedPage(cursor, context).dictionary!;
 }
 
 /**
@@ -152,16 +267,7 @@ export async function decodePage(
 
   const pageType = getThriftEnum(PageType, pageHeader.type);
   const pageEnd = cursor.offset + pageHeader.compressed_page_size;
-  if (context.verifyPageChecksums && pageHeader.crc !== undefined) {
-    if (pageEnd > (cursor.size ?? cursor.buffer.length)) {
-      throw new Error('Parquet page extends beyond the available buffer');
-    }
-    const expected = pageHeader.crc >>> 0;
-    const actual = crc32(cursor.buffer.subarray(cursor.offset, pageEnd));
-    if (actual !== expected) {
-      throw new Error(`Parquet page checksum mismatch: expected ${expected}, calculated ${actual}`);
-    }
-  }
+  verifyPageChecksum(cursor, pageHeader, pageEnd, context);
 
   switch (pageType) {
     case 'DATA_PAGE':
@@ -181,6 +287,56 @@ export async function decodePage(
   }
 
   return page;
+}
+
+/** Decodes one uncompressed page without introducing a Promise/microtask boundary. */
+function decodeUncompressedPage(
+  cursor: CursorBuffer,
+  context: ParquetReaderContext,
+  target?: ParquetPageDecodeTarget
+): ParquetPageData {
+  const {pageHeader, length} = decodePageHeader(cursor.buffer, cursor.offset);
+  cursor.offset += length;
+  const pageEnd = cursor.offset + pageHeader.compressed_page_size;
+  verifyPageChecksum(cursor, pageHeader, pageEnd, context);
+
+  const pageType = getThriftEnum(PageType, pageHeader.type);
+  switch (pageType) {
+    case 'DATA_PAGE':
+      return decodeDataPageValues(cursor, pageHeader, context, target);
+    case 'DATA_PAGE_V2':
+      return decodeUncompressedDataPageV2(cursor, pageHeader, context, target);
+    case 'DICTIONARY_PAGE':
+      return {
+        dictionary: decodeUncompressedDictionaryPage(cursor, pageHeader, context),
+        dlevels: EMPTY_PARQUET_LEVEL_BUFFER,
+        rlevels: EMPTY_PARQUET_LEVEL_BUFFER,
+        values: [],
+        count: 0,
+        pageHeader
+      };
+    default:
+      throw new Error(`invalid page type: ${pageType}`);
+  }
+}
+
+/** Verifies a page checksum before either the synchronous or asynchronous decode path consumes it. */
+function verifyPageChecksum(
+  cursor: CursorBuffer,
+  pageHeader: PageHeader,
+  pageEnd: number,
+  context: ParquetReaderContext
+): void {
+  if (!context.verifyPageChecksums) return;
+  if (pageEnd > (cursor.size ?? cursor.buffer.length)) {
+    throw new Error('Parquet page extends beyond the available buffer');
+  }
+  if (pageHeader.crc === undefined) return;
+  const expected = pageHeader.crc >>> 0;
+  const actual = crc32(cursor.buffer.subarray(cursor.offset, pageEnd));
+  if (actual !== expected) {
+    throw new Error(`Parquet page checksum mismatch: expected ${expected}, calculated ${actual}`);
+  }
 }
 
 /**
@@ -449,17 +605,15 @@ async function decodeDataPage(
   target?: ParquetPageDecodeTarget
 ): Promise<ParquetPageData> {
   const cursorEnd = cursor.offset + header.compressed_page_size;
-  const valueCount = header.data_page_header?.num_values;
 
   /* uncompress page */
   let dataCursor = cursor;
 
   if (context.compression !== 'UNCOMPRESSED') {
-    const valuesBuf = await decompress(
-      context.compression,
-      cursor.buffer.slice(cursor.offset, cursorEnd),
-      header.uncompressed_page_size
-    );
+    const compressedValues = cursor.buffer.slice(cursor.offset, cursorEnd);
+    const valuesBuf = context.decompressPage
+      ? await context.decompressPage(compressedValues, header.uncompressed_page_size)
+      : await decompress(context.compression, compressedValues, header.uncompressed_page_size);
     dataCursor = {
       buffer: valuesBuf,
       offset: 0,
@@ -467,6 +621,18 @@ async function decodeDataPage(
     };
     cursor.offset = cursorEnd;
   }
+
+  return decodeDataPageValues(dataCursor, header, context, target);
+}
+
+/** Decodes one uncompressed Data Page V1 body without introducing an asynchronous boundary. */
+function decodeDataPageValues(
+  dataCursor: CursorBuffer,
+  header: PageHeader,
+  context: ParquetReaderContext,
+  target?: ParquetPageDecodeTarget
+): ParquetPageData {
+  const valueCount = header.data_page_header?.num_values;
 
   /* read repetition levels */
   const rLevelEncoding = getThriftEnum(
@@ -518,6 +684,7 @@ async function decodeDataPage(
     output: target?.values,
     outputOffset: target?.valueOffset,
     dictionary: isDictionaryEncoding(valueEncoding) ? target?.dictionary : undefined,
+    byteArrayOutput: target?.byteArrayOutput,
     int64AsBigInt: shouldDecodeInt64AsBigInt(context),
     int96AsTimestamp: context.int96AsTimestamp
   };
@@ -628,14 +795,125 @@ async function decodeDataPageV2(
   let valuesBuffer = cursor.buffer.subarray(valuesOffset, cursorEnd);
 
   if (dataPageHeader.is_compressed !== false && context.compression !== 'UNCOMPRESSED') {
-    valuesBuffer = await decompress(
-      context.compression,
-      valuesBuffer,
-      valuesUncompressedByteLength
-    );
+    valuesBuffer = context.decompressPage
+      ? await context.decompressPage(valuesBuffer, valuesUncompressedByteLength)
+      : await decompress(context.compression, valuesBuffer, valuesUncompressedByteLength);
   }
-  const valuesBufCursor = {buffer: valuesBuffer, offset: 0, size: valuesBuffer.length};
   cursor.offset = cursorEnd;
+  return decodeDataPageV2Values(
+    valuesBuffer,
+    header,
+    context,
+    target,
+    rLevels,
+    dLevels,
+    valueCount,
+    valueCountNonNull,
+    valueEncoding
+  );
+}
+
+/** Decodes one uncompressed Data Page V2 without awaiting an unused decompressor. */
+function decodeUncompressedDataPageV2(
+  cursor: CursorBuffer,
+  header: PageHeader,
+  context: ParquetReaderContext,
+  target?: ParquetPageDecodeTarget
+): ParquetPageData {
+  const dataPageHeader = header.data_page_header_v2;
+  if (!dataPageHeader) {
+    throw new Error('Missing Parquet data page v2 header');
+  }
+  const cursorEnd = cursor.offset + header.compressed_page_size;
+  const levelsOffset = cursor.offset;
+  const valueCount = dataPageHeader.num_values;
+  const valueCountNonNull = valueCount - dataPageHeader.num_nulls;
+  const valueEncoding = getThriftEnum(Encoding, dataPageHeader.encoding) as ParquetCodec;
+  if (
+    header.compressed_page_size < 0 ||
+    cursorEnd > (cursor.size ?? cursor.buffer.length) ||
+    valueCountNonNull < 0
+  ) {
+    throw new Error('Invalid Parquet data page v2 header');
+  }
+
+  let rLevels: number[] = [];
+  if (context.column.rLevelMax > 0) {
+    const repetitionLevelCursor = createPageSliceCursor(
+      cursor,
+      levelsOffset,
+      dataPageHeader.repetition_levels_byte_length
+    );
+    rLevels = decodeLevels(
+      repetitionLevelCursor,
+      valueCount,
+      context.column.rLevelMax,
+      PARQUET_RDLVL_ENCODING,
+      true,
+      target?.rlevels,
+      target?.levelOffset
+    );
+  } else if (!target) {
+    rLevels = new Array(valueCount).fill(0);
+  }
+
+  const definitionLevelsOffset = levelsOffset + dataPageHeader.repetition_levels_byte_length;
+  let dLevels: number[] = [];
+  if (context.column.dLevelMax > 0) {
+    const definitionLevelCursor = createPageSliceCursor(
+      cursor,
+      definitionLevelsOffset,
+      dataPageHeader.definition_levels_byte_length
+    );
+    dLevels = decodeLevels(
+      definitionLevelCursor,
+      valueCount,
+      context.column.dLevelMax,
+      PARQUET_RDLVL_ENCODING,
+      true,
+      target?.dlevels,
+      target?.levelOffset
+    );
+  } else if (!target) {
+    dLevels = new Array(valueCount).fill(0);
+  }
+
+  const valuesOffset = definitionLevelsOffset + dataPageHeader.definition_levels_byte_length;
+  const valuesUncompressedByteLength =
+    header.uncompressed_page_size -
+    dataPageHeader.repetition_levels_byte_length -
+    dataPageHeader.definition_levels_byte_length;
+  if (valuesOffset > cursorEnd || valuesUncompressedByteLength < 0) {
+    throw new Error('Invalid Parquet data page v2 level lengths');
+  }
+  const valuesBuffer = cursor.buffer.subarray(valuesOffset, cursorEnd);
+  cursor.offset = cursorEnd;
+  return decodeDataPageV2Values(
+    valuesBuffer,
+    header,
+    context,
+    target,
+    rLevels,
+    dLevels,
+    valueCount,
+    valueCountNonNull,
+    valueEncoding
+  );
+}
+
+/** Decodes a prepared Data Page V2 value section without an asynchronous boundary. */
+function decodeDataPageV2Values(
+  valuesBuffer: Uint8Array,
+  header: PageHeader,
+  context: ParquetReaderContext,
+  target: ParquetPageDecodeTarget | undefined,
+  rLevels: number[],
+  dLevels: number[],
+  valueCount: number,
+  valueCountNonNull: number,
+  valueEncoding: ParquetCodec
+): ParquetPageData {
+  const valuesBufCursor = {buffer: valuesBuffer, offset: 0, size: valuesBuffer.length};
 
   const decodeOptions = {
     typeLength: context.column.typeLength,
@@ -644,6 +922,7 @@ async function decodeDataPageV2(
     output: target?.values,
     outputOffset: target?.valueOffset,
     dictionary: isDictionaryEncoding(valueEncoding) ? target?.dictionary : undefined,
+    byteArrayOutput: target?.byteArrayOutput,
     int64AsBigInt: shouldDecodeInt64AsBigInt(context),
     int96AsTimestamp: context.int96AsTimestamp
   };
@@ -688,12 +967,114 @@ function decodeLevels(
   return output ? [] : levels;
 }
 
+/**
+ * Allocates a compact Arrow-compatible destination for supported uncompressed byte pages.
+ *
+ * Scanning only the small Thrift page headers avoids committing to the fast path when a column
+ * mixes in an encoding that still requires materialized values. The page buffer is a useful
+ * initial capacity; the destination grows for prefix-reconstructed delta values when necessary.
+ */
+function createArrowByteArrayOutput(
+  buffer: Uint8Array,
+  context: ParquetReaderContext,
+  valueCapacity: number
+): ParquetByteArrayOutput | undefined {
+  if (
+    !context.useArrowByteArrayBuffers ||
+    context.compression !== 'UNCOMPRESSED' ||
+    !supportsArrowByteArrayOutput(context.column) ||
+    valueCapacity === 0
+  ) {
+    return undefined;
+  }
+  if (
+    !context.hasOnlyArrowByteArrayDataPages &&
+    !hasOnlyArrowByteArrayDataPages(buffer, valueCapacity)
+  ) {
+    return undefined;
+  }
+  return {
+    data:
+      context.column.primitiveType === 'FIXED_LEN_BYTE_ARRAY'
+        ? new Uint8Array(0)
+        : new Uint8Array(Math.max(1, buffer.byteLength)),
+    valueOffsets: new Int32Array(valueCapacity + 1),
+    byteLength: 0
+  };
+}
+
+/** Returns whether a BYTE_ARRAY field maps directly to Arrow Utf8 or Binary without conversion. */
+function supportsArrowByteArrayOutput(column: ParquetReaderContext['column']): boolean {
+  if (column.primitiveType !== 'BYTE_ARRAY' && column.primitiveType !== 'FIXED_LEN_BYTE_ARRAY') {
+    return false;
+  }
+  if (column.logicalType) {
+    return (
+      column.logicalType.type === 'STRING' ||
+      column.logicalType.type === 'ENUM' ||
+      column.logicalType.type === 'JSON' ||
+      column.logicalType.type === 'BSON' ||
+      column.logicalType.type === 'VARIANT' ||
+      column.logicalType.type === 'GEOMETRY' ||
+      column.logicalType.type === 'GEOGRAPHY'
+    );
+  }
+  return (
+    !column.originalType ||
+    column.originalType === 'UTF8' ||
+    column.originalType === 'ENUM' ||
+    column.originalType === 'JSON' ||
+    column.originalType === 'BSON' ||
+    column.originalType === 'INTERVAL'
+  );
+}
+
+/** Returns whether a complete column buffer contains only direct Arrow byte-array data pages. */
+function hasOnlyArrowByteArrayDataPages(buffer: Uint8Array, expectedLevelCount: number): boolean {
+  let offset = 0;
+  let levelCount = 0;
+  while (offset < buffer.byteLength && levelCount < expectedLevelCount) {
+    const {pageHeader, length} = decodePageHeader(buffer, offset);
+    const pageType = getThriftEnum(PageType, pageHeader.type);
+    if (pageType !== 'DATA_PAGE' && pageType !== 'DATA_PAGE_V2') {
+      return false;
+    }
+    const encoding = getThriftEnum(
+      Encoding,
+      pageHeader.data_page_header?.encoding ?? pageHeader.data_page_header_v2?.encoding!
+    );
+    if (
+      encoding !== 'PLAIN' &&
+      encoding !== 'DELTA_LENGTH_BYTE_ARRAY' &&
+      encoding !== 'DELTA_BYTE_ARRAY'
+    ) {
+      return false;
+    }
+    const valueCount =
+      pageHeader.data_page_header?.num_values ?? pageHeader.data_page_header_v2?.num_values;
+    if (valueCount === undefined || valueCount < 0) {
+      return false;
+    }
+    levelCount += valueCount;
+    offset += length + pageHeader.compressed_page_size;
+    if (offset > buffer.byteLength) {
+      return false;
+    }
+  }
+  return levelCount === expectedLevelCount;
+}
+
 /** Allocates compact unsigned storage for repetition and definition levels. */
 function createParquetLevelBuffer(
   context: ParquetReaderContext,
   capacity: number,
   levelMax: number
 ): ParquetLevelBuffer {
+  if (context.useTypedLevelBuffers && levelMax === 0) {
+    // Required flat columns have no encoded levels. Avoid allocating two row-sized zero buffers
+    // that neither direct Arrow construction nor level decoding will inspect.
+    return EMPTY_PARQUET_LEVEL_BUFFER;
+  }
   if (!context.useTypedLevelBuffers || capacity === 0) {
     return levelMax > 0 ? new Array<number>(capacity) : new Array<number>(capacity).fill(0);
   }
@@ -712,6 +1093,7 @@ function trimParquetLevelBuffer(levels: ParquetLevelBuffer, length: number): Par
     levels.length = length;
     return levels;
   }
+  if (levels.length === 0 || levels.length === length) return levels;
   return levels.subarray(0, length) as ParquetLevelBuffer;
 }
 
@@ -807,11 +1189,10 @@ async function decodeDictionaryPage(
   cursor.offset = cursorEnd;
 
   if (context.compression !== 'UNCOMPRESSED') {
-    const valuesBuf = await decompress(
-      context.compression,
-      dictCursor.buffer.subarray(dictCursor.offset),
-      pageHeader.uncompressed_page_size
-    );
+    const compressedValues = dictCursor.buffer.subarray(dictCursor.offset);
+    const valuesBuf = context.decompressPage
+      ? await context.decompressPage(compressedValues, pageHeader.uncompressed_page_size)
+      : await decompress(context.compression, compressedValues, pageHeader.uncompressed_page_size);
 
     dictCursor = {
       buffer: valuesBuf,
@@ -822,6 +1203,34 @@ async function decodeDictionaryPage(
     cursor.offset = cursorEnd;
   }
 
+  return decodeDictionaryValues(dictCursor, pageHeader, context);
+}
+
+/** Decodes an uncompressed dictionary page directly from a view of the column chunk. */
+function decodeUncompressedDictionaryPage(
+  cursor: CursorBuffer,
+  pageHeader: PageHeader,
+  context: ParquetReaderContext
+): (string | ArrayBuffer)[] {
+  const cursorEnd = cursor.offset + pageHeader.compressed_page_size;
+  if (cursorEnd > (cursor.size ?? cursor.buffer.length)) {
+    throw new Error('Parquet dictionary page exceeds the available buffer');
+  }
+  const dictionaryCursor: CursorBuffer = {
+    buffer: cursor.buffer.subarray(cursor.offset, cursorEnd),
+    offset: 0,
+    size: pageHeader.compressed_page_size
+  };
+  cursor.offset = cursorEnd;
+  return decodeDictionaryValues(dictionaryCursor, pageHeader, context);
+}
+
+/** Decodes one dictionary body from its current cursor without copying uncompressed page bytes. */
+function decodeDictionaryValues(
+  dictionaryCursor: CursorBuffer,
+  pageHeader: PageHeader,
+  context: ParquetReaderContext
+): (string | ArrayBuffer)[] {
   const numValues = pageHeader?.dictionary_page_header?.num_values || 0;
   const declaredEncoding = getThriftEnum(
     Encoding,
@@ -837,7 +1246,7 @@ async function decodeDictionaryPage(
   const decodedDictionaryValues = decodeValues(
     context.column.primitiveType!,
     dictionaryValueEncoding,
-    dictCursor,
+    dictionaryCursor,
     numValues,
     {
       ...context,

--- a/modules/parquet/src/parquetjs/parser/parquet-reader.ts
+++ b/modules/parquet/src/parquetjs/parser/parquet-reader.ts
@@ -7,13 +7,21 @@
 import type {ReadableFile} from '@loaders.gl/loader-utils';
 
 import {ParquetSchema} from '../schema/schema';
-import {decodeSchema, decodeDataPages, decodePage} from './decoders';
+import {
+  decodeSchema,
+  decodeDataPages,
+  decodePage,
+  decodeUncompressedDataPages,
+  decodeUncompressedDictionaryBuffer
+} from './decoders';
 import {materializeRows} from '../schema/shred';
+import {createParquetPageDecompressor, type ParquetPageDecompressor} from '../compression';
 
 import {PARQUET_MAGIC, PARQUET_MAGIC_ENCRYPTED} from '../../lib/constants';
 import {
   ColumnChunk,
   CompressionCodec,
+  Encoding,
   FileMetaData,
   PageType,
   RowGroup,
@@ -56,6 +64,32 @@ import type {ParquetEncryptionModule} from '../../lib/parquet-encryption';
 /** Bounds concurrent range requests when a row group contains unusually many selected columns. */
 const MAXIMUM_CONCURRENT_COLUMN_READS = 16;
 
+/**
+ * Returns whether column metadata guarantees that every data page can decode directly into an
+ * Arrow-compatible byte buffer. Level encodings are included in the metadata encoding set and do
+ * not prevent the byte-array fast path.
+ */
+function hasOnlyArrowByteArrayDataPageEncodings(
+  encodings: Encoding[],
+  dictionaryPageOffset: number | undefined
+): boolean {
+  if (dictionaryPageOffset !== undefined || encodings.length === 0) {
+    return false;
+  }
+  for (const encoding of encodings) {
+    if (
+      encoding !== Encoding.PLAIN &&
+      encoding !== Encoding.DELTA_LENGTH_BYTE_ARRAY &&
+      encoding !== Encoding.DELTA_BYTE_ARRAY &&
+      encoding !== Encoding.RLE &&
+      encoding !== Encoding.BIT_PACKED
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
 /** Returns the algorithm name represented by the Thrift encryption union. */
 function getEncryptionAlgorithm(value: {
   AES_GCM_V1?: unknown;
@@ -77,6 +111,8 @@ export type ParquetReaderProps = {
   useTypedValueBuffers?: boolean;
   /** Decode repetition and definition levels into compact unsigned typed arrays. */
   useTypedLevelBuffers?: boolean;
+  /** Decode eligible PLAIN BYTE_ARRAY columns into Arrow-compatible contiguous buffers. */
+  useArrowByteArrayBuffers?: boolean;
   /** Verify page-header CRC values when present. Disabled by default for throughput. */
   verifyPageChecksums?: boolean;
   /** Decode legacy INT96 values as epoch nanoseconds for Arrow timestamp columns. */
@@ -137,6 +173,7 @@ export class ParquetReader {
     retainByteArrayViews: false,
     useTypedValueBuffers: false,
     useTypedLevelBuffers: false,
+    useArrowByteArrayBuffers: false,
     verifyPageChecksums: false,
     int96AsTimestamp: false,
     verifyFooterSignature: true,
@@ -155,6 +192,8 @@ export class ParquetReader {
   private encryptionContext?: ParquetEncryptionContext;
   /** Resolved keys shared by encrypted modules in this reader instance. */
   private readonly encryptionKeyCache = new Map<string, Promise<ArrayBuffer | ArrayBufferView>>();
+  /** Compression backends selected once and shared by every page in this reader. */
+  private readonly pageDecompressors = new Map<ParquetCompression, ParquetPageDecompressor>();
 
   constructor(file: ReadableFile, props?: ParquetReaderProps) {
     this.file = file;
@@ -215,8 +254,35 @@ export class ParquetReader {
 
   close(): void {
     this.encryptionKeyCache.clear();
+    this.pageDecompressors.clear();
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
     this.file.close();
+  }
+
+  /** Returns the reader-scoped decoder for one Parquet compression method. */
+  private getPageDecompressor(compression: ParquetCompression): ParquetPageDecompressor {
+    let decompressor = this.pageDecompressors.get(compression);
+    if (!decompressor) {
+      decompressor = createParquetPageDecompressor(compression);
+      this.pageDecompressors.set(compression, decompressor);
+    }
+    return decompressor;
+  }
+
+  /** Reads a byte range, retaining a zero-copy view when the complete file is already in memory. */
+  private async readBytes(
+    start: number,
+    length: number,
+    signal?: AbortSignal
+  ): Promise<Uint8Array> {
+    const effectiveSignal = signal ?? this.props.signal;
+    if (effectiveSignal?.aborted) {
+      throw new Error('Request aborted');
+    }
+    if (this.file.handle instanceof ArrayBuffer) {
+      return new Uint8Array(this.file.handle, start, length);
+    }
+    return toUint8Array(await this.file.read(start, length, effectiveSignal));
   }
 
   /** Returns a reader-scoped key resolver that avoids repeating key-provider work per module. */
@@ -334,8 +400,7 @@ export class ParquetReader {
 
   /** Metadata is stored in the footer */
   async readHeader(signal?: AbortSignal): Promise<void> {
-    const arrayBuffer = await this.file.read(0, PARQUET_MAGIC.length, signal ?? this.props.signal);
-    const magic = decodeString(toUint8Array(arrayBuffer));
+    const magic = decodeString(await this.readBytes(0, PARQUET_MAGIC.length, signal));
     switch (magic) {
       case PARQUET_MAGIC:
         break;
@@ -349,12 +414,7 @@ export class ParquetReader {
   /** Metadata is stored in the footer */
   async readFooter(signal?: AbortSignal): Promise<FileMetaData> {
     const trailerLen = PARQUET_MAGIC.length + 4;
-    const arrayBuffer = await this.file.read(
-      this.file.size - trailerLen,
-      trailerLen,
-      signal ?? this.props.signal
-    );
-    const trailer = toUint8Array(arrayBuffer);
+    const trailer = await this.readBytes(this.file.size - trailerLen, trailerLen, signal);
 
     const magic = decodeString(trailer, 4);
     const metadataSize = readUInt32LE(trailer, 0);
@@ -370,12 +430,7 @@ export class ParquetReader {
       throw new Error(`Invalid metadata size ${metadataOffset}`);
     }
 
-    const arrayBuffer2 = await this.file.read(
-      metadataOffset,
-      metadataSize,
-      signal ?? this.props.signal
-    );
-    const metadataBuf = toUint8Array(arrayBuffer2);
+    const metadataBuf = await this.readBytes(metadataOffset, metadataSize, signal);
     // let metadata = new parquet_thrift.FileMetaData();
     // parquet_util.decodeThrift(metadata, metadataBuf);
 
@@ -419,9 +474,7 @@ export class ParquetReader {
     if (!this.props.keyRetriever) {
       throw new Error('Encrypted Parquet footer requires parquet.keyRetriever');
     }
-    const encryptedFooter = toUint8Array(
-      await this.file.read(metadataOffset, metadataSize, signal ?? this.props.signal)
-    );
+    const encryptedFooter = await this.readBytes(metadataOffset, metadataSize, signal);
     const cryptoMetadata = decodeFileCryptoMetadata(encryptedFooter);
     const algorithm = getEncryptionAlgorithm(cryptoMetadata.metadata.encryption_algorithm);
     const algorithmMetadata =
@@ -637,14 +690,30 @@ export class ParquetReader {
         continue;
       }
       const physicalColumnOrdinal = getPhysicalColumnOrdinal(columnChunk, columnOrdinal);
-      const metadata = await this.getColumnMetadata(
-        columnChunk,
-        rowGroupOrdinal,
-        physicalColumnOrdinal
-      );
+      const metadata =
+        columnChunk.meta_data ||
+        (await this.getColumnMetadata(columnChunk, rowGroupOrdinal, physicalColumnOrdinal));
       if (columnList.length === 0 || fieldIndexOf(columnList, metadata.path_in_schema) >= 0) {
         selectedColumnChunks.push({columnChunk, metadata, columnOrdinal: physicalColumnOrdinal});
       }
+    }
+    if (
+      this.file.handle instanceof ArrayBuffer &&
+      selectedColumnChunks.every(
+        ({columnChunk, metadata}) =>
+          !columnChunk.crypto_metadata &&
+          getThriftEnum(CompressionCodec, metadata.codec) === 'UNCOMPRESSED'
+      )
+    ) {
+      return {
+        rowCount: Number(rowGroup.num_rows),
+        columnData: Object.fromEntries(
+          selectedColumnChunks.map(({columnChunk, metadata}) => [
+            metadata.path_in_schema.join(),
+            this.readUncompressedColumnChunkFromMemory(schema, columnChunk, metadata)
+          ])
+        )
+      };
     }
     const columnEntries: Array<readonly [string, ParquetColumnChunk]> = [];
     for (
@@ -658,17 +727,26 @@ export class ParquetReader {
       );
       columnEntries.push(
         ...(await Promise.all(
-          columnBatch.map(async ({columnChunk, metadata, columnOrdinal}) => {
+          columnBatch.map(({columnChunk, metadata, columnOrdinal}) => {
             const columnKey = metadata.path_in_schema.join();
-            const columnData = await this.readColumnChunk(
+            if (
+              this.file.handle instanceof ArrayBuffer &&
+              !columnChunk.crypto_metadata &&
+              getThriftEnum(CompressionCodec, metadata.codec) === 'UNCOMPRESSED'
+            ) {
+              return [
+                columnKey,
+                this.readUncompressedColumnChunkFromMemory(schema, columnChunk, metadata)
+              ] as const;
+            }
+            return this.readColumnChunk(
               schema,
               columnChunk,
               signal,
               rowGroupOrdinal,
               columnOrdinal,
               metadata
-            );
-            return [columnKey, columnData] as const;
+            ).then(columnData => [columnKey, columnData] as const);
           })
         ))
       );
@@ -702,11 +780,9 @@ export class ParquetReader {
         continue;
       }
       const physicalColumnOrdinal = getPhysicalColumnOrdinal(columnChunk, columnOrdinal);
-      const metadata = await this.getColumnMetadata(
-        columnChunk,
-        rowGroupOrdinal,
-        physicalColumnOrdinal
-      );
+      const metadata =
+        columnChunk.meta_data ||
+        (await this.getColumnMetadata(columnChunk, rowGroupOrdinal, physicalColumnOrdinal));
       if (columnList.length === 0 || fieldIndexOf(columnList, metadata.path_in_schema) >= 0) {
         selectedColumnChunks.push({columnChunk, metadata, columnOrdinal: physicalColumnOrdinal});
       }
@@ -735,6 +811,80 @@ export class ParquetReader {
       rowCount: rowRange.end - rowRange.start,
       columnData: Object.fromEntries(columnEntries)
     };
+  }
+
+  /**
+   * Each row group contains column chunks for all the columns.
+   */
+  private readUncompressedColumnChunkFromMemory(
+    schema: ParquetSchema,
+    columnChunk: ColumnChunk,
+    metadata: NonNullable<ColumnChunk['meta_data']>
+  ): ParquetColumnChunk {
+    if (!(this.file.handle instanceof ArrayBuffer)) {
+      throw new Error('Synchronous Parquet column reads require an in-memory ArrayBuffer');
+    }
+    const field = schema.findField(metadata.path_in_schema);
+    const type: PrimitiveType = getThriftEnum(Type, metadata.type) as PrimitiveType;
+    if (type !== field.primitiveType) {
+      throw new Error(`chunk type not matching schema: ${type}`);
+    }
+
+    const pagesOffset = Number(metadata.data_page_offset);
+    const dictionaryPageOffset = metadata.dictionary_page_offset;
+    const validDictionaryPageOffset =
+      dictionaryPageOffset !== undefined && Number(dictionaryPageOffset) > 0
+        ? Number(dictionaryPageOffset)
+        : undefined;
+    const chunkOffset = Math.min(pagesOffset, validDictionaryPageOffset ?? pagesOffset);
+    const chunkEnd = chunkOffset + Number(metadata.total_compressed_size);
+    const chunkSize = Math.min(this.file.size - chunkOffset, Math.max(0, chunkEnd - chunkOffset));
+    const chunkBuffer = new Uint8Array(this.file.handle, chunkOffset, chunkSize);
+    const pagesRelativeOffset = pagesOffset - chunkOffset;
+    const pagesSize = Math.min(
+      chunkBuffer.length - pagesRelativeOffset,
+      Math.max(0, chunkEnd - pagesOffset)
+    );
+    const context: ParquetReaderContext = {
+      type,
+      rLevelMax: field.rLevelMax,
+      dLevelMax: field.dLevelMax,
+      compression: 'UNCOMPRESSED',
+      column: field,
+      numValues: metadata.num_values,
+      dictionary: [],
+      decompressPage: this.getPageDecompressor('UNCOMPRESSED'),
+      preserveBinary: this.props.preserveBinary,
+      retainByteArrayViews: this.props.retainByteArrayViews,
+      useTypedValueBuffers: this.props.useTypedValueBuffers,
+      useTypedLevelBuffers: this.props.useTypedLevelBuffers,
+      useArrowByteArrayBuffers: this.props.useArrowByteArrayBuffers,
+      // Metadata proves whether the decoder may skip its otherwise duplicated page-header scan.
+      // Keep the scan for mixed/unknown encodings: it is both a correctness guard and fallback.
+      hasOnlyArrowByteArrayDataPages: hasOnlyArrowByteArrayDataPageEncodings(
+        metadata.encodings,
+        validDictionaryPageOffset
+      ),
+      verifyPageChecksums: this.props.verifyPageChecksums,
+      int96AsTimestamp: this.props.int96AsTimestamp
+    };
+    let dictionary: unknown[] | undefined;
+    if (validDictionaryPageOffset !== undefined) {
+      const dictionaryRelativeOffset = validDictionaryPageOffset - chunkOffset;
+      const dictionarySize = Math.min(
+        Math.max(0, pagesOffset - validDictionaryPageOffset),
+        chunkBuffer.length - dictionaryRelativeOffset,
+        this.props.defaultDictionarySize
+      );
+      dictionary = decodeUncompressedDictionaryBuffer(
+        chunkBuffer.subarray(dictionaryRelativeOffset, dictionaryRelativeOffset + dictionarySize),
+        context
+      );
+    }
+    return decodeUncompressedDataPages(
+      chunkBuffer.subarray(pagesRelativeOffset, pagesRelativeOffset + pagesSize),
+      {...context, dictionary}
+    );
   }
 
   /**
@@ -774,8 +924,7 @@ export class ParquetReader {
     const chunkOffset = Math.min(pagesOffset, validDictionaryPageOffset ?? pagesOffset);
     const chunkEnd = chunkOffset + Number(metadata.total_compressed_size);
     const chunkSize = Math.min(this.file.size - chunkOffset, Math.max(0, chunkEnd - chunkOffset));
-    const arrayBuffer = await this.file.read(chunkOffset, chunkSize, signal ?? this.props.signal);
-    const chunkBuffer = toUint8Array(arrayBuffer);
+    const chunkBuffer = await this.readBytes(chunkOffset, chunkSize, signal);
     const pagesRelativeOffset = pagesOffset - chunkOffset;
     const pagesSize = Math.min(
       chunkBuffer.length - pagesRelativeOffset,
@@ -790,11 +939,19 @@ export class ParquetReader {
       column: field,
       numValues: metadata.num_values,
       dictionary: [],
+      decompressPage: this.getPageDecompressor(compression),
       // Options - TBD is this the right place for these?
       preserveBinary: this.props.preserveBinary,
       retainByteArrayViews: this.props.retainByteArrayViews,
       useTypedValueBuffers: this.props.useTypedValueBuffers,
       useTypedLevelBuffers: this.props.useTypedLevelBuffers,
+      useArrowByteArrayBuffers: this.props.useArrowByteArrayBuffers,
+      // Avoid parsing every page header twice when trusted column metadata already establishes the
+      // direct Arrow byte-array invariant. Unknown/mixed encodings retain the defensive scan.
+      hasOnlyArrowByteArrayDataPages: hasOnlyArrowByteArrayDataPageEncodings(
+        metadata.encodings,
+        validDictionaryPageOffset
+      ),
       verifyPageChecksums: this.props.verifyPageChecksums,
       int96AsTimestamp: this.props.int96AsTimestamp
     };
@@ -968,9 +1125,11 @@ export class ParquetReader {
           ? new CompactInt64(lastPage.endRowIndex - firstPage.firstRowIndex)
           : undefined,
       dictionary: [],
+      decompressPage: this.getPageDecompressor(compression),
       preserveBinary: this.props.preserveBinary,
       retainByteArrayViews: this.props.retainByteArrayViews,
       useTypedValueBuffers: this.props.useTypedValueBuffers,
+      useArrowByteArrayBuffers: this.props.useArrowByteArrayBuffers,
       verifyPageChecksums: this.props.verifyPageChecksums,
       int96AsTimestamp: this.props.int96AsTimestamp
     };
@@ -979,9 +1138,7 @@ export class ParquetReader {
     const dictionaryPageOffset = Number(columnMetadata.dictionary_page_offset);
     if (Number.isSafeInteger(dictionaryPageOffset) && dictionaryPageOffset > 0) {
       const dictionaryLength = Math.max(0, pages[0].offset - dictionaryPageOffset);
-      const dictionaryBuffer = toUint8Array(
-        await this.file.read(dictionaryPageOffset, dictionaryLength, signal ?? this.props.signal)
-      );
+      const dictionaryBuffer = await this.readBytes(dictionaryPageOffset, dictionaryLength, signal);
       const decodedDictionaryBuffer = encrypted
         ? await this.decryptColumnPages(
             dictionaryBuffer,
@@ -999,12 +1156,10 @@ export class ParquetReader {
       // Probe predecessor pages independently, then decode the final range once. This avoids
       // quadratic re-decoding when a large repeated row spans many pages.
       while (firstPageIndex > 0) {
-        const probeBuffer = toUint8Array(
-          await this.file.read(
-            firstPage.offset,
-            firstPage.compressedByteLength,
-            signal ?? this.props.signal
-          )
+        const probeBuffer = await this.readBytes(
+          firstPage.offset,
+          firstPage.compressedByteLength,
+          signal
         );
         const decodedProbeBuffer = encrypted
           ? await this.decryptColumnPages(
@@ -1025,9 +1180,7 @@ export class ParquetReader {
       }
     }
     const dataLength = lastPage.offset + lastPage.compressedByteLength - firstPage.offset;
-    const dataBuffer = toUint8Array(
-      await this.file.read(firstPage.offset, dataLength, signal ?? this.props.signal)
-    );
+    const dataBuffer = await this.readBytes(firstPage.offset, dataLength, signal);
     const decodedDataBuffer = encrypted
       ? await this.decryptColumnPages(
           dataBuffer,
@@ -1083,12 +1236,7 @@ export class ParquetReader {
       this.file.size - dictionaryPageOffset,
       this.props.defaultDictionarySize
     );
-    const arrayBuffer = await this.file.read(
-      dictionaryPageOffset,
-      dictionarySize,
-      signal ?? this.props.signal
-    );
-    const pagesBuf = toUint8Array(arrayBuffer);
+    const pagesBuf = await this.readBytes(dictionaryPageOffset, dictionarySize, signal);
     return await decodeDictionaryBuffer(pagesBuf, context);
   }
 }

--- a/modules/parquet/src/parquetjs/parser/parquet-reader.ts
+++ b/modules/parquet/src/parquetjs/parser/parquet-reader.ts
@@ -701,6 +701,7 @@ export class ParquetReader {
       this.file.handle instanceof ArrayBuffer &&
       selectedColumnChunks.every(
         ({columnChunk, metadata}) =>
+          (columnChunk.file_path === undefined || columnChunk.file_path === null) &&
           !columnChunk.crypto_metadata &&
           getThriftEnum(CompressionCodec, metadata.codec) === 'UNCOMPRESSED'
       )
@@ -731,6 +732,7 @@ export class ParquetReader {
             const columnKey = metadata.path_in_schema.join();
             if (
               this.file.handle instanceof ArrayBuffer &&
+              (columnChunk.file_path === undefined || columnChunk.file_path === null) &&
               !columnChunk.crypto_metadata &&
               getThriftEnum(CompressionCodec, metadata.codec) === 'UNCOMPRESSED'
             ) {

--- a/modules/parquet/src/parquetjs/schema/declare.ts
+++ b/modules/parquet/src/parquetjs/schema/declare.ts
@@ -194,6 +194,8 @@ export interface ParquetReaderContext {
   column: ParquetField;
   numValues?: Int64;
   dictionary?: ParquetDictionary;
+  /** Reader-scoped codec selected once and reused for independently compressed pages. */
+  decompressPage?: (value: Uint8Array, size: number) => Promise<Uint8Array>;
   /** If true, binary values are not converted to strings */
   preserveBinary?: boolean;
   /** Retain byte arrays as views into decoded page buffers for direct materialization. */
@@ -202,6 +204,10 @@ export interface ParquetReaderContext {
   useTypedValueBuffers?: boolean;
   /** Decode repetition and definition levels into compact unsigned typed arrays. */
   useTypedLevelBuffers?: boolean;
+  /** Decode eligible PLAIN BYTE_ARRAY columns into Arrow-compatible contiguous buffers. */
+  useArrowByteArrayBuffers?: boolean;
+  /** Column metadata guarantees every data page supports direct Arrow byte-array decoding. */
+  hasOnlyArrowByteArrayDataPages?: boolean;
   /** Verify a page-header CRC when one is present. */
   verifyPageChecksums?: boolean;
   /** Decode legacy INT96 physical values as epoch nanoseconds. */
@@ -212,8 +218,8 @@ export interface ParquetReaderContext {
 export type ParquetLevelBuffer = number[] | Uint8Array | Uint16Array | Uint32Array;
 
 export interface ParquetPageData {
-  dlevels: number[];
-  rlevels: number[];
+  dlevels: ParquetLevelBuffer;
+  rlevels: ParquetLevelBuffer;
   /** Actual column chunks */
   values: ParquetValueBuffer;
   /** Number of values written directly into the column destination, if one was supplied. */
@@ -247,6 +253,15 @@ export interface ParquetColumnChunk {
   dlevels: ParquetLevelBuffer;
   rlevels: ParquetLevelBuffer;
   values: ParquetValueBuffer;
+  /** Number of omitted physical values represented by definition levels when known. */
+  nullCount?: number;
+  /** Compact Arrow-compatible physical BYTE_ARRAY data produced by the Arrow reader path. */
+  byteArrayData?: {
+    /** Contiguous non-null physical value bytes. */
+    data: Uint8Array;
+    /** Offsets into `data`, with one entry beyond the final physical value. */
+    valueOffsets: Int32Array;
+  };
   count: number;
   pageHeaders: PageHeader[];
 }

--- a/modules/parquet/src/parquetjs/schema/schema.ts
+++ b/modules/parquet/src/parquetjs/schema/schema.ts
@@ -43,9 +43,19 @@ export class ParquetSchema {
    */
   findField(path: string | string[]): ParquetField {
     if (typeof path === 'string') {
+      // Flat schemas dominate analytical Parquet. Avoid split/array allocation for every Arrow
+      // field lookup while retaining the existing traversal for genuinely nested paths.
+      if (!path.includes(',')) {
+        return this.fields[path];
+      }
       // tslint:disable-next-line:no-parameter-reassignment
       path = path.split(',');
     } else {
+      // Column metadata already stores paths as arrays; the one-segment case needs no defensive
+      // clone or shift and is exercised once per selected flat column.
+      if (path.length === 1) {
+        return this.fields[path[0]];
+      }
       // tslint:disable-next-line:no-parameter-reassignment
       path = path.slice(0); // clone array
     }

--- a/modules/parquet/src/parquetjs/schema/shred.ts
+++ b/modules/parquet/src/parquetjs/schema/shred.ts
@@ -347,13 +347,20 @@ function materializeColumnAsRows(
   const rLevels: number[] = new Array(field.rLevelMax + 1).fill(0);
   let vIndex = 0;
   for (let i = 0; i < columnData.count; i++) {
-    const dLevel = columnData.dlevels[i];
-    const rLevel = columnData.rlevels[i];
+    // Zero maximum levels are implicit and may use allocation-free empty buffers. Preserve both
+    // fallbacks: required nested scalars still need dLevel === 0 to materialize their leaf value.
+    const dLevel = columnData.dlevels[i] ?? 0;
+    const rLevel = columnData.rlevels[i] ?? 0;
     rLevels[rLevel]++;
     rLevels.fill(0, rLevel + 1);
 
     let rIndex = 0;
     let record = rows[rLevels[rIndex++] - 1];
+    if (!record) {
+      throw new Error(
+        `Parquet column ${key} referenced row ${rLevels[0] - 1} of ${rows.length} at value ${i} (rLevel ${rLevel}, dLevel ${dLevel})`
+      );
+    }
 
     // Internal nodes - Build a nested row object
     for (const step of branch) {
@@ -383,7 +390,7 @@ function materializeColumnAsRows(
 
     // Leaf node - Add the value
     if (dLevel === field.dLevelMax) {
-      const primitiveValue = columnData.values[vIndex];
+      const primitiveValue = getDecodedColumnValue(columnData, vIndex);
       const value = fromPrimitive ? fromPrimitive(primitiveValue, field) : primitiveValue;
       vIndex++;
 
@@ -421,14 +428,24 @@ function materializeFlatColumnAsRows(
 
   if (field.repetitionType === 'REQUIRED' && !fromPrimitive) {
     for (let rowIndex = 0; rowIndex < count; rowIndex++) {
-      rows[rowIndex][field.name] = columnData.values[rowIndex];
+      rows[rowIndex][field.name] = getDecodedColumnValue(columnData, rowIndex);
+    }
+    return;
+  }
+
+  if (field.repetitionType === 'REQUIRED') {
+    for (let rowIndex = 0; rowIndex < count; rowIndex++) {
+      rows[rowIndex][field.name] = fromPrimitive!(
+        getDecodedColumnValue(columnData, rowIndex),
+        field
+      );
     }
     return;
   }
 
   for (let rowIndex = 0; rowIndex < count; rowIndex++) {
     if (columnData.dlevels[rowIndex] === field.dLevelMax) {
-      const primitiveValue = columnData.values[valueIndex];
+      const primitiveValue = getDecodedColumnValue(columnData, valueIndex);
       rows[rowIndex][field.name] = fromPrimitive
         ? fromPrimitive(primitiveValue, field)
         : primitiveValue;
@@ -601,7 +618,7 @@ function materializeColumnAsColumnarArray(
       const value = Types.fromPrimitive(
         // @ts-ignore
         field.originalType || field.primitiveType,
-        columnData.values[vIndex],
+        getDecodedColumnValue(columnData, vIndex),
         field
       );
       vIndex++;
@@ -653,14 +670,34 @@ function materializeFlatColumn(
     return columnData.values;
   }
 
+  if (field.repetitionType === 'REQUIRED') {
+    const column = new Array(rowCount).fill(null);
+    for (let rowIndex = 0; rowIndex < count; rowIndex++) {
+      column[rowIndex] = fromPrimitive
+        ? fromPrimitive(getDecodedColumnValue(columnData, rowIndex), field)
+        : getDecodedColumnValue(columnData, rowIndex);
+    }
+    return column;
+  }
+
   const column = new Array(rowCount).fill(null);
   let valueIndex = 0;
   for (let rowIndex = 0; rowIndex < count; rowIndex++) {
     if (columnData.dlevels[rowIndex] === field.dLevelMax) {
-      const primitiveValue = columnData.values[valueIndex];
+      const primitiveValue = getDecodedColumnValue(columnData, valueIndex);
       column[rowIndex] = fromPrimitive ? fromPrimitive(primitiveValue, field) : primitiveValue;
       valueIndex++;
     }
   }
   return column;
+}
+
+/** Returns one compact byte value or one value from the decoder's conventional destination. */
+function getDecodedColumnValue(columnData: ParquetColumnChunk, valueIndex: number): unknown {
+  const byteArrayData = columnData.byteArrayData;
+  if (!byteArrayData) return columnData.values[valueIndex];
+  return byteArrayData.data.subarray(
+    byteArrayData.valueOffsets[valueIndex],
+    byteArrayData.valueOffsets[valueIndex + 1]
+  );
 }

--- a/modules/parquet/test/parquet-arrow-primitive-fast-path.spec.ts
+++ b/modules/parquet/test/parquet-arrow-primitive-fast-path.spec.ts
@@ -1,0 +1,68 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {encode, load} from '@loaders.gl/core';
+import {ParquetJSLoader, ParquetJSWriter} from '@loaders.gl/parquet';
+import type {ObjectRowTable} from '@loaders.gl/schema';
+import {expect, test} from 'vitest';
+
+test('ParquetJSLoader builds nullable primitive Arrow vectors without losing null positions', async () => {
+  const input: ObjectRowTable = {
+    shape: 'object-row-table',
+    schema: {
+      fields: [
+        {name: 'integer', type: 'int32', nullable: true},
+        {name: 'measurement', type: 'float64', nullable: true},
+        {name: 'counter', type: 'int64', nullable: true}
+      ],
+      metadata: {}
+    },
+    data: [
+      {integer: null, measurement: 1.25, counter: 9_007_199_254_740_993n},
+      {integer: 7, measurement: null, counter: -2n},
+      {integer: -11, measurement: 3.5, counter: null},
+      {integer: null, measurement: null, counter: 4n}
+    ]
+  };
+  const parquet = await encode(input, ParquetJSWriter, {worker: false});
+  const table = await load(parquet, ParquetJSLoader, {
+    core: {worker: false},
+    parquet: {shape: 'arrow-table'}
+  });
+
+  expect(table.shape).toBe('arrow-table');
+  if (table.shape !== 'arrow-table') return;
+  expect(Array.from(table.data.getChild('integer')!)).toEqual([null, 7, -11, null]);
+  expect(Array.from(table.data.getChild('measurement')!)).toEqual([1.25, null, 3.5, null]);
+  expect(Array.from(table.data.getChild('counter')!)).toEqual([
+    9_007_199_254_740_993n,
+    -2n,
+    null,
+    4n
+  ]);
+});
+
+test('ParquetJSLoader direct INT64 delta vectors match object decoding across bit widths 0-64', async () => {
+  const url = '@loaders.gl/parquet/test/data/apache/good/delta_binary_packed.parquet';
+  const [arrowTable, objectTable] = await Promise.all([
+    load(url, ParquetJSLoader, {
+      core: {worker: false},
+      parquet: {shape: 'arrow-table'}
+    }),
+    load(url, ParquetJSLoader, {
+      core: {worker: false},
+      parquet: {shape: 'object-row-table'}
+    })
+  ]);
+
+  expect(arrowTable.shape).toBe('arrow-table');
+  expect(objectTable.shape).toBe('object-row-table');
+  if (arrowTable.shape !== 'arrow-table' || objectTable.shape !== 'object-row-table') return;
+
+  for (const field of arrowTable.data.schema.fields) {
+    expect(Array.from(arrowTable.data.getChild(field.name) || []), field.name).toEqual(
+      objectTable.data.map(row => row[field.name] ?? null)
+    );
+  }
+});

--- a/modules/parquet/test/parquet-compression.spec.ts
+++ b/modules/parquet/test/parquet-compression.spec.ts
@@ -5,7 +5,8 @@
 import { expect, test } from "vitest";
 import { ZstdCodec } from 'zstd-codec';
 import { ZstdCompression } from '@loaders.gl/compression/zstd-compression';
-import { decompress } from '../src/parquetjs/compression';
+import { SnappyJSCompressor } from '@loaders.gl/compression/snappy-compressor-snappyjs';
+import { createParquetPageDecompressor, decompress } from '../src/parquetjs/compression';
 test('Parquet compression#native streams avoid codec fallbacks', async () => {
     const formats: string[] = [];
     const restoreDecompressionStream = installMockDecompressionStream(formats, [
@@ -74,6 +75,29 @@ test('Parquet compression#unsupported native gzip lazily falls back to fflate', 
     }
     finally {
         restoreDecompressionStream();
+    }
+});
+test('Parquet compression#Snappy falls back when WebAssembly is unavailable', async () => {
+    const originalDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'WebAssembly');
+    const input = new TextEncoder().encode('Snappy fallback for a Parquet page');
+    const compressor = new SnappyJSCompressor();
+    const compressed = await compressor.compress(input.buffer);
+    try {
+        Object.defineProperty(globalThis, 'WebAssembly', {
+            configurable: true,
+            writable: true,
+            value: undefined
+        });
+        const decompressPage = createParquetPageDecompressor('SNAPPY');
+        expect(await decompressPage(new Uint8Array(compressed), input.byteLength)).toEqual(input);
+    }
+    finally {
+        if (originalDescriptor) {
+            Object.defineProperty(globalThis, 'WebAssembly', originalDescriptor);
+        }
+        else {
+            delete (globalThis as any).WebAssembly;
+        }
     }
 });
 /**

--- a/modules/parquet/test/parquet-nested-arrow.spec.ts
+++ b/modules/parquet/test/parquet-nested-arrow.spec.ts
@@ -4,8 +4,10 @@
 
 import {expect, test} from 'vitest';
 
-import {load} from '@loaders.gl/core';
-import {ParquetJSLoader} from '@loaders.gl/parquet';
+import {fetchFile, load} from '@loaders.gl/core';
+import {parseBSONSync} from '@loaders.gl/bson';
+import {ArrayBufferFile} from '@loaders.gl/loader-utils';
+import {ParquetJSLoader, ParquetReader} from '@loaders.gl/parquet';
 
 test('ParquetJSLoader projects nested and repeated columns directly to Arrow', async () => {
   const table = await load(
@@ -45,3 +47,102 @@ test('ParquetJSLoader projects nested and repeated columns directly to Arrow', a
     []
   ]);
 });
+
+test('ParquetJSLoader retains byte-backed logical columns directly in Arrow', async () => {
+  const table = await load(
+    '@loaders.gl/parquet/test/data/fruits.parquet',
+    ParquetJSLoader,
+    {
+      core: {worker: false},
+      parquet: {
+        shape: 'arrow-table',
+        columns: ['inter', 'meta_json'],
+        limit: 4
+      }
+    }
+  );
+
+  expect(table.shape).toBe('arrow-table');
+  if (table.shape !== 'arrow-table') {
+    return;
+  }
+
+  const interval = table.data.getChild('inter')?.get(0) as Uint8Array;
+  expect(Array.from(interval)).toEqual([42, 0, 0, 0, 23, 0, 0, 0, 9, 3, 0, 0]);
+
+  const metadata = table.data.getChild('meta_json');
+  expect(metadata?.get(0)).toBeNull();
+  expect(metadata?.get(1)).toBeNull();
+  const expectedShipDate = metadata?.get(2) as Uint8Array;
+  const curvedShape = metadata?.get(3) as Uint8Array;
+  expect(parseBSONSync(toExactArrayBuffer(expectedShipDate))).toHaveProperty('expected_ship_date');
+  expect(parseBSONSync(toExactArrayBuffer(curvedShape))).toEqual({shape: 'curved'});
+});
+
+test('ParquetJSLoader reuses single-page fixed byte payloads as Arrow Binary data', async () => {
+  const response = await fetchFile('@loaders.gl/parquet/test/data/fruits.parquet');
+  const parquet = await response.arrayBuffer();
+  const table = await load(parquet, ParquetJSLoader, {
+    core: {worker: false},
+    parquet: {shape: 'arrow-table', columns: ['finger', 'inter']}
+  });
+
+  expect(table.shape).toBe('arrow-table');
+  if (table.shape !== 'arrow-table') return;
+
+  const finger = table.data.getChild('finger');
+  const interval = table.data.getChild('inter');
+  expect(finger?.data[0].values.buffer).toBe(parquet);
+  expect(interval?.data[0].values.buffer).toBe(parquet);
+  expect(Array.from(finger?.get(0) as Uint8Array)).toEqual([70, 78, 79, 82, 68]);
+  expect(Array.from(interval?.get(0) as Uint8Array)).toEqual([
+    42, 0, 0, 0, 23, 0, 0, 0, 9, 3, 0, 0
+  ]);
+});
+
+test('ParquetReader compacts eligible PLAIN byte arrays for direct Arrow construction', async () => {
+  const response = await fetchFile('@loaders.gl/parquet/test/data/fruits.parquet');
+  const parquet = await response.arrayBuffer();
+  const reader = new ParquetReader(new ArrayBufferFile(parquet), {
+    retainByteArrayViews: true,
+    useTypedValueBuffers: true,
+    useTypedLevelBuffers: true,
+    useArrowByteArrayBuffers: true
+  });
+  const firstRowGroup = await reader.rowGroupIterator({columnList: ['name']}).next();
+  const name = firstRowGroup.value?.columnData.name;
+
+  expect(name?.values).toHaveLength(0);
+  expect(name?.byteArrayData?.valueOffsets).toHaveLength(4097);
+  const firstEnd = name?.byteArrayData?.valueOffsets[1] || 0;
+  expect(new TextDecoder().decode(name?.byteArrayData?.data.subarray(0, firstEnd))).toBe('apples');
+  reader.close();
+});
+
+test('ParquetReader compacts DELTA_BYTE_ARRAY strings for direct Arrow construction', async () => {
+  const response = await fetchFile(
+    '@loaders.gl/parquet/test/data/apache/good/delta_byte_array.parquet'
+  );
+  const parquet = await response.arrayBuffer();
+  const reader = new ParquetReader(new ArrayBufferFile(parquet), {
+    retainByteArrayViews: true,
+    useTypedValueBuffers: true,
+    useTypedLevelBuffers: true,
+    useArrowByteArrayBuffers: true
+  });
+  const firstRowGroup = await reader.rowGroupIterator({columnList: ['c_customer_id']}).next();
+  const customerIdentifier = firstRowGroup.value?.columnData.c_customer_id;
+
+  expect(customerIdentifier?.values).toHaveLength(0);
+  expect(customerIdentifier?.byteArrayData?.valueOffsets.length).toBeGreaterThan(1);
+  const firstEnd = customerIdentifier?.byteArrayData?.valueOffsets[1] || 0;
+  expect(
+    new TextDecoder().decode(customerIdentifier?.byteArrayData?.data.subarray(0, firstEnd))
+  ).not.toBe('');
+  reader.close();
+});
+
+/** Copies one Arrow byte view into the exact ArrayBuffer required by the BSON parser. */
+function toExactArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
+}

--- a/modules/parquet/test/parquetjs/codec-dictionary-encode.spec.ts
+++ b/modules/parquet/test/parquetjs/codec-dictionary-encode.spec.ts
@@ -21,6 +21,23 @@ test.each([
   expect(Array.from(decoded)).toEqual(indices);
 });
 
+test.each([
+  {indices: [0, 1, 0, 1, 1, 0, 1, 0], bitWidth: 1},
+  {indices: [0, 1, 2, 3, 3, 2, 1, 0], bitWidth: 2},
+  {indices: [0, 1, 2, 3, 4, 5, 6, 7], bitWidth: 3},
+  {indices: [0, 3, 6, 9, 12, 15, 8, 1], bitWidth: 4}
+])('dictionary decoder resolves specialized $bitWidth-bit indices', ({indices, bitWidth}) => {
+  const dictionary = Array.from({length: 2 ** bitWidth}, (_, index) => `value-${index}`);
+  const encoded = PARQUET_CODECS.RLE_DICTIONARY.encodeValues('INT32', indices, {bitWidth});
+  const decoded = PARQUET_CODECS.RLE_DICTIONARY.decodeValues(
+    'INT32',
+    {buffer: encoded, offset: 0, size: encoded.length},
+    indices.length,
+    {dictionary}
+  );
+  expect(Array.from(decoded)).toEqual(indices.map(index => dictionary[index]));
+});
+
 test('dictionary planner selects low-cardinality values and rejects larger output', () => {
   const column = new ParquetSchema({value: {type: 'UTF8'}}).fields.value;
   const repeatedValues = Array.from({length: 100}, (_, index) =>

--- a/modules/parquet/test/parquetjs/codec-output-buffer.spec.ts
+++ b/modules/parquet/test/parquetjs/codec-output-buffer.spec.ts
@@ -23,6 +23,27 @@ test('PLAIN writes values into a caller-provided typed buffer', () => {
   expect(output).toEqual(new Int32Array([-1, 1, -2, 3, -1]));
 });
 
+test('PLAIN exposes fixed-length values as contiguous Arrow bytes and offsets', () => {
+  const encoded = bytes([0x61, 0x62, 0x63, 0x64, 0x65, 0x66]);
+  const byteArrayOutput = {
+    data: new Uint8Array(0),
+    valueOffsets: new Int32Array(3),
+    byteLength: 0
+  };
+
+  PARQUET_CODECS.PLAIN.decodeValues(
+    'FIXED_LEN_BYTE_ARRAY',
+    {buffer: encoded, offset: 0},
+    2,
+    {typeLength: 3, byteArrayOutput}
+  );
+
+  expect(byteArrayOutput.data.buffer).toBe(encoded.buffer);
+  expect(byteArrayOutput.data).toEqual(encoded);
+  expect(byteArrayOutput.valueOffsets).toEqual(new Int32Array([0, 3, 6]));
+  expect(byteArrayOutput.byteLength).toBe(6);
+});
+
 test('RLE resolves bit-packed dictionary indices into the destination', () => {
   const output = new Float64Array(10).fill(-1);
   const dictionary = [11, 13, 17, 19, 23, 29, 31, 37];
@@ -35,6 +56,83 @@ test('RLE resolves bit-packed dictionary indices into the destination', () => {
 
   expect(decoded).toBe(output);
   expect(Array.from(output)).toEqual([-1, ...dictionary, -1]);
+});
+
+test.each([1, 2, 3, 4])('RLE decodes complete groups and tails of %i-bit unsigned values', bitWidth => {
+  const values = Array.from({length: 23}, (_, index) => index % 2 ** bitWidth);
+  const encoded = PARQUET_CODECS.RLE.encodeValues('INT32', values, {
+    bitWidth,
+    disableEnvelope: true
+  });
+  const output = new Uint8Array(values.length + 2).fill(0xff);
+
+  PARQUET_CODECS.RLE.decodeValues(
+    'INT32',
+    {buffer: encoded, offset: 0},
+    values.length,
+    {bitWidth, disableEnvelope: true, output, outputOffset: 1}
+  );
+
+  expect(output).toEqual(new Uint8Array([0xff, ...values, 0xff]));
+});
+
+test.each([1, 2, 3, 4, 10, 12])(
+  'RLE resolves complete groups and tails of %i-bit dictionary indices',
+  bitWidth => {
+    const dictionary = Array.from({length: 2 ** bitWidth}, (_, index) => `value-${index}`);
+    const indices = Array.from({length: 23}, (_, index) => index % dictionary.length);
+    const encoded = PARQUET_CODECS.RLE.encodeValues('INT32', indices, {
+      bitWidth,
+      disableEnvelope: true
+    });
+    const output = new Array<unknown>(indices.length + 2).fill('untouched');
+
+    PARQUET_CODECS.RLE.decodeValues(
+      'INT32',
+      {buffer: encoded, offset: 0},
+      indices.length,
+      {bitWidth, disableEnvelope: true, dictionary, output, outputOffset: 1}
+    );
+
+    expect(output).toEqual([
+      'untouched',
+      ...indices.map(index => dictionary[index]),
+      'untouched'
+    ]);
+  }
+);
+
+test.each([
+  {bitWidth: 10, dictionaryLength: 1000, invalidIndex: 1023, bytes: [0x03, 0xff, 0x03]},
+  {bitWidth: 12, dictionaryLength: 4095, invalidIndex: 4095, bytes: [0x03, 0xff, 0x0f]}
+])(
+  'RLE rejects corrupt $bitWidth-bit dictionary index $invalidIndex',
+  ({bitWidth, dictionaryLength, invalidIndex, bytes: encodedBytes}) => {
+    expect(() =>
+      PARQUET_CODECS.RLE.decodeValues(
+        'INT32',
+        {buffer: bytes(encodedBytes), offset: 0},
+        8,
+        {
+          disableEnvelope: true,
+          bitWidth,
+          dictionary: new Array(dictionaryLength).fill(0),
+          output: new Array(8)
+        }
+      )
+    ).toThrow(`Invalid Parquet dictionary index ${invalidIndex}`);
+  }
+);
+
+test('RLE rejects corrupt narrow bit-packed dictionary indices', () => {
+  expect(() =>
+    PARQUET_CODECS.RLE.decodeValues(
+      'INT32',
+      {buffer: bytes([0x03, 0x03]), offset: 0},
+      8,
+      {disableEnvelope: true, bitWidth: 1, dictionary: ['zero'], output: new Array(8)}
+    )
+  ).toThrow('Invalid Parquet dictionary index 1');
 });
 
 test('RLE resolves repeated dictionary indices into the destination', () => {
@@ -74,6 +172,71 @@ test('DELTA_BINARY_PACKED writes values at a destination offset', () => {
 
   expect(decoded).toBe(output);
   expect(output).toEqual(new Int32Array([-1, -1, 1, 2, 3, -1]));
+});
+
+test('DELTA_BINARY_PACKED writes wrapping INT64 values directly into Arrow storage', () => {
+  const values = [0x7fff_ffff_ffff_ffffn, -0x8000_0000_0000_0000n, 0x7fff_ffff_ffff_ffffn];
+  const encoded = PARQUET_CODECS.DELTA_BINARY_PACKED.encodeValues('INT64', values, {});
+  const output = new BigInt64Array(5).fill(-1n);
+  const decoded = PARQUET_CODECS.DELTA_BINARY_PACKED.decodeValues(
+    'INT64',
+    {buffer: encoded, offset: 0},
+    values.length,
+    {output, outputOffset: 1, int64AsBigInt: true}
+  );
+
+  expect(decoded).toBe(output);
+  expect(output).toEqual(new BigInt64Array([-1n, ...values, -1n]));
+});
+
+test('DELTA_LENGTH_BYTE_ARRAY writes contiguous Arrow bytes and offsets', () => {
+  const values = [bytes([0x61]), bytes([0x62, 0x63]), bytes([0x64, 0x65, 0x66])];
+  const encoded = PARQUET_CODECS.DELTA_LENGTH_BYTE_ARRAY.encodeValues('BYTE_ARRAY', values);
+  const byteArrayOutput = {
+    data: bytes([0xaa, 0xbb, 0, 0, 0, 0, 0, 0]),
+    valueOffsets: new Int32Array(5),
+    byteLength: 2
+  };
+  const output: unknown[] = [];
+
+  const decoded = PARQUET_CODECS.DELTA_LENGTH_BYTE_ARRAY.decodeValues(
+    'BYTE_ARRAY',
+    {buffer: encoded, offset: 0},
+    values.length,
+    {output, outputOffset: 1, byteArrayOutput}
+  );
+
+  expect(decoded).toBe(output);
+  expect(byteArrayOutput.data.subarray(0, byteArrayOutput.byteLength)).toEqual(
+    bytes([0xaa, 0xbb, 0x61, 0x62, 0x63, 0x64, 0x65, 0x66])
+  );
+  expect(byteArrayOutput.valueOffsets).toEqual(new Int32Array([0, 2, 3, 5, 8]));
+});
+
+test('DELTA_BYTE_ARRAY reconstructs shared prefixes in contiguous Arrow storage', () => {
+  const values = [
+    bytes([0x61, 0x62, 0x63]),
+    bytes([0x61, 0x62, 0x64]),
+    bytes([0x61, 0x62, 0x64, 0x65])
+  ];
+  const encoded = PARQUET_CODECS.DELTA_BYTE_ARRAY.encodeValues('BYTE_ARRAY', values);
+  const byteArrayOutput = {
+    data: new Uint8Array(4),
+    valueOffsets: new Int32Array(values.length + 1),
+    byteLength: 0
+  };
+
+  PARQUET_CODECS.DELTA_BYTE_ARRAY.decodeValues(
+    'BYTE_ARRAY',
+    {buffer: encoded, offset: 0},
+    values.length,
+    {byteArrayOutput}
+  );
+
+  expect(byteArrayOutput.data.subarray(0, byteArrayOutput.byteLength)).toEqual(
+    bytes([0x61, 0x62, 0x63, 0x61, 0x62, 0x64, 0x61, 0x62, 0x64, 0x65])
+  );
+  expect(byteArrayOutput.valueOffsets).toEqual(new Int32Array([0, 3, 6, 10]));
 });
 
 test('PLAIN keeps boolean arrays compatible and supports compact typed destinations', () => {

--- a/modules/parquet/test/parquetjs/reader.spec.ts
+++ b/modules/parquet/test/parquetjs/reader.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "vitest";
-import { BlobFile } from '@loaders.gl/loader-utils';
+import { ArrayBufferFile, BlobFile } from '@loaders.gl/loader-utils';
 import { ParquetReader } from '@loaders.gl/parquet';
 import { fetchFile } from '@loaders.gl/core';
 const FRUITS_URL = '@loaders.gl/parquet/test/data/fruits.parquet';
@@ -34,6 +34,39 @@ class TrackedBlobFile extends BlobFile {
         }
     }
 }
+
+/** In-memory file that records whether the reader requested copying range reads. */
+class TrackedArrayBufferFile extends ArrayBufferFile {
+    /** Number of copying reads requested from the file adapter. */
+    readCount = 0;
+
+    /** Records a fallback range read before delegating to the file adapter. */
+    override async read(
+        start?: number | bigint,
+        length?: number,
+        signal?: AbortSignal
+    ): Promise<ArrayBuffer> {
+        this.readCount++;
+        return await super.read(start, length, signal);
+    }
+}
+
+test('ParquetReader#uses zero-copy ranges for in-memory files', async () => {
+    const response = await fetchFile(DICTIONARY_URL);
+    const file = new TrackedArrayBufferFile(await response.arrayBuffer());
+    const reader = new ParquetReader(file, {
+        retainByteArrayViews: true,
+        useTypedLevelBuffers: true,
+        useTypedValueBuffers: true
+    });
+
+    const iterator = reader.rowGroupIterator({columnList: ['id']});
+    const firstRowGroup = await iterator.next();
+
+    expect(firstRowGroup.done).toBe(false);
+    expect(file.readCount).toBe(0);
+    reader.close();
+});
 // eslint-disable-next-line
 test('ParquetReader#fruits.parquet', async () => {
     const response = await fetchFile(FRUITS_URL);

--- a/modules/parquet/test/parquetjs/reader.spec.ts
+++ b/modules/parquet/test/parquetjs/reader.spec.ts
@@ -67,6 +67,21 @@ test('ParquetReader#uses zero-copy ranges for in-memory files', async () => {
     expect(file.readCount).toBe(0);
     reader.close();
 });
+test('ParquetReader#rejects external columns before using the in-memory fast path', async () => {
+    const response = await fetchFile(FRUITS_URL);
+    const reader = new ParquetReader(new ArrayBufferFile(await response.arrayBuffer()), {
+        useTypedLevelBuffers: true,
+        useTypedValueBuffers: true
+    });
+    const metadata = await reader.getFileMetadata();
+    const schema = await reader.getSchema();
+    metadata.row_groups[0].columns[0].file_path = 'external.parquet';
+
+    await expect(reader.readRowGroup(schema, metadata.row_groups[0], [])).rejects.toThrow(
+        'external references are not supported'
+    );
+    reader.close();
+});
 // eslint-disable-next-line
 test('ParquetReader#fruits.parquet', async () => {
     const response = await fetchFile(FRUITS_URL);

--- a/website/src/examples/parquet-benchmarks-app.tsx
+++ b/website/src/examples/parquet-benchmarks-app.tsx
@@ -108,6 +108,8 @@ const PARQUET_BENCHMARK_IMPLEMENTATION_IDS: ParquetBenchmarkImplementationId[] =
   'hyparquet'
 ];
 
+let parquetBenchmarkScenariosPromise: Promise<ParquetBenchmarkScenario[]> | undefined;
+
 /** Renders live comparative Parquet decode benchmarks in the visitor's browser. */
 export default function ParquetBenchmarksApp(): JSX.Element {
   const [rows, setRows] = useState<BenchmarkResultRow[]>([]);
@@ -165,7 +167,7 @@ export default function ParquetBenchmarksApp(): JSX.Element {
       try {
         const scenarios = await runBenchmarkPhase(
           'Fixture setup failed',
-          createParquetBenchmarkScenarios
+          loadParquetBenchmarkScenarios
         );
         if (isMounted) {
           setScenarios(
@@ -225,10 +227,6 @@ export default function ParquetBenchmarksApp(): JSX.Element {
 
   return (
     <div className="benchmark-page">
-      <p>
-        Live Parquet decode throughput, primarily to Arrow with one object-row control. Keep this tab
-        focused while it runs.
-      </p>
       <div className="benchmark-status-row" aria-live="polite">
         {isRunning ? <span className="benchmark-spinner" aria-hidden="true" /> : null}
         <p className="benchmark-status">Status: {status}</p>
@@ -337,6 +335,21 @@ export default function ParquetBenchmarksApp(): JSX.Element {
   );
 }
 
+/** Loads the immutable benchmark fixture set once for the lifetime of the page. */
+async function loadParquetBenchmarkScenarios(): Promise<ParquetBenchmarkScenario[]> {
+  if (!parquetBenchmarkScenariosPromise) {
+    const nextPromise = createParquetBenchmarkScenarios();
+    const cachedPromise = nextPromise.catch(error => {
+      if (parquetBenchmarkScenariosPromise === cachedPromise) {
+        parquetBenchmarkScenariosPromise = undefined;
+      }
+      throw error;
+    });
+    parquetBenchmarkScenariosPromise = cachedPromise;
+  }
+  return await parquetBenchmarkScenariosPromise;
+}
+
 /** Adds a stable phase label to browser benchmark setup failures. */
 async function runBenchmarkPhase<Result>(
   label: string,
@@ -402,8 +415,16 @@ async function createParquetBenchmarkScenarios(): Promise<ParquetBenchmarkScenar
   );
   return [
     {
-      name: 'GeoParquet SNAPPY · 1K rows × 4 cols → Arrow',
-      arrayBuffer: geoParquetArrayBuffer,
+      name: 'PLAIN nullable primitives · 40K rows × 6 cols → Arrow',
+      arrayBuffer: fruitsArrayBuffer,
+      columns: ['name', 'quantity', 'price', 'date', 'day', 'finger'],
+      shape: 'arrow-table',
+      implementationIds: ['typescript', 'wasm', 'hyparquet']
+    },
+    {
+      name: 'PLAIN single-column projection · 40K rows × 1 col → Arrow',
+      arrayBuffer: fruitsArrayBuffer,
+      columns: ['quantity'],
       shape: 'arrow-table',
       implementationIds: ['typescript', 'wasm', 'hyparquet']
     },
@@ -412,29 +433,50 @@ async function createParquetBenchmarkScenarios(): Promise<ParquetBenchmarkScenar
       arrayBuffer: fruitsArrayBuffer,
       columns: ['name', 'quantity', 'price', 'date', 'day', 'finger', 'stock', 'colour'],
       shape: 'arrow-table',
-      // parquet-wasm 0.7.2 retains the unprojected INTERVAL field in its IPC schema.
-      implementationIds: ['typescript', 'hyparquet']
+      implementationIds: ['typescript', 'wasm', 'hyparquet']
     },
     {
-      name: 'PLAIN nullable primitives · 40K rows × 6 cols → Arrow',
+      name: 'PLAIN full table · 40K rows × 10 cols → Arrow',
       arrayBuffer: fruitsArrayBuffer,
-      columns: ['name', 'quantity', 'price', 'date', 'day', 'finger'],
       shape: 'arrow-table',
-      // parquet-wasm 0.7.2 retains the unprojected INTERVAL field in its IPC schema.
-      implementationIds: ['typescript', 'hyparquet']
+      implementationIds: ['typescript', 'wasm', 'hyparquet']
+    },
+    {
+      name: 'RLE_DICTIONARY mixed table · 20K rows × 5 cols → Arrow Utf8',
+      arrayBuffer: dictionaryArrayBuffer,
+      shape: 'arrow-table',
+      implementationIds: ['typescript', 'wasm', 'hyparquet']
     },
     {
       name: 'PLAIN nested/repeated · 40K rows × 2 cols → Arrow',
       arrayBuffer: fruitsArrayBuffer,
       columns: ['stock', 'colour'],
       shape: 'arrow-table',
-      // parquet-wasm 0.7.2 retains the unprojected INTERVAL field in its IPC schema.
-      implementationIds: ['typescript', 'hyparquet']
+      implementationIds: ['typescript', 'wasm', 'hyparquet']
     },
     {
-      name: 'RLE_DICTIONARY mixed table · 20K rows × 5 cols → Arrow',
-      arrayBuffer: dictionaryArrayBuffer,
+      name: 'DELTA_BINARY_PACKED wide integers · 200 rows × 66 cols → Arrow',
+      arrayBuffer: deltaBinaryPackedArrayBuffer,
       shape: 'arrow-table',
+      implementationIds: ['typescript', 'wasm', 'hyparquet']
+    },
+    {
+      name: 'DELTA_BYTE_ARRAY strings · 1K rows × 9 cols → Arrow',
+      arrayBuffer: deltaByteArrayBuffer,
+      shape: 'arrow-table',
+      implementationIds: ['typescript', 'wasm', 'hyparquet']
+    },
+    {
+      name: 'DELTA_BYTE_ARRAY projection · 1K rows × 2 cols → Arrow',
+      arrayBuffer: deltaByteArrayBuffer,
+      columns: ['c_customer_id', 'c_email_address'],
+      shape: 'arrow-table',
+      implementationIds: ['typescript', 'wasm', 'hyparquet']
+    },
+    {
+      name: 'DELTA_BYTE_ARRAY control · 1K rows × 9 cols → object rows',
+      arrayBuffer: deltaByteArrayBuffer,
+      shape: 'object-row-table',
       implementationIds: ['typescript', 'wasm', 'hyparquet']
     },
     {
@@ -446,12 +488,6 @@ async function createParquetBenchmarkScenarios(): Promise<ParquetBenchmarkScenar
     {
       name: 'RLE_DICTIONARY + ZSTD · 20K rows × 5 cols → Arrow',
       arrayBuffer: compressedDictionaryFixtures.zstd,
-      shape: 'arrow-table',
-      implementationIds: ['typescript', 'wasm', 'hyparquet']
-    },
-    {
-      name: 'DELTA_BINARY_PACKED wide integers · 200 rows × 66 cols → Arrow',
-      arrayBuffer: deltaBinaryPackedArrayBuffer,
       shape: 'arrow-table',
       implementationIds: ['typescript', 'wasm', 'hyparquet']
     },
@@ -468,23 +504,9 @@ async function createParquetBenchmarkScenarios(): Promise<ParquetBenchmarkScenar
       implementationIds: ['typescript', 'wasm', 'hyparquet']
     },
     {
-      name: 'DELTA_BYTE_ARRAY strings · 1K rows × 9 cols → Arrow',
-      arrayBuffer: deltaByteArrayBuffer,
+      name: 'GeoParquet SNAPPY · 1K rows × 4 cols → Arrow',
+      arrayBuffer: geoParquetArrayBuffer,
       shape: 'arrow-table',
-      implementationIds: ['typescript', 'wasm', 'hyparquet']
-    },
-    {
-      name: 'DELTA_BYTE_ARRAY projection · 1K rows × 2 cols → Arrow',
-      arrayBuffer: deltaByteArrayBuffer,
-      columns: ['c_customer_id', 'c_email_address'],
-      shape: 'arrow-table',
-      // parquet-wasm 0.7.2 returns mismatched IPC schema/vector counts for this projection.
-      implementationIds: ['typescript', 'hyparquet']
-    },
-    {
-      name: 'DELTA_BYTE_ARRAY control · 1K rows × 9 cols → object rows',
-      arrayBuffer: deltaByteArrayBuffer,
-      shape: 'object-row-table',
       implementationIds: ['typescript', 'wasm', 'hyparquet']
     }
   ];
@@ -496,18 +518,25 @@ async function createCompressedBenchmarkFixtures(
 ): Promise<{gzip: ArrayBuffer; zstd: ArrayBuffer}> {
   const {loadWasm} = await import('../../../modules/parquet/src/lib/utils/load-wasm');
   const parquetWasm = await loadWasm();
+
   const gzipTable = parquetWasm.readParquet(new Uint8Array(arrayBuffer));
-  const zstdTable = parquetWasm.readParquet(new Uint8Array(arrayBuffer));
   const gzipProperties = new parquetWasm.WriterPropertiesBuilder()
     .setCompression(parquetWasm.Compression.GZIP)
     .setMaxRowGroupSize(4000)
     .build();
+  const gzip = copyUint8ArrayToArrayBuffer(
+    parquetWasm.writeParquet(gzipTable, gzipProperties)
+  );
+
+  // Build the second fixture only after writeParquet has consumed and released the first table
+  // and its writer properties, keeping the WASM linear-memory high-water mark smaller.
+  const zstdTable = parquetWasm.readParquet(new Uint8Array(arrayBuffer));
   const zstdProperties = new parquetWasm.WriterPropertiesBuilder()
     .setCompression(parquetWasm.Compression.ZSTD)
     .setMaxRowGroupSize(4000)
     .build();
   return {
-    gzip: copyUint8ArrayToArrayBuffer(parquetWasm.writeParquet(gzipTable, gzipProperties)),
+    gzip,
     zstd: copyUint8ArrayToArrayBuffer(parquetWasm.writeParquet(zstdTable, zstdProperties))
   };
 }
@@ -531,24 +560,23 @@ async function createParquetBenchmarkImplementations(): Promise<
   ParquetBenchmarkImplementation[]
 > {
   const [
-    loadersGlLoaderUtils,
     loadersGlTypeScript,
-    loadersGlWasm,
+    loadersGlWasmRuntime,
     loadersGlTableConverters,
     loadersGlSchemaUtils,
+    arrowJs,
     hyparquet,
-    hyparquetCompressors,
-    zstdCodec
+    hyparquetCompressors
   ] = await Promise.all([
-    import('@loaders.gl/loader-utils'),
     import('../../../modules/parquet/src/parquet-js-loader'),
-    import('../../../modules/parquet/src/lib/parsers/parse-parquet-to-arrow'),
+    import('../../../modules/parquet/src/lib/utils/load-wasm'),
     import('../../../modules/parquet/src/lib/parsers/convert-parquet-tables'),
     import('@loaders.gl/schema-utils'),
+    import('apache-arrow'),
     import('hyparquet'),
-    import('hyparquet-compressors'),
-    import('zstd-codec')
+    import('hyparquet-compressors')
   ]);
+  const parquetWasm = await loadersGlWasmRuntime.loadWasm();
   return [
     {
       id: 'typescript',
@@ -558,8 +586,7 @@ async function createParquetBenchmarkImplementations(): Promise<
           scenario.arrayBuffer,
           {
             core: {worker: false},
-            parquet: {columns: scenario.columns, shape: scenario.shape},
-            modules: {'zstd-codec': zstdCodec.ZstdCodec}
+            parquet: {columns: scenario.columns, shape: scenario.shape}
           }
         )) as ArrowTable | ObjectRowTable;
         return getBenchmarkTableRowCount(table);
@@ -569,10 +596,16 @@ async function createParquetBenchmarkImplementations(): Promise<
       id: 'wasm',
       name: PARQUET_BENCHMARK_IMPLEMENTATION_LABELS.wasm,
       decode: async scenario => {
-        const arrowTable = await loadersGlWasm.parseParquetFileToArrow(
-          new loadersGlLoaderUtils.BlobFile(scenario.arrayBuffer),
-          {columns: scenario.columns}
-        );
+        const wasmTable = parquetWasm.readParquet(new Uint8Array(scenario.arrayBuffer), {
+          columns: scenario.columns
+        });
+        const arrowTable: ArrowTable = {
+          shape: 'arrow-table',
+          data: expandArrowDictionaryColumns(
+            arrowJs.tableFromIPC(wasmTable.intoIPCStream()),
+            arrowJs
+          )
+        };
         if (scenario.shape === 'arrow-table') {
           return arrowTable.data.numRows;
         }
@@ -606,6 +639,28 @@ async function createParquetBenchmarkImplementations(): Promise<
       }
     }
   ];
+}
+
+/**
+ * Expands Arrow dictionary columns so the WASM comparison performs the same Utf8 materialization
+ * as the TypeScript and hyparquet cases.
+ */
+function expandArrowDictionaryColumns(
+  table: import('apache-arrow').Table,
+  arrowJs: typeof import('apache-arrow')
+): import('apache-arrow').Table {
+  const columns: Record<string, import('apache-arrow').Vector | unknown[]> = {};
+  let hasDictionaryColumn = false;
+  for (const field of table.schema.fields) {
+    const vector = table.getChild(field.name)!;
+    if (field.type instanceof arrowJs.Dictionary) {
+      columns[field.name] = Array.from(vector);
+      hasDictionaryColumn = true;
+    } else {
+      columns[field.name] = vector;
+    }
+  }
+  return hasDictionaryColumn ? arrowJs.tableFromArrays(columns) : table;
 }
 
 /** Returns the materialized row count for either benchmark table shape. */

--- a/yarn.lock
+++ b/yarn.lock
@@ -5179,6 +5179,7 @@ __metadata:
     compress-utils: "npm:^0.8.0"
     fflate: "npm:0.7.4"
     fzstd: "npm:0.1.1"
+    hysnappy: "npm:^1.1.1"
     lz4js: "npm:^0.2.0"
     pako: "npm:^2.1.0"
     snappyjs: "npm:^0.6.1"
@@ -20573,6 +20574,13 @@ __metadata:
   version: 1.0.0
   resolution: "hysnappy@npm:1.0.0"
   checksum: 10c0/f7d920290832b34d0582bd0e3fdac60df8399ceab740722311c7dbd845c69c38c8e448fbc50e58315c000bcad04365e3f461dc785432cb890540406040724ecc
+  languageName: node
+  linkType: hard
+
+"hysnappy@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "hysnappy@npm:1.1.1"
+  checksum: 10c0/d8e2f098ee0452992c13bf77e5d83fbc59247ad67f1310e0d880996e5eba4f26d5a620c9a2366415521c69e8dd38f2fec70fe22fcc5bfcb533b63764e21f5f04
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Goals

- Make the TypeScript `ParquetJSLoader` competitive with native/WASM implementations on representative Arrow workloads.
- Reduce intermediate allocation, buffer copying, async overhead, and repeated codec setup without changing public output semantics.
- Keep the browser benchmark honest, compact, versioned, and broad enough to expose both wins and remaining gaps.

## Changes

- Decode PLAIN, RLE/dictionary, DELTA_BINARY_PACKED, DELTA_LENGTH_BYTE_ARRAY, and DELTA_BYTE_ARRAY data into typed or Arrow-compatible buffers on their hot paths.
- Decode Arrow INT64 output with exact two-word arithmetic instead of per-value BigInt arithmetic, fuse equal-width mini-blocks, and use narrow bit reservoirs where V8 can remain exact.
- Construct flat primitive, byte-array, and supported nested Arrow vectors directly from decoded column buffers; avoid object-row and generic table conversion where possible.
- Add synchronous in-memory handling for uncompressed row groups, zero-copy in-memory range views, reader-scoped decompressor caching, compact level buffers, and metadata-backed page-scan avoidance.
- Preserve the object-row path with typed decoded values and fix implicit zero levels for required nested fields.
- Use synchronous JavaScript page codecs where per-page native `DecompressionStream` setup is counterproductive; add the lightweight hysnappy fallback and document the page-frame tradeoff.
- Reorder and compact the live benchmark around mainstream uncompressed/encoded cases first and compression-focused cases last; report exact external package versions and distinguish failed results.
- Add focused Vitest coverage for direct Arrow buffers, integer widths, nested values, dictionary output, and codec fallbacks.

## Live browser results

On the final local production build, `ParquetJSLoader` wins the six mainstream non-compression rows before the DELTA stress cases, plus DELTA projection, DELTA object rows, GZIP, and ZSTD. The two remaining non-compression gaps remain visible:

- DELTA_BINARY_PACKED 200 rows × 66 columns: 211K rows/s vs 309K rows/s for parquet-wasm
- DELTA_BYTE_ARRAY 1K rows × 9 columns: 2.13M rows/s vs 3.19M rows/s for parquet-wasm

Results vary by browser and hardware; the embedded benchmark remains the source of truth for local comparisons.

## Validation

- `yarn lint fix`
- `yarn build`
- `yarn build-workers`
- `yarn test-node` — 52 files, 361 passed, 6 skipped
- `yarn test-headless` — 519 files passed; one required-nested-field regression found and fixed
- focused `modules/parquet/test/parquet-loader.spec.ts` rerun — 33 passed
- `yarn test-audit` — 623 files, 0 Tape, 0 violations
- `cd website && yarn build`
- final production-site live benchmark completed in Chromium
