### PR TITLE
feat(worker-utils): add stateful batched worker sessions

### DIFF
--- a/docs/developer-guide/using-worker-loaders.md
+++ b/docs/developer-guide/using-worker-loaders.md
@@ -28,6 +28,11 @@ The `processOnWorker` function in `@loaders.gl/worker-utils` is used with worker
 exported by modules like `@loaders.gl/compression` and `@loaders.gl/crypto` to move
 processing intensive tasks to workers.
 
+`processOnWorkerInBatches` leases one worker for an entire input iterator. This lets streaming
+parsers and encoders retain state across chunks while applying input and output backpressure.
+See the [worker processing API](/docs/modules/worker-utils/api-reference/worker-processing) for
+worker implementation, cancellation, transfer, and lifecycle guidance.
+
 ## Parsing data on Workers
 
 ## Loading Files in Parallel using Worker Loaders

--- a/docs/docs-sidebar.json
+++ b/docs/docs-sidebar.json
@@ -283,6 +283,14 @@
       },
       {
         "type": "category",
+        "label": "@loaders.gl/worker-utils",
+        "items": [
+          "modules/worker-utils/README",
+          "modules/worker-utils/api-reference/worker-processing"
+        ]
+      },
+      {
+        "type": "category",
         "label": "@loaders.gl/3d-tiles",
         "items": [
           "modules/3d-tiles/README",

--- a/docs/modules/worker-utils/README.md
+++ b/docs/modules/worker-utils/README.md
@@ -1,0 +1,27 @@
+# Overview
+
+The `@loaders.gl/worker-utils` module provides the shared worker runtime used by loaders.gl
+loaders, writers, compression codecs, and application-defined processors. It manages worker
+creation, bounded concurrency, worker reuse, transferable data, cancellation, and stateful batch
+sessions in browsers and Node.js.
+
+## Installation
+
+```bash
+npm install @loaders.gl/worker-utils
+```
+
+## APIs
+
+| API | Purpose |
+| --- | --- |
+| [`processOnWorker`](/docs/modules/worker-utils/api-reference/worker-processing#processonworker) | Run one atomic operation on a pooled worker. |
+| [`processOnWorkerInBatches`](/docs/modules/worker-utils/api-reference/worker-processing#processonworkerinbatches) | Stream batches through one leased, stateful worker. |
+| [`preloadWorker`](/docs/modules/worker-utils/api-reference/worker-processing#preloadworker) | Warm reusable workers before latency-sensitive work. |
+| [`createWorker`](/docs/modules/worker-utils/api-reference/worker-processing#createworker) | Implement the atomic and batched operations exposed by a worker bundle. |
+| [`WorkerFarm` and `WorkerPool`](/docs/modules/worker-utils/api-reference/worker-processing#pool-lifecycle) | Configure concurrency, reuse, and explicit shutdown. |
+
+Use atomic processing for independent inputs. Use batched processing when parsing or encoding
+requires state across input chunks, or when input and output should remain streaming rather than
+being concatenated in memory.
+

--- a/docs/modules/worker-utils/api-reference/worker-processing.md
+++ b/docs/modules/worker-utils/api-reference/worker-processing.md
@@ -1,0 +1,115 @@
+# Worker Processing
+
+`@loaders.gl/worker-utils` runs atomic and streaming operations on bounded pools of browser Web
+Workers or Node.js worker threads.
+
+## `processOnWorker`
+
+Runs one independent operation and resolves with its result.
+
+```typescript
+const result = await processOnWorker(MyWorker, input, {
+  worker: true,
+  maxConcurrency: 3,
+  reuseWorkers: true,
+  signal
+});
+```
+
+The input and result use transferable `ArrayBuffer` ownership where possible. Transferred input
+buffers are detached on the calling thread.
+
+## `processOnWorkerInBatches`
+
+Streams an iterable of input batches through one leased worker and returns an `AsyncIterable` of
+output batches.
+
+```typescript
+const outputBatches = processOnWorkerInBatches(MyWorker, inputBatches, {
+  worker: true,
+  maxConcurrency: 2,
+  reuseWorkers: true,
+  signal
+});
+
+for await (const outputBatch of outputBatches) {
+  consume(outputBatch);
+}
+```
+
+One pool worker is reserved for the complete iterator lifetime. The same `processInBatches`
+invocation therefore receives every input batch and may retain parser, decoder, dictionary, or
+encoder state between batches. Separate sessions may run concurrently on different workers.
+
+Flow control is demand-driven in both directions:
+
+- The calling thread advances the input iterator only when the leased worker requests another
+  batch.
+- The worker advances its output iterator only after the caller requests the next output batch.
+
+At most one unacknowledged input and output batch is in flight for a session. This bounds queue
+growth while preserving transferable ownership.
+
+Stopping output iteration early or aborting the signal terminates the leased worker. This is a
+hard cancellation: worker-side `finally` blocks are not guaranteed to run, but terminating the
+worker releases its JavaScript and WebAssembly state. The pool creates a replacement worker for
+later jobs. A supplied `AbortSignal.reason` is preserved.
+
+## `createWorker`
+
+Worker bundles expose atomic and optional batched processors with `createWorker`:
+
+```typescript
+createWorker(
+  async (input, options) => processAtomically(input, options),
+  async function* processInBatches(inputBatches, options) {
+    const parser = new StatefulParser(options);
+    try {
+      for await (const inputBatch of inputBatches) {
+        for (const outputBatch of parser.parse(inputBatch)) {
+          yield outputBatch;
+        }
+      }
+      yield* parser.finish();
+    } finally {
+      parser.destroy();
+    }
+  }
+);
+```
+
+Keep per-session state inside `processInBatches`. Module-level state persists when workers are
+reused and should be limited to intentionally shared resources such as an initialized WebAssembly
+module.
+
+`AbortSignal` and callback functions are controlled on the calling thread and are not cloned into
+the worker. Communicate streaming progress by yielding output batches or including progress
+metadata in those batches.
+
+## `preloadWorker`
+
+Warms one or more workers in the same pool used by the processing APIs:
+
+```typescript
+await preloadWorker(MyWorker, {worker: true, maxConcurrency: 3}, {count: 2});
+```
+
+Preloading starts the worker bundle. Format-specific initialization can remain lazily cached in
+module scope or can be triggered by the worker's atomic processor.
+
+## Pool lifecycle
+
+`WorkerFarm` owns one `WorkerPool` per worker name. Each pool queues jobs and enforces
+`maxConcurrency`, `maxMobileConcurrency`, and `reuseWorkers`.
+
+```typescript
+WorkerFarm.getWorkerFarm({maxConcurrency: 3, reuseWorkers: true});
+
+// Release idle workers and retire active workers after their jobs finish.
+WorkerFarm.getWorkerFarm().destroy();
+```
+
+Set concurrency according to CPU and memory cost, particularly for WebAssembly codecs that create
+one heap per worker. A stateful batch session occupies one concurrency slot until its output
+iterator completes, is closed, fails, or is aborted.
+

--- a/docs/whats-new.mdx
+++ b/docs/whats-new.mdx
@@ -116,6 +116,13 @@ Release Date: 2026
 - [`KSPLATLoader`](/docs/modules/splats/api-reference/ksplat-loader) NEW - loads GaussianSplats3D `.ksplat` files into Mesh Arrow tables.
 - Handwritten RAD and RADC metadata types are paired with runtime validators from `@loaders.gl/splats/rad-zod-schema`, plus published draft-07 JSON Schema assets.
 
+**@loaders.gl/worker-utils**
+
+- `processOnWorkerInBatches()` streams input and output through one leased worker, preserving
+  parser or encoder state across batches with demand-driven backpressure and transferable data.
+- Worker cancellation preserves `AbortSignal.reason`; closing a batch iterator terminates its
+  leased worker so later jobs receive a clean replacement.
+
 **@loaders.gl/terrain**
 
 - [`QuantizedMeshWriter`](/docs/modules/terrain/api-reference/quantized-mesh-writer) NEW - writes quantized mesh terrain data.

--- a/modules/worker-utils/README.md
+++ b/modules/worker-utils/README.md
@@ -2,4 +2,6 @@
 
 This module contains shared utilities for loaders.gl, a collection of framework-independent 3D and geospatial loaders (parsers).
 
-For documentation please visit the [website](https://loaders.gl).
+For documentation, see the
+[worker-utils module guide](https://loaders.gl/docs/modules/worker-utils) and
+[worker processing API](https://loaders.gl/docs/modules/worker-utils/api-reference/worker-processing).

--- a/modules/worker-utils/src/index.ts
+++ b/modules/worker-utils/src/index.ts
@@ -9,6 +9,10 @@ import {VERSION} from './lib/env-utils/version';
 export type {
   WorkerObject,
   WorkerOptions,
+  WorkerContext,
+  WorkerJobContext,
+  Process,
+  ProcessInBatches,
   // Protocol
   WorkerMessage,
   WorkerMessageType,
@@ -34,6 +38,7 @@ export type {ProcessOnWorkerOptions} from './lib/worker-api/process-on-worker';
 export type {PreloadWorkerOptions} from './lib/worker-api/process-on-worker';
 export {
   processOnWorker,
+  processOnWorkerInBatches,
   preloadWorker,
   canProcessOnWorker
 } from './lib/worker-api/process-on-worker';

--- a/modules/worker-utils/src/lib/worker-api/create-worker.ts
+++ b/modules/worker-utils/src/lib/worker-api/create-worker.ts
@@ -16,8 +16,8 @@ import WorkerBody from '../worker-farm/worker-body';
 
 /** Counter for jobs */
 let requestId = 0;
-let inputBatches: AsyncQueue<any>;
-let options: {[key: string]: any};
+let activeInputBatches: AsyncQueue<any> | null = null;
+let activeOutputAcknowledgements: AsyncQueue<void> | null = null;
 
 export type ProcessOnMainThread = (
   data: any,
@@ -65,26 +65,47 @@ export async function createWorker(
           if (!processInBatches) {
             throw new Error('Worker does not support batched processing');
           }
-          inputBatches = new AsyncQueue<any>();
-          options = payload.options || {};
-          const resultIterator = processInBatches(
-            inputBatches,
-            options,
-            context,
-            payload.context || {}
-          );
-          for await (const batch of resultIterator) {
-            WorkerBody.postMessage('output-batch', {result: batch});
+          const inputBatches = new AsyncQueue<any>();
+          const outputAcknowledgements = new AsyncQueue<void>();
+          activeInputBatches = inputBatches;
+          activeOutputAcknowledgements = outputAcknowledgements;
+          try {
+            const resultIterator = processInBatches(
+              createDemandDrivenIterator(inputBatches),
+              payload.options || {},
+              context,
+              payload.context || {}
+            );
+            for await (const batch of resultIterator) {
+              await WorkerBody.postMessage('output-batch', {result: batch});
+              await outputAcknowledgements.next();
+            }
+            await WorkerBody.postMessage('done', {});
+          } finally {
+            activeInputBatches = null;
+            activeOutputAcknowledgements = null;
           }
-          WorkerBody.postMessage('done', {});
           break;
 
         case 'input-batch':
-          inputBatches.push(payload.input);
+          if (!activeInputBatches) {
+            throw new Error('Worker has no active batched processing session');
+          }
+          activeInputBatches.push(payload.input);
           break;
 
         case 'input-done':
-          inputBatches.close();
+          if (!activeInputBatches) {
+            throw new Error('Worker has no active batched processing session');
+          }
+          activeInputBatches.close();
+          break;
+
+        case 'output-ack':
+          if (!activeOutputAcknowledgements) {
+            throw new Error('Worker has no active batched processing session');
+          }
+          activeOutputAcknowledgements.push(undefined);
           break;
 
         default:
@@ -94,6 +115,18 @@ export async function createWorker(
       WorkerBody.postMessage('error', {error: message});
     }
   };
+}
+
+/** Requests exactly one input batch whenever the worker-side processor advances its iterator. */
+async function* createDemandDrivenIterator(inputBatches: AsyncQueue<any>): AsyncIterable<any> {
+  while (true) {
+    await WorkerBody.postMessage('input-request', {});
+    const nextBatch = await inputBatches.next();
+    if (nextBatch.done) {
+      return;
+    }
+    yield nextBatch.value;
+  }
 }
 
 function processOnMainThread(arrayBuffer: ArrayBuffer, options = {}, jobContext = {}) {

--- a/modules/worker-utils/src/lib/worker-api/process-on-worker.ts
+++ b/modules/worker-utils/src/lib/worker-api/process-on-worker.ts
@@ -11,6 +11,7 @@ import type {
   WorkerMessagePayload
 } from '../../types';
 import type WorkerJob from '../worker-farm/worker-job';
+import AsyncQueue from '../async-queue/async-queue';
 import WorkerFarm from '../worker-farm/worker-farm';
 import {getWorkerURL, getWorkerName} from './get-worker-url';
 import {getTransferListForWriter} from '../worker-utils/get-transfer-list';
@@ -75,7 +76,7 @@ export async function processOnWorker(
     onMessage.bind(null, context)
   );
 
-  const abortJob = (): void => job.abort();
+  const abortJob = (): void => job.abort(getAbortReason(options.signal));
   options.signal?.addEventListener('abort', abortJob, {once: true});
   if (options.signal?.aborted) {
     abortJob();
@@ -101,14 +102,182 @@ export async function processOnWorker(
   }
 }
 
+/**
+ * Processes an input iterator on one leased worker and streams output batches back.
+ *
+ * The worker remains assigned to this job for the complete iterator lifetime, allowing
+ * `processInBatches` implementations to retain parser or encoder state between input batches.
+ * Input is demand-driven: the main thread advances the source only when that worker requests the
+ * next batch.
+ */
+export function processOnWorkerInBatches<InputBatch = any, OutputBatch = any>(
+  worker: WorkerObject,
+  input: AsyncIterable<InputBatch> | Iterable<InputBatch>,
+  options: ProcessOnWorkerOptions = {},
+  context: WorkerContext = {},
+  jobContext: WorkerJobContext = {}
+): AsyncIterable<OutputBatch> {
+  return processOnWorkerInBatchesIterator(worker, input, options, context, jobContext);
+}
+
+/** Implements stateful worker batch processing as an async generator. */
+async function* processOnWorkerInBatchesIterator<InputBatch, OutputBatch>(
+  worker: WorkerObject,
+  input: AsyncIterable<InputBatch> | Iterable<InputBatch>,
+  options: ProcessOnWorkerOptions,
+  context: WorkerContext,
+  jobContext: WorkerJobContext
+): AsyncIterable<OutputBatch> {
+  throwIfAborted(options.signal);
+  const name = getWorkerName(worker);
+  const workerFarm = WorkerFarm.getWorkerFarm(options);
+  const {source} = options;
+  const workerPoolProps: {name: string; source?: string; url?: string} = {name, source};
+  if (!source) {
+    workerPoolProps.url = getWorkerURL(worker, options);
+  }
+  const workerPool = workerFarm.getWorkerPool(workerPoolProps);
+  const outputBatches = new AsyncQueue<OutputBatch>();
+  const inputIterator = getAsyncIterator(input);
+  let outputFinished = false;
+  let inputFinished = false;
+  let inputRequest = Promise.resolve();
+  const batchJobFailed = new Error('Worker batch job failed');
+
+  const finishOutput = (): void => {
+    if (!outputFinished) {
+      outputFinished = true;
+      outputBatches.close();
+    }
+  };
+  const failOutput = (_error: unknown): void => {
+    if (!outputFinished) {
+      outputFinished = true;
+      outputBatches.enqueue(batchJobFailed);
+      outputBatches.close();
+    }
+  };
+
+  const job = await workerPool.startJob(
+    options.jobName || worker.name,
+    (activeJob, type, payload) => {
+      switch (type) {
+        case 'input-request':
+          inputRequest = inputRequest
+            .then(async () => {
+              const nextBatch = await inputIterator.next();
+              if (!activeJob.isRunning) {
+                return;
+              }
+              if (nextBatch.done) {
+                inputFinished = true;
+                activeJob.postMessage('input-done', {});
+              } else {
+                activeJob.postMessage('input-batch', {input: nextBatch.value});
+              }
+            })
+            .catch(error => activeJob.abort(error));
+          break;
+
+        case 'output-batch':
+          outputBatches.push(payload.result as OutputBatch);
+          break;
+
+        case 'done':
+          activeJob.done(payload);
+          finishOutput();
+          break;
+
+        case 'error': {
+          const error = new Error(payload.error || 'Worker batch processing failed');
+          activeJob.error(error);
+          failOutput(error);
+          break;
+        }
+
+        case 'process':
+          void onMessage(context, activeJob, type, payload);
+          break;
+
+        default: {
+          const error = new Error(`Unexpected worker batch message: ${type}`);
+          activeJob.error(error);
+          failOutput(error);
+          break;
+        }
+      }
+    }
+  );
+
+  const abortJob = (): void => job.abort(getAbortReason(options.signal));
+  options.signal?.addEventListener('abort', abortJob, {once: true});
+  if (options.signal?.aborted) {
+    abortJob();
+  }
+  void job.result.catch(failOutput);
+
+  try {
+    const {signal: _signal, ...workerOptions} = options;
+    if (job.isRunning) {
+      job.postMessage('process-in-batches', {
+        options: getTransferListForWriter(workerOptions),
+        context: getTransferListForWriter(jobContext)
+      });
+    }
+
+    try {
+      for await (const outputBatch of outputBatches) {
+        yield outputBatch;
+        if (job.isRunning) {
+          job.postMessage('output-ack', {});
+        }
+      }
+    } catch (error) {
+      if (error === batchJobFailed) {
+        await job.result;
+      }
+      throw error;
+    }
+    await job.result;
+  } finally {
+    options.signal?.removeEventListener('abort', abortJob);
+    if (job.isRunning) {
+      job.abort(createAbortError('Worker batch iterator was closed'));
+    }
+    if (!inputFinished) {
+      await inputIterator.return?.();
+    }
+  }
+}
+
 /** Throws a cross-runtime abort error when a signal is already aborted. */
 function throwIfAborted(signal?: AbortSignal): void {
   if (!signal?.aborted) {
     return;
   }
-  const error = new Error('Worker job was aborted');
+  throw getAbortReason(signal);
+}
+
+/** Returns a caller-provided abort reason or a cross-runtime `AbortError`. */
+function getAbortReason(signal?: AbortSignal): unknown {
+  return signal?.reason ?? createAbortError('Worker job was aborted');
+}
+
+/** Creates an abort error without requiring the DOMException global. */
+function createAbortError(message: string): Error {
+  const error = new Error(message);
   error.name = 'AbortError';
-  throw error;
+  return error;
+}
+
+/** Returns an asynchronous iterator for either accepted source kind. */
+function getAsyncIterator<T>(input: AsyncIterable<T> | Iterable<T>): AsyncIterator<T> {
+  if (Symbol.asyncIterator in input) {
+    return input[Symbol.asyncIterator]();
+  }
+  return (async function* iterateSynchronously() {
+    yield* input;
+  })();
 }
 
 /**

--- a/modules/worker-utils/src/lib/worker-api/process-on-worker.ts
+++ b/modules/worker-utils/src/lib/worker-api/process-on-worker.ts
@@ -245,7 +245,7 @@ async function* processOnWorkerInBatchesIterator<InputBatch, OutputBatch>(
       job.abort(createAbortError('Worker batch iterator was closed'));
     }
     if (!inputFinished) {
-      await inputIterator.return?.();
+      closeInputIterator(inputIterator);
     }
   }
 }
@@ -278,6 +278,15 @@ function getAsyncIterator<T>(input: AsyncIterable<T> | Iterable<T>): AsyncIterat
   return (async function* iterateSynchronously() {
     yield* input;
   })();
+}
+
+/** Closes an input iterator without allowing a blocked return to delay cancellation. */
+function closeInputIterator<InputBatch>(inputIterator: AsyncIterator<InputBatch>): void {
+  try {
+    void Promise.resolve(inputIterator.return?.()).catch(() => undefined);
+  } catch {
+    // The worker job has already been aborted; iterator cleanup is best effort.
+  }
 }
 
 /**

--- a/modules/worker-utils/src/lib/worker-farm/worker-body.ts
+++ b/modules/worker-utils/src/lib/worker-farm/worker-body.ts
@@ -8,6 +8,8 @@ import {getTransferList} from '../worker-utils/get-transfer-list';
 import {parentPort} from '../node/worker_threads';
 
 type TransferListItem = any;
+type WorkerMessageEvent = MessageEvent<WorkerMessageData> | WorkerMessageData;
+type WorkerMessageListener = (type: WorkerMessageType, payload: WorkerMessagePayload) => any;
 
 /** Vile hack to defeat over-zealous bundlers from stripping out the require */
 async function getParentPort() {
@@ -30,7 +32,7 @@ async function getParentPort() {
   return parentPort;
 }
 
-const onMessageWrapperMap = new Map();
+const onMessageWrapperMap = new Map<WorkerMessageListener, (message: WorkerMessageEvent) => void>();
 
 /**
  * Type safe wrapper for worker code
@@ -70,40 +72,37 @@ export default class WorkerBody {
     });
   }
 
-  static async addEventListener(
-    onMessage: (type: WorkerMessageType, payload: WorkerMessagePayload) => any
-  ) {
+  static async addEventListener(onMessage: WorkerMessageListener) {
     let onMessageWrapper = onMessageWrapperMap.get(onMessage);
 
     if (!onMessageWrapper) {
-      onMessageWrapper = async (message: MessageEvent<any>) => {
-        if (!isKnownMessage(message)) {
+      onMessageWrapper = (message: WorkerMessageEvent) => {
+        const messageData = getWorkerMessageData(message);
+        if (!messageData) {
           return;
         }
-
-        const parentPort = await getParentPort();
-        // Confusingly in the browser, the message itself also has a 'type' field which is always set to 'message'
-        const {type, payload} = parentPort ? message : message.data;
-        onMessage(type, payload);
+        onMessage(messageData.type, messageData.payload);
       };
+      onMessageWrapperMap.set(onMessage, onMessageWrapper);
     }
 
     const parentPort = await getParentPort();
     if (parentPort) {
-      console.error('not implemented'); // eslint-disable-line
+      parentPort.on('message', onMessageWrapper);
     } else {
       globalThis.addEventListener('message', onMessageWrapper);
     }
   }
 
-  static async removeEventListener(
-    onMessage: (type: WorkerMessageType, payload: WorkerMessagePayload) => any
-  ) {
+  static async removeEventListener(onMessage: WorkerMessageListener) {
     const onMessageWrapper = onMessageWrapperMap.get(onMessage);
     onMessageWrapperMap.delete(onMessage);
+    if (!onMessageWrapper) {
+      return;
+    }
     const parentPort = await getParentPort();
     if (parentPort) {
-      console.error('not implemented'); // eslint-disable-line
+      parentPort.off('message', onMessageWrapper);
     } else {
       globalThis.removeEventListener('message', onMessageWrapper);
     }
@@ -133,12 +132,11 @@ export default class WorkerBody {
 }
 
 // Filter out noise messages sent to workers
-function isKnownMessage(message: MessageEvent<any>) {
-  const {type, data} = message;
-  return (
-    type === 'message' &&
-    data &&
-    typeof data.source === 'string' &&
-    data.source.startsWith('loaders.gl')
-  );
+function getWorkerMessageData(message: WorkerMessageEvent): WorkerMessageData | null {
+  const messageData = 'data' in message && message.type === 'message' ? message.data : message;
+  return messageData &&
+    typeof messageData.source === 'string' &&
+    messageData.source.startsWith('loaders.gl')
+    ? messageData
+    : null;
 }

--- a/modules/worker-utils/src/lib/worker-farm/worker-body.ts
+++ b/modules/worker-utils/src/lib/worker-farm/worker-body.ts
@@ -133,6 +133,9 @@ export default class WorkerBody {
 
 // Filter out noise messages sent to workers
 function getWorkerMessageData(message: WorkerMessageEvent): WorkerMessageData | null {
+  if (!message || typeof message !== 'object') {
+    return null;
+  }
   const messageData = 'data' in message && message.type === 'message' ? message.data : message;
   return messageData &&
     typeof messageData.source === 'string' &&

--- a/modules/worker-utils/src/lib/worker-farm/worker-job.ts
+++ b/modules/worker-utils/src/lib/worker-farm/worker-job.ts
@@ -53,7 +53,7 @@ export default class WorkerJob {
   /**
    * Call to reject the `result` Promise with the supplied error
    */
-  error(error: Error): void {
+  error(error: unknown): void {
     if (!this.isRunning) {
       return;
     }
@@ -61,14 +61,23 @@ export default class WorkerJob {
     this._reject(error);
   }
 
-  /** Terminates the worker executing this job and rejects its result with an abort error. */
-  abort(): void {
+  /**
+   * Terminates the worker executing this job and rejects its result.
+   * @param reason Abort reason supplied by the caller, or a cross-runtime `AbortError`.
+   */
+  abort(reason?: unknown): void {
     if (!this.isRunning) {
       return;
     }
-    const error = new Error(`Worker job "${this.name}" was aborted`);
-    error.name = 'AbortError';
+    const error = reason ?? createAbortError(`Worker job "${this.name}" was aborted`);
     this.workerThread.destroy();
     this.error(error);
   }
+}
+
+/** Creates an abort error without requiring the DOMException global. */
+function createAbortError(message: string): Error {
+  const error = new Error(message);
+  error.name = 'AbortError';
+  return error;
 }

--- a/modules/worker-utils/src/types.ts
+++ b/modules/worker-utils/src/types.ts
@@ -61,18 +61,20 @@ export type WorkerObject = {
   PROTOCOL
 
   Main thread                                     worker
-               => process-batches-start
+               => process-in-batches
 
-               => process-batches-input-batch
-               <= process-batches-output-batch
+               <= input-request
+               => input-batch
+               <= output-batch
+               => output-ack
                   ... // repeat
 
-              => process-batches-input-done
-              <= process-batches-result
+              => input-done
+              <= done
 
                  // or
 
-              <= process-batches-error
+              <= error
  */
 export type WorkerMessageType =
   | 'preload'
@@ -80,9 +82,11 @@ export type WorkerMessageType =
   | 'done'
   | 'error'
   | 'process-in-batches'
+  | 'input-request'
   | 'input-batch'
   | 'input-done'
-  | 'output-batch';
+  | 'output-batch'
+  | 'output-ack';
 
 export type WorkerMessagePayload = {
   id?: number;

--- a/modules/worker-utils/src/workers/null-worker.ts
+++ b/modules/worker-utils/src/workers/null-worker.ts
@@ -4,7 +4,17 @@
 
 import {createWorker} from '../lib/worker-api/create-worker';
 
-createWorker(async data => {
-  // @ts-ignore
-  return data;
-});
+createWorker(
+  async data => {
+    // @ts-ignore
+    return data;
+  },
+  /** Echoes batches together with session-local state for worker protocol tests. */
+  async function* processInBatches(iterator) {
+    let batchIndex = 0;
+    for await (const input of iterator) {
+      yield {input, batchIndex};
+      batchIndex++;
+    }
+  }
+);

--- a/modules/worker-utils/test/lib/worker-api/process-on-worker-batches.node.spec.ts
+++ b/modules/worker-utils/test/lib/worker-api/process-on-worker-batches.node.spec.ts
@@ -90,3 +90,33 @@ test('processOnWorkerInBatches preserves an active AbortSignal reason', async ()
   controller.abort(reason);
   await expect(outputIterator.next()).rejects.toBe(reason);
 });
+
+test('processOnWorkerInBatches does not wait for blocked input cleanup after abort', async () => {
+  let inputStartedResolve: () => void = () => {};
+  const inputStarted = new Promise<void>(resolve => {
+    inputStartedResolve = resolve;
+  });
+  const input = {
+    [Symbol.asyncIterator]() {
+      return {
+        next: () => {
+          inputStartedResolve();
+          return new Promise<IteratorResult<string>>(() => {});
+        },
+        return: () => new Promise<IteratorResult<string>>(() => {})
+      };
+    }
+  };
+  const controller = new AbortController();
+  const reason = new Error('cancel while input is pending');
+  const outputIterator = processOnWorkerInBatches(StatefulBatchWorker, input, {
+    worker: true,
+    source: statefulBatchWorkerSource,
+    signal: controller.signal
+  })[Symbol.asyncIterator]();
+  const outputPromise = outputIterator.next();
+
+  await inputStarted;
+  controller.abort(reason);
+  await expect(outputPromise).rejects.toBe(reason);
+});

--- a/modules/worker-utils/test/lib/worker-api/process-on-worker-batches.node.spec.ts
+++ b/modules/worker-utils/test/lib/worker-api/process-on-worker-batches.node.spec.ts
@@ -1,0 +1,92 @@
+import {expect, test} from 'vitest';
+import {processOnWorkerInBatches} from '@loaders.gl/worker-utils';
+
+const StatefulBatchWorker = {
+  id: 'stateful-batch-test',
+  name: 'stateful-batch-test',
+  module: 'worker-utils',
+  version: 'latest',
+  worker: true,
+  options: {}
+};
+
+const statefulBatchWorkerSource = `
+const {parentPort, threadId} = require('worker_threads');
+
+let batchIndex = 0;
+
+function post(type, payload = {}) {
+  parentPort.postMessage({source: 'loaders.gl', type, payload});
+}
+
+parentPort.on('message', message => {
+  const {type, payload} = message;
+  if (type === 'process-in-batches') {
+    batchIndex = 0;
+    post('input-request');
+  } else if (type === 'input-batch') {
+    post('output-batch', {result: {input: payload.input, batchIndex, threadId}});
+    batchIndex++;
+  } else if (type === 'output-ack') {
+    post('input-request');
+  } else if (type === 'input-done') {
+    post('done');
+  }
+});
+`;
+
+test('processOnWorkerInBatches leases one worker and applies backpressure', async () => {
+  let inputPullCount = 0;
+  const input = {
+    async *[Symbol.asyncIterator]() {
+      for (const value of ['first', 'second', 'third']) {
+        inputPullCount++;
+        yield value;
+      }
+    }
+  };
+  const outputIterator = processOnWorkerInBatches(StatefulBatchWorker, input, {
+    worker: true,
+    source: statefulBatchWorkerSource,
+    maxConcurrency: 2,
+    reuseWorkers: true
+  })[Symbol.asyncIterator]();
+
+  const firstOutput = await outputIterator.next();
+  expect(firstOutput.value).toMatchObject({input: 'first', batchIndex: 0});
+  expect(inputPullCount).toBe(1);
+
+  const secondOutput = await outputIterator.next();
+  expect(secondOutput.value).toMatchObject({input: 'second', batchIndex: 1});
+  expect(secondOutput.value.threadId).toBe(firstOutput.value.threadId);
+  expect(inputPullCount).toBe(2);
+
+  await outputIterator.return?.();
+
+  const replacementResults = [];
+  for await (const output of processOnWorkerInBatches(StatefulBatchWorker, ['replacement'], {
+    worker: true,
+    source: statefulBatchWorkerSource,
+    maxConcurrency: 2,
+    reuseWorkers: true
+  })) {
+    replacementResults.push(output);
+  }
+  expect(replacementResults).toHaveLength(1);
+  expect(replacementResults[0]).toMatchObject({input: 'replacement', batchIndex: 0});
+});
+
+test('processOnWorkerInBatches preserves an active AbortSignal reason', async () => {
+  const controller = new AbortController();
+  const reason = new Error('cancel stateful worker');
+  reason.name = 'AbortError';
+  const outputIterator = processOnWorkerInBatches(StatefulBatchWorker, ['first', 'second'], {
+    worker: true,
+    source: statefulBatchWorkerSource,
+    signal: controller.signal
+  })[Symbol.asyncIterator]();
+
+  expect((await outputIterator.next()).value).toMatchObject({input: 'first'});
+  controller.abort(reason);
+  await expect(outputIterator.next()).rejects.toBe(reason);
+});

--- a/modules/worker-utils/test/lib/worker-api/process-on-worker-batches.spec.ts
+++ b/modules/worker-utils/test/lib/worker-api/process-on-worker-batches.spec.ts
@@ -21,3 +21,58 @@ test('processOnWorkerInBatches keeps state on one worker', async () => {
   ]);
   WorkerFarm.getWorkerFarm().destroy();
 });
+
+test('processOnWorkerInBatches accepts async input and applies output backpressure', async () => {
+  let inputPullCount = 0;
+  const input = {
+    async *[Symbol.asyncIterator]() {
+      for (const value of ['async-first', 'async-second']) {
+        inputPullCount++;
+        yield value;
+      }
+    }
+  };
+  const results = [];
+  for await (const output of processOnWorkerInBatches(NullWorker, input, {
+    worker: true,
+    _workerType: 'test'
+  })) {
+    results.push(output);
+  }
+
+  expect(results).toEqual([
+    {input: 'async-first', batchIndex: 0},
+    {input: 'async-second', batchIndex: 1}
+  ]);
+  expect(inputPullCount).toBe(2);
+});
+
+test('processOnWorkerInBatches closes and aborts an active session early', async () => {
+  const outputIterator = processOnWorkerInBatches(NullWorker, ['first', 'second'], {
+    worker: true,
+    _workerType: 'test'
+  })[Symbol.asyncIterator]();
+
+  await outputIterator.next();
+  await outputIterator.return?.();
+});
+
+test('processOnWorkerInBatches propagates input iterator failures', async () => {
+  const input = {
+    async *[Symbol.asyncIterator]() {
+      yield 'first';
+      throw new Error('input failed');
+    }
+  };
+
+  await expect(
+    (async () => {
+      for await (const _output of processOnWorkerInBatches(NullWorker, input, {
+        worker: true,
+        _workerType: 'test'
+      })) {
+        // Consume until the source fails.
+      }
+    })()
+  ).rejects.toThrow('input failed');
+});

--- a/modules/worker-utils/test/lib/worker-api/process-on-worker-batches.spec.ts
+++ b/modules/worker-utils/test/lib/worker-api/process-on-worker-batches.spec.ts
@@ -1,0 +1,23 @@
+import {expect, test} from 'vitest';
+import {NullWorker, processOnWorkerInBatches, WorkerFarm} from '@loaders.gl/worker-utils';
+
+test('processOnWorkerInBatches keeps state on one worker', async () => {
+  const outputBatches = processOnWorkerInBatches(NullWorker, ['first', 'second', 'third'], {
+    worker: true,
+    _workerType: 'test',
+    maxConcurrency: 2,
+    reuseWorkers: true
+  });
+
+  const results = [];
+  for await (const outputBatch of outputBatches) {
+    results.push(outputBatch);
+  }
+
+  expect(results).toEqual([
+    {input: 'first', batchIndex: 0},
+    {input: 'second', batchIndex: 1},
+    {input: 'third', batchIndex: 2}
+  ]);
+  WorkerFarm.getWorkerFarm().destroy();
+});

--- a/modules/worker-utils/test/lib/worker-api/process-on-worker.node.spec.ts
+++ b/modules/worker-utils/test/lib/worker-api/process-on-worker.node.spec.ts
@@ -91,20 +91,22 @@ test('processOnWorker#jobContext', async () => {
 });
 test('processOnWorker#AbortSignal terminates and replaces an active worker', async () => {
   const abortController = new AbortController();
+  const abortReason = new Error('cancel worker job');
+  abortReason.name = 'AbortError';
   const abortedResult = processOnWorker(AbortWorker, 'aborted', {
     worker: true,
     source: abortWorkerSource,
     delay: 1000,
     signal: abortController.signal
   });
-  setTimeout(() => abortController.abort(), 10);
+  setTimeout(() => abortController.abort(abortReason), 10);
   let abortError: unknown;
   try {
     await abortedResult;
   } catch (error) {
     abortError = error;
   }
-  expect((abortError as Error | undefined)?.name, 'rejects with an abort error').toBe('AbortError');
+  expect(abortError, 'preserves the signal abort reason').toBe(abortReason);
   const nextResult = await processOnWorker(AbortWorker, 'replacement', {
     worker: true,
     source: abortWorkerSource,

--- a/modules/worker-utils/test/lib/worker-api/process-on-worker.spec.ts
+++ b/modules/worker-utils/test/lib/worker-api/process-on-worker.spec.ts
@@ -4,6 +4,7 @@ import {
   processOnWorker,
   preloadWorker,
   NullWorker,
+  WorkerBody,
   isBrowser
 } from '@loaders.gl/worker-utils';
 test('canProcessOnWorker#custom worker URL', () => {
@@ -76,4 +77,30 @@ test('preloadWorker handles count above maxConcurrency', async () => {
     reuseWorkers: true
   });
   expect(nullData, 'preloaded constrained worker pool can process later jobs').toBe('abc');
+});
+
+test('WorkerBody filters browser messages and manages listeners', async () => {
+  const receivedMessages: Array<{type: string; payload: unknown}> = [];
+  const onMessage = (type: string, payload: unknown): void => {
+    receivedMessages.push({type, payload});
+  };
+
+  await WorkerBody.removeEventListener(onMessage);
+  await WorkerBody.addEventListener(onMessage);
+  await WorkerBody.addEventListener(onMessage);
+
+  globalThis.dispatchEvent(
+    new MessageEvent('message', {
+      data: {source: 'unrelated', type: 'done', payload: {result: 'ignored'}}
+    })
+  );
+  globalThis.dispatchEvent(
+    new MessageEvent('message', {
+      data: {source: 'loaders.gl', type: 'done', payload: {result: 'accepted'}}
+    })
+  );
+
+  expect(receivedMessages).toEqual([{type: 'done', payload: {result: 'accepted'}}]);
+  await WorkerBody.removeEventListener(onMessage);
+  await WorkerBody.removeEventListener(onMessage);
 });


### PR DESCRIPTION
## Goals

- Make stateful batched processing a first-class capability of the shared loaders.gl worker system.
- Guarantee that one worker owns an entire batch session so parsers and encoders can retain state across input chunks.
- Bound memory in both directions while preserving worker reuse, concurrency controls, transferables, and cancellation semantics.
- Establish worker-utils as a documented public module rather than internal-only infrastructure.

## Changes

- Add `processOnWorkerInBatches()` returning an `AsyncIterable` tied to one leased `WorkerJob`.
- Complete the dormant batch protocol with demand-driven `input-request` and `output-ack` flow control.
- Keep at most one unacknowledged input and output batch in flight for ordinary sequential iterators.
- Extend `createWorker()` with stateful batch-session handling while retaining atomic processing.
- Preserve `AbortSignal.reason`; early iterator closure or cancellation terminates the leased worker and lets the pool create a clean replacement.
- Export the worker context and batch processor types needed to author custom worker bundles.
- Add browser and Node coverage for session-local state, worker identity, bidirectional backpressure, replacement after early close, and cancellation.
- Add first-class worker-utils overview/API documentation, sidebar navigation, developer-guide guidance, and release notes.

## Validation

- `yarn lint fix`
- focused Node worker tests: 4 passed
- `yarn test-audit`: 637 files, 0 violations
- worker-utils TypeScript project check passed
- full build and local headless startup reach an unrelated existing dependency mismatch where the installed `@math.gl/crs` does not export current master APIs; fresh CI installation is expected to exercise the browser test.