### PR TITLE
fix(website): streamline builds and restore deployment

### DIFF
--- a/.github/workflows/website-deploy.yml
+++ b/.github/workflows/website-deploy.yml
@@ -3,7 +3,6 @@ name: website
 on:
   push:
     branches:
-      - master
       - '*-release'
   workflow_run:
     workflows:
@@ -85,7 +84,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ needs.check_branch.outputs.checkout_ref }}
-          token: ${{ github.token }}
+          token: ${{ secrets.WEBSITE_DEPLOY_TOKEN }}
 
       - name: Setup Node (with Corepack)
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
@@ -121,7 +120,7 @@ jobs:
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f # 4.8.0
         with:
-          token: ${{ github.token }}
+          token: ${{ secrets.WEBSITE_DEPLOY_TOKEN }}
           branch: gh-pages
           folder: website/build
           target-folder: ${{ needs.check_branch.outputs.target_folder }}

--- a/docs/modules/3d-tiles/README.md
+++ b/docs/modules/3d-tiles/README.md
@@ -10,7 +10,7 @@ import {Tiles3DDocsTabs} from '@site/src/components/docs/tiles-3d-docs-tabs';
 
 The `@loaders.gl/3d-tiles` module supports loading and traversing 3D Tiles.
 
-See the [3D Tiles format compatibility matrix](./formats/3d-tiles) for a capability-by-capability
+See the [3D Tiles format compatibility matrix](/docs/modules/3d-tiles/formats/3d-tiles) for a capability-by-capability
 summary of parser, traversal, extension, and renderer-facing support.
 
 References

--- a/docs/modules/lance/README.md
+++ b/docs/modules/lance/README.md
@@ -28,5 +28,5 @@ encodings, predicate pushdown, and writes are not yet supported.
   subpath. They read selected primitive or two-dimensional coordinate columns
   with HTTP ranges.
 
-See the [Lance browser example](/examples/lance) for a curated Hugging Face
-picker, LAION scalar table, and PushT deck.gl coordinate view.
+See the [Lance browser example](https://github.com/visgl/loaders.gl/tree/master/examples/lance/browser)
+for a curated Hugging Face picker, LAION scalar table, and PushT deck.gl coordinate view.

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -18,6 +18,16 @@ function createBundlerPlugin() {
     configureWebpack(_config, _isServer, {currentBundler}) {
       const bundler = currentBundler.instance;
       return {
+        // These modules intentionally use Node fallbacks or dynamic WASM paths that are replaced
+        // in browser builds. Keep unrelated bundler warnings visible.
+        ignoreWarnings: [
+          {module: /zstd-codec[\\/]lib[\\/]zstd-codec-binding(?:-wasm)?\.js$/, message: /__dirname/},
+          {module: /modules[\\/]las[\\/]src[\\/]libs[\\/]laz-perf[\\/]laz-perf\.ts$/, message: /__dirname/},
+          {module: /modules[\\/]lerc[\\/]src[\\/]lerc-wasm-url\.ts$/, message: /__dirname/},
+          {module: /modules[\\/]parquet[\\/]src[\\/]lib[\\/]utils[\\/]load-wasm-node\.ts$/, message: /__filename/},
+          {module: /modules[\\/]parquet[\\/]src[\\/]parquet-source-worker-url\.ts$/, message: /Critical dependency/},
+          {module: /modules[\\/]las[\\/]src[\\/]libs[\\/]laz-rs-wasm[\\/]laz_rs_wasm\.js$/, message: /Critical dependency/}
+        ],
         plugins: [
           new bundler.DefinePlugin({
             __VERSION__: JSON.stringify(version)
@@ -151,12 +161,14 @@ const config = {
             '@loaders.gl/pmtiles': resolve('../modules/pmtiles/src'),
             '@loaders.gl/polyfills': resolve('../modules/polyfills/src'),
             '@loaders.gl/potree': resolve('../modules/potree/src'),
+            '@loaders.gl/scan': resolve('../modules/scan/src'),
             '@loaders.gl/schema': resolve('../modules/schema/src'),
             '@loaders.gl/schema-utils': resolve('../modules/schema-utils/src'),
             '@loaders.gl/scene': resolve('../modules/scene/src'),
             '@loaders.gl/shapefile': resolve('../modules/shapefile/src'),
             '@loaders.gl/splats': resolve('../modules/splats/src'),
             '@loaders.gl/stac': resolve('../modules/stac/src'),
+            '@loaders.gl/sql': resolve('../modules/sql/src'),
             '@loaders.gl/terrain': resolve('../modules/terrain/src'),
             '@loaders.gl/textures': resolve('../modules/textures/src'),
             '@loaders.gl/tile-converter': resolve('../apps/tile/converter/src-'),

--- a/website/scripts/build.sh
+++ b/website/scripts/build.sh
@@ -6,7 +6,7 @@ node scripts/validate-token.js
 # Build the worker bundle imported by the cloud-native Parquet examples.
 (
   cd ..
-  npm run build-source-worker --prefix modules/parquet
+  npm run --silent build-source-worker --prefix modules/parquet -- --log-level=error
 )
 
 # staging or prod
@@ -14,15 +14,21 @@ MODE=$1
 WEBSITE_DIR=`pwd`
 OUTPUT_DIR=build
 
+# Docusaurus' HTML minifier reports known, non-fatal diagnostics for generated
+# documentation markup. Rendering failures still fail the build.
+export DOCUSAURUS_IGNORE_SSG_WARNINGS=true
+export DOCUSAURUS_NO_PERSISTENT_CACHE=1
+export NO_UPDATE_NOTIFIER=1
+
 # clean up cache
 # docusaurus clear
 
 case $MODE in
   "prod")
-    DOCUSAURUS_NO_PERSISTENT_CACHE=1 docusaurus build
+    docusaurus build
     ;;
   "staging")
-    DOCUSAURUS_NO_PERSISTENT_CACHE=1 STAGING=true docusaurus build
+    STAGING=true docusaurus build
     ;;
 esac
 


### PR DESCRIPTION
## Goals\n\n- Keep website build logs concise while preserving actionable compiler failures.\n- Restore GitHub Pages deployment using the same user-backed credential pattern as luma.gl.\n- Publish the master preview to /next only when the website workflow is run manually.\n\n## Changes\n\n- Suppress known non-fatal Docusaurus SSG diagnostics and exact known browser/WASM bundler warnings.\n- Silence routine Parquet worker and update-notifier output.\n- Add the missing scan and SQL source aliases.\n- Fix the two broken documentation links reported by the website build.\n- Use WEBSITE_DEPLOY_TOKEN for checkout and deployment.\n- Stop deploying on every master push; release publishing remains automated.\n\n## Repository setting required\n\nThe protected gh-pages branch must allow the visgl-ci user to push. WEBSITE_DEPLOY_TOKEN authenticates as visgl-ci, matching luma.gl, but loaders.gl currently does not include that user in its push allowlist.\n\n## Verification\n\n- yarn lint fix\n- DOCUSAURUS_BASE_URL=/next/ yarn build\n- Production build output is reduced to three status lines.