### PR TITLE
ci(website): separate install and build steps

### DIFF
--- a/.github/workflows/website-deploy.yml
+++ b/.github/workflows/website-deploy.yml
@@ -84,13 +84,14 @@ jobs:
             .yarn/install-state.gz
           key: ${{ runner.os }}-yarn4-${{ hashFiles('yarn.lock', '.yarnrc.yml', 'package.json') }}
 
-      - name: Install dependencies and build website
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Build website
         env:
           DOCUSAURUS_BASE_URL: ${{ needs.check_branch.outputs.website_base_url }}
-        run: |
-          yarn install --immutable
-          cd website
-          yarn build
+        run: yarn build
+        working-directory: website
 
       - name: Disable repository hooks for deployment
         run: git config --global core.hooksPath /dev/null


### PR DESCRIPTION
Split the website deployment workflow into explicit Install dependencies and Build website steps. Installation runs at the repository root; the website build runs with website as its working directory and receives DOCUSAURUS_BASE_URL. This makes Yarn install output, native package build messages, and Docusaurus build output independently visible in CI. Verification: git diff --check passes.