### PR TITLE
fix(website): disable hooks during gh-pages deploy

### DIFF
--- a/.github/workflows/website-deploy.yml
+++ b/.github/workflows/website-deploy.yml
@@ -92,6 +92,9 @@ jobs:
           cd website
           yarn build
 
+      - name: Disable repository hooks for deployment
+        run: git config --global core.hooksPath /dev/null
+
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f # 4.8.0
         with:


### PR DESCRIPTION
The built-in GitHub token now gets past the previous 403, but the post-merge website deployment fails because the checked-in pre-push hook invokes a missing node_modules/pre-push/hook. Configure core.hooksPath to /dev/null immediately before the deployment action so only the generated gh-pages push skips repository hooks. Verification: the failure is reproduced in run 33185528317 and git diff --check passes.