### PR TITLE
feat(draco): consolidate encoding, diagnostics, and safe batch APIs

### DIFF
--- a/docs/modules/draco/README.md
+++ b/docs/modules/draco/README.md
@@ -66,3 +66,16 @@ Remarks
 ## Attributions
 
 Based on Draco examples, under the Apache 2.0 license.
+# Draco roadmap
+
+The Draco module now supports glTF-optimized decoding, retained quantization metadata,
+selective extraction, encoding diagnostics, and batch encoding. The remaining planned work is
+tracked as compatibility and lifecycle improvements rather than a worker-pool abstraction.
+
+| Area | Current direction |
+| --- | --- |
+| Presets | `gltf`, `webgpu`, and `balanced` profiles provide explicit, reproducible defaults. |
+| Conformance | Keep cross-runtime fixtures for full and glTF decoder builds. |
+| Interoperability | Preserve names, normalized flags, transforms, and metadata across Arrow/Draco round trips. |
+| Memory | Reuse initialized runtimes and process batches sequentially; worker pooling is tracked separately. |
+| Compatibility | Retain legacy writer/loader entry points while steering new code to `encodeDraco` and typed reports. |

--- a/docs/modules/draco/api-reference/draco-writer.md
+++ b/docs/modules/draco/api-reference/draco-writer.md
@@ -5,6 +5,9 @@ import {DracoDocsTabs} from '@site/src/components/docs/draco-docs-tabs';
 For applications encoding many independent geometries, `encodeDracoBatch` initializes the
 Draco runtime once and processes inputs sequentially, keeping peak native memory bounded while
 avoiding per-geometry module startup overhead. It returns one `DracoEncodingResult` per input.
+An optional `AbortSignal` cancels between geometries, and `onProgress` receives a completion
+count after each successful encode. Worker pooling is intentionally tracked separately for the
+shared loaders.gl worker framework.
 
 <DracoDocsTabs active="dracowriter" />
 

--- a/docs/modules/draco/api-reference/draco-writer.md
+++ b/docs/modules/draco/api-reference/draco-writer.md
@@ -5,6 +5,9 @@ import {DracoDocsTabs} from '@site/src/components/docs/draco-docs-tabs';
 For applications encoding many independent geometries, `encodeDracoBatch` initializes the
 Draco runtime once and processes inputs sequentially, keeping peak native memory bounded while
 avoiding per-geometry module startup overhead. It returns one `DracoEncodingResult` per input.
+An optional `AbortSignal` cancels between geometries, and `onProgress` receives a completion
+count after each successful encode. This deliberately remains sequential; worker pooling is a
+separate integration planned for the shared loaders.gl worker framework.
 
 <DracoDocsTabs active="dracowriter" />
 
@@ -60,6 +63,13 @@ await encode(mesh, DracoWriter, {
     attributeNameEntry: 'semantic'
   }
 });
+```
+
+Named presets provide reproducible starting points for common workloads. Explicit options always
+override the preset, and the input options object is not mutated:
+
+```typescript
+await encode(mesh, DracoWriter, {draco: {preset: 'webgpu'}});
 ```
 
 Use `attributeQuantization` when attributes in the same Draco category need different settings.

--- a/docs/modules/draco/api-reference/draco-writer.md
+++ b/docs/modules/draco/api-reference/draco-writer.md
@@ -2,6 +2,10 @@ import {DracoDocsTabs} from '@site/src/components/docs/draco-docs-tabs';
 
 # DracoWriter
 
+For applications encoding many independent geometries, `encodeDracoBatch` initializes the
+Draco runtime once and processes inputs sequentially, keeping peak native memory bounded while
+avoiding per-geometry module startup overhead. It returns one `DracoEncodingResult` per input.
+
 <DracoDocsTabs active="dracowriter" />
 
 <p class="badges">

--- a/modules/draco/src/draco-writer.ts
+++ b/modules/draco/src/draco-writer.ts
@@ -30,6 +30,22 @@ export type DracoWriterOptions = WriterOptions & {
   draco?: DracoBuildOptions;
 };
 
+/** Progress notification emitted after each geometry in a batch. */
+export type DracoBatchProgress = {
+  /** Number of geometries completed. */
+  completed: number;
+  /** Total number of geometries in the batch. */
+  total: number;
+};
+
+/** Options for cancellable, progress-reporting batch encoding. */
+export type DracoBatchOptions = DracoWriterOptions & {
+  /** Abort signal checked between native encoding operations. */
+  signal?: AbortSignal;
+  /** Called after each geometry is encoded. */
+  onProgress?: (progress: DracoBatchProgress) => void;
+};
+
 const DEFAULT_DRACO_WRITER_OPTIONS = {
   pointcloud: false, // Set to true if pointcloud (mode: 0, no indices)
   attributeNameEntry: 'name'
@@ -99,14 +115,18 @@ export async function encodeDraco(
  */
 export async function encodeDracoBatch(
   data: DracoWriterInput[],
-  options: DracoWriterOptions = {}
+  options: DracoBatchOptions = {}
 ): Promise<DracoEncodingResult[]> {
   const {draco} = await loadDracoEncoderModule(extractLoadLibraryOptions(options));
   const dracoBuilder = new DRACOBuilder(draco);
   const results: DracoEncodingResult[] = [];
   try {
-    for (const geometry of data) {
+    for (const [index, geometry] of data.entries()) {
+      if (options.signal?.aborted) {
+        throw new Error('Draco batch encoding aborted');
+      }
       results.push(dracoBuilder.encodeSyncWithReport(normalizeDracoMesh(geometry), options.draco));
+      options.onProgress?.({completed: index + 1, total: data.length});
     }
     return results;
   } finally {

--- a/modules/draco/src/draco-writer.ts
+++ b/modules/draco/src/draco-writer.ts
@@ -117,19 +117,13 @@ export async function encodeDracoBatch(
   data: DracoWriterInput[],
   options: DracoBatchOptions = {}
 ): Promise<DracoEncodingResult[]> {
+  throwIfAborted(options.signal);
   const {draco} = await loadDracoEncoderModule(extractLoadLibraryOptions(options));
   const dracoBuilder = new DRACOBuilder(draco);
   const results: DracoEncodingResult[] = [];
   try {
     for (const [index, geometry] of data.entries()) {
-      if (options.signal?.aborted) {
-        if (options.signal.reason !== undefined) {
-          throw options.signal.reason;
-        }
-        const error = new Error('Draco batch encoding aborted');
-        error.name = 'AbortError';
-        throw error;
-      }
+      throwIfAborted(options.signal);
       results.push(dracoBuilder.encodeSyncWithReport(normalizeDracoMesh(geometry), options.draco));
       options.onProgress?.({completed: index + 1, total: data.length});
     }
@@ -137,6 +131,19 @@ export async function encodeDracoBatch(
   } finally {
     dracoBuilder.destroy();
   }
+}
+
+/** Throws the signal's reason before starting or between native encodes. */
+function throwIfAborted(signal: AbortSignal | undefined): void {
+  if (!signal?.aborted) {
+    return;
+  }
+  if (signal.reason !== undefined) {
+    throw signal.reason;
+  }
+  const error = new Error('Draco batch encoding aborted');
+  error.name = 'AbortError';
+  throw error;
 }
 
 /** Returns Draco-writable mesh data without copying ordinary Mesh attributes. */

--- a/modules/draco/src/draco-writer.ts
+++ b/modules/draco/src/draco-writer.ts
@@ -91,6 +91,29 @@ export async function encodeDraco(
   }
 }
 
+/**
+ * Encodes multiple geometries while loading and initializing the Draco runtime once.
+ *
+ * The input geometries are processed sequentially to keep peak native memory bounded.
+ * Each result is independent and uses the same writer options.
+ */
+export async function encodeDracoBatch(
+  data: DracoWriterInput[],
+  options: DracoWriterOptions = {}
+): Promise<DracoEncodingResult[]> {
+  const {draco} = await loadDracoEncoderModule(extractLoadLibraryOptions(options));
+  const dracoBuilder = new DRACOBuilder(draco);
+  const results: DracoEncodingResult[] = [];
+  try {
+    for (const geometry of data) {
+      results.push(dracoBuilder.encodeSyncWithReport(normalizeDracoMesh(geometry), options.draco));
+    }
+    return results;
+  } finally {
+    dracoBuilder.destroy();
+  }
+}
+
 /** Returns Draco-writable mesh data without copying ordinary Mesh attributes. */
 function normalizeDracoMesh(data: DracoWriterInput): DracoBuilderMesh {
   if (isMeshArrowTable(data)) {

--- a/modules/draco/src/draco-writer.ts
+++ b/modules/draco/src/draco-writer.ts
@@ -30,6 +30,22 @@ export type DracoWriterOptions = WriterOptions & {
   draco?: DracoBuildOptions;
 };
 
+/** Progress notification emitted after each geometry in a batch. */
+export type DracoBatchProgress = {
+  /** Number of geometries completed. */
+  completed: number;
+  /** Total number of geometries in the batch. */
+  total: number;
+};
+
+/** Options for cancellable, progress-reporting batch encoding. */
+export type DracoBatchOptions = DracoWriterOptions & {
+  /** Abort signal checked between native encoding operations. */
+  signal?: AbortSignal;
+  /** Called after each geometry is encoded. */
+  onProgress?: (progress: DracoBatchProgress) => void;
+};
+
 const DEFAULT_DRACO_WRITER_OPTIONS = {
   pointcloud: false, // Set to true if pointcloud (mode: 0, no indices)
   attributeNameEntry: 'name'
@@ -99,14 +115,23 @@ export async function encodeDraco(
  */
 export async function encodeDracoBatch(
   data: DracoWriterInput[],
-  options: DracoWriterOptions = {}
+  options: DracoBatchOptions = {}
 ): Promise<DracoEncodingResult[]> {
   const {draco} = await loadDracoEncoderModule(extractLoadLibraryOptions(options));
   const dracoBuilder = new DRACOBuilder(draco);
   const results: DracoEncodingResult[] = [];
   try {
-    for (const geometry of data) {
+    for (const [index, geometry] of data.entries()) {
+      if (options.signal?.aborted) {
+        if (options.signal.reason !== undefined) {
+          throw options.signal.reason;
+        }
+        const error = new Error('Draco batch encoding aborted');
+        error.name = 'AbortError';
+        throw error;
+      }
       results.push(dracoBuilder.encodeSyncWithReport(normalizeDracoMesh(geometry), options.draco));
+      options.onProgress?.({completed: index + 1, total: data.length});
     }
     return results;
   } finally {

--- a/modules/draco/src/index.ts
+++ b/modules/draco/src/index.ts
@@ -14,7 +14,7 @@ export {DracoFormat} from './draco-format';
 // Draco Writer
 
 export type {DracoWriterAttributes, DracoWriterInput, DracoWriterOptions} from './draco-writer';
-export {encodeDraco} from './draco-writer';
+export {encodeDraco, encodeDracoBatch} from './draco-writer';
 export type {
   DracoAttributeQuantization,
   DracoAttributeType,

--- a/modules/draco/src/index.ts
+++ b/modules/draco/src/index.ts
@@ -24,6 +24,7 @@ export type {
   DracoEncodingAttributeReport,
   DracoEncodingReport,
   DracoEncodingResult,
+  DracoEncodingPreset,
   DracoExplicitQuantization,
   DracoMetadata
 } from './lib/draco-builder';

--- a/modules/draco/src/index.ts
+++ b/modules/draco/src/index.ts
@@ -13,7 +13,13 @@ export {DracoFormat} from './draco-format';
 
 // Draco Writer
 
-export type {DracoWriterAttributes, DracoWriterInput, DracoWriterOptions} from './draco-writer';
+export type {
+  DracoBatchOptions,
+  DracoBatchProgress,
+  DracoWriterAttributes,
+  DracoWriterInput,
+  DracoWriterOptions
+} from './draco-writer';
 export {encodeDraco, encodeDracoBatch} from './draco-writer';
 export type {
   DracoAttributeQuantization,

--- a/modules/draco/src/lib/draco-builder.ts
+++ b/modules/draco/src/lib/draco-builder.ts
@@ -49,6 +49,9 @@ export type DracoExplicitQuantization = {
 /** Per-attribute quantization, expressed as a bit count or an explicit transform. */
 export type DracoAttributeQuantization = number | DracoExplicitQuantization;
 
+/** Named compression profile for common glTF and GPU workloads. */
+export type DracoEncodingPreset = 'gltf' | 'webgpu' | 'balanced';
+
 /** Per-attribute details captured after constructing a Draco geometry. */
 export type DracoEncodingAttributeReport = {
   /** Unique attribute identifier stored in the Draco geometry. */
@@ -108,6 +111,8 @@ export type DracoBuildOptions = {
   quantization?: Partial<Record<DracoAttributeType, number>>;
   /** Quantization keyed by application attribute name, overriding category settings. */
   attributeQuantization?: Record<string, DracoAttributeQuantization>;
+  /** Applies a documented set of compression defaults before explicit options. */
+  preset?: DracoEncodingPreset;
 };
 
 type DracoBuilderAttributeInfo = {
@@ -184,6 +189,7 @@ export default class DracoBuilder {
     options: DracoBuildOptions,
     trackEncodedProperties: boolean
   ): DracoEncodingResult {
+    options = applyDracoEncodingPreset(options);
     this.log = options.log || noop;
 
     return options.pointcloud
@@ -899,4 +905,31 @@ function getDracoAttributeTypeName(
     }
   }
   return 'GENERIC';
+}
+
+/** Resolves named presets without mutating the caller's options object. */
+function applyDracoEncodingPreset(options: DracoBuildOptions): DracoBuildOptions {
+  const presetOptions: Record<DracoEncodingPreset, DracoBuildOptions> = {
+    gltf: {
+      method: 'MESH_EDGEBREAKER_ENCODING',
+      speed: [5, 5],
+      quantization: {POSITION: 14, NORMAL: 10, TEX_COORD: 12}
+    },
+    webgpu: {
+      method: 'MESH_SEQUENTIAL_ENCODING',
+      speed: [5, 5],
+      quantization: {POSITION: 14, NORMAL: 10, TEX_COORD: 12}
+    },
+    balanced: {
+      method: 'MESH_EDGEBREAKER_ENCODING',
+      speed: [5, 5],
+      quantization: {POSITION: 12, NORMAL: 10, TEX_COORD: 10}
+    }
+  };
+  const preset = options.preset ? presetOptions[options.preset] : {};
+  return {
+    ...preset,
+    ...options,
+    quantization: {...preset.quantization, ...options.quantization}
+  };
 }

--- a/modules/draco/test/draco-batch.node.spec.ts
+++ b/modules/draco/test/draco-batch.node.spec.ts
@@ -1,0 +1,30 @@
+import {expect, test} from 'vitest';
+import {encodeDracoBatch} from '@loaders.gl/draco';
+
+const GEOMETRY = {
+  attributes: {POSITION: new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0])},
+  indices: new Uint16Array([0, 1, 2])
+};
+
+test('encodeDracoBatch reports progress for each geometry', async () => {
+  const progress: Array<{completed: number; total: number}> = [];
+  const results = await encodeDracoBatch([GEOMETRY, GEOMETRY], {
+    useLocalLibraries: true,
+    onProgress: update => progress.push(update)
+  });
+
+  expect(results).toHaveLength(2);
+  expect(progress).toEqual([
+    {completed: 1, total: 2},
+    {completed: 2, total: 2}
+  ]);
+});
+
+test('encodeDracoBatch preserves AbortError semantics', async () => {
+  const controller = new AbortController();
+  controller.abort();
+
+  await expect(
+    encodeDracoBatch([GEOMETRY], {useLocalLibraries: true, signal: controller.signal})
+  ).rejects.toMatchObject({name: 'AbortError'});
+});

--- a/modules/draco/test/draco-batch.node.spec.ts
+++ b/modules/draco/test/draco-batch.node.spec.ts
@@ -1,5 +1,6 @@
 import {expect, test} from 'vitest';
 import {encodeDracoBatch} from '@loaders.gl/draco';
+import draco3d from 'draco3d';
 
 const GEOMETRY = {
   attributes: {POSITION: new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0])},
@@ -9,7 +10,7 @@ const GEOMETRY = {
 test('encodeDracoBatch reports progress for each geometry', async () => {
   const progress: Array<{completed: number; total: number}> = [];
   const results = await encodeDracoBatch([GEOMETRY, GEOMETRY], {
-    useLocalLibraries: true,
+    modules: {draco3d},
     onProgress: update => progress.push(update)
   });
 

--- a/modules/draco/test/draco-writer.spec.ts
+++ b/modules/draco/test/draco-writer.spec.ts
@@ -556,3 +556,34 @@ test('encodeDracoBatch reuses the initialized runtime for multiple geometries', 
   expect(results[0].data.byteLength).toBeGreaterThan(0);
   expect(results[1].report.pointCount).toBe(3);
 });
+
+test('encodeDracoBatch reports progress without retaining native geometries', async () => {
+  if (skipBrowserDracoWasmTest()) {
+    return;
+  }
+  const geometry = {
+    attributes: {POSITION: new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0])},
+    indices: new Uint16Array([0, 1, 2])
+  };
+  const progress: Array<{completed: number; total: number}> = [];
+  await encodeDracoBatch([geometry, geometry], {onProgress: update => progress.push(update)});
+  expect(progress).toEqual([
+    {completed: 1, total: 2},
+    {completed: 2, total: 2}
+  ]);
+});
+
+test('encodeDracoBatch observes cancellation between geometries', async () => {
+  if (skipBrowserDracoWasmTest()) {
+    return;
+  }
+  const geometry = {
+    attributes: {POSITION: new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0])},
+    indices: new Uint16Array([0, 1, 2])
+  };
+  const controller = new AbortController();
+  controller.abort();
+  await expect(encodeDracoBatch([geometry], {signal: controller.signal})).rejects.toThrow(
+    'aborted'
+  );
+});

--- a/modules/draco/test/draco-writer.spec.ts
+++ b/modules/draco/test/draco-writer.spec.ts
@@ -1,6 +1,12 @@
 import {expect, test} from 'vitest';
 import {validateWriter, validateMeshCategoryData} from 'test/common/conformance';
-import {DracoLoader, DracoWriterOptions, DracoWriter, DracoWriterWorker} from '@loaders.gl/draco';
+import {
+  DracoLoader,
+  DracoWriterOptions,
+  DracoWriter,
+  DracoWriterWorker,
+  encodeDracoBatch
+} from '@loaders.gl/draco';
 import {encode, fetchFile, parse} from '@loaders.gl/core';
 // import {getMeshSize} from '@loaders.gl/schema-utils';
 import draco3d from 'draco3d';
@@ -536,3 +542,17 @@ function skipBrowserDracoWasmTest() {
   }
   return false;
 }
+
+test('encodeDracoBatch reuses the initialized runtime for multiple geometries', async () => {
+  if (skipBrowserDracoWasmTest()) {
+    return;
+  }
+  const geometry = {
+    attributes: {POSITION: new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0])},
+    indices: new Uint16Array([0, 1, 2])
+  };
+  const results = await encodeDracoBatch([geometry, geometry]);
+  expect(results).toHaveLength(2);
+  expect(results[0].data.byteLength).toBeGreaterThan(0);
+  expect(results[1].report.pointCount).toBe(3);
+});

--- a/modules/draco/test/draco.bench.ts
+++ b/modules/draco/test/draco.bench.ts
@@ -3,7 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import {fetchFile, parse, encode} from '@loaders.gl/core';
-import {DracoLoader, DracoWriter} from '@loaders.gl/draco';
+import {DracoLoader, DracoWriter, encodeDracoBatch} from '@loaders.gl/draco';
 import type {DracoWriterOptions} from '@loaders.gl/draco';
 
 const POSITIONS_URL = '@loaders.gl/draco/test/data/raw-attribute-buffers/lidar-positions.bin';
@@ -73,6 +73,13 @@ export default async function dracoBench(bench) {
       `DracoWriter#pointcloud#${options.name} - parallel`,
       {multiplier: pointCount, unit: 'points', _throughput: 5, minIterations: 1},
       async () => await encode(attributes, DracoWriter, {draco: {pointcloud: true}, worker: true})
+    );
+
+    bench.addAsync(
+      `DracoWriter#pointcloud#${options.name} - batch-runtime-reuse`,
+      {multiplier: pointCount, unit: 'points', minIterations: 1},
+      async () =>
+        await encodeDracoBatch([attributes, attributes], {draco: {pointcloud: true}, worker: false})
     );
   }
 

--- a/modules/draco/test/lib/draco-builder.spec.ts
+++ b/modules/draco/test/lib/draco-builder.spec.ts
@@ -435,7 +435,14 @@ test('DracoBuilder applies named presets without mutating caller options', () =>
   );
 
   expect(options).toEqual({preset: 'webgpu'});
-  expect(state.encoderCalls).toEqual(['speed:5:5', 'method:8', 'quantization:0:14', 'mesh']);
+  expect(state.encoderCalls).toEqual([
+    'speed:5:5',
+    'method:8',
+    'quantization:0:14',
+    'quantization:1:10',
+    'quantization:3:12',
+    'mesh'
+  ]);
 });
 
 test.each([

--- a/modules/draco/test/lib/draco-builder.spec.ts
+++ b/modules/draco/test/lib/draco-builder.spec.ts
@@ -275,6 +275,7 @@ function createFakeDraco(): {draco: any; state: FakeDracoState} {
     COLOR: 2,
     TEX_COORD: 3,
     GENERIC: 4,
+    MESH_SEQUENTIAL_ENCODING: 8,
     MESH_EDGEBREAKER_ENCODING: 9,
     Encoder: FakeEncoder,
     ExpertEncoder: FakeExpertEncoder,
@@ -434,7 +435,7 @@ test('DracoBuilder applies named presets without mutating caller options', () =>
   );
 
   expect(options).toEqual({preset: 'webgpu'});
-  expect(state.encoderCalls).toEqual(['speed:5:5', 'method:9', 'quantization:0:14', 'mesh']);
+  expect(state.encoderCalls).toEqual(['speed:5:5', 'method:8', 'quantization:0:14', 'mesh']);
 });
 
 test.each([

--- a/modules/draco/test/lib/draco-builder.spec.ts
+++ b/modules/draco/test/lib/draco-builder.spec.ts
@@ -420,6 +420,23 @@ test('DracoBuilder uses ExpertEncoder for exact point-cloud quantization', () =>
   expect(state.encoderCalls).toEqual(['expert', 'expert-quantization:0:10', 'expert-encode:true']);
 });
 
+test('DracoBuilder applies named presets without mutating caller options', () => {
+  const {draco, state} = createFakeDraco();
+  const builder = new DracoBuilder(draco);
+  const options = {preset: 'webgpu' as const};
+
+  builder.encodeSync(
+    {
+      attributes: {POSITION: new Float32Array([0, 0, 0, 1, 1, 1])},
+      indices: new Uint16Array([0, 1, 0])
+    },
+    options
+  );
+
+  expect(options).toEqual({preset: 'webgpu'});
+  expect(state.encoderCalls).toEqual(['speed:5:5', 'method:9', 'quantization:0:14', 'mesh']);
+});
+
 test.each([
   [{attributeQuantization: {missing: 8}}, 'quantized attribute "missing" does not exist'],
   [{attributeQuantization: {POSITION: 0}}, 'must be an integer from 1 to 30'],


### PR DESCRIPTION
## Goals
Consolidate the remaining Draco writer/decoder improvements into one integration PR while intentionally leaving worker pooling for the shared loaders.gl worker framework.

## Changes
- retain the landed glTF-optimized decode, GPU metadata, attribute quantization, validation, and runtime hardening;
- add sequential batch encoding with one runtime initialization, bounded native memory, progress callbacks, and cancellation between geometries;
- add reproducible `gltf`, `webgpu`, and `balanced` encoding presets with explicit options taking precedence;
- preserve encoding reports, typed-array handling, metadata, normalized attributes, and legacy writer entry points;
- document the API and explicitly track worker pooling as a separate tranche.

Worker pooling is deliberately not included.