### PR TITLE
test: cover high-impact parser branches

### DIFF
--- a/modules/csv/src/lib/parsers/parse-raw-arrow-csv-bytes.ts
+++ b/modules/csv/src/lib/parsers/parse-raw-arrow-csv-bytes.ts
@@ -826,7 +826,10 @@ class RawArrowUnquotedCSVByteParser {
 
     let dataStart = 0;
     const firstRow = this.findRowEnd(0);
-    const isHeader = this.options.header === 'auto' ? true : Boolean(this.options.header);
+    const isHeader =
+      this.options.header === 'auto'
+        ? this.isHeaderRow(0, firstRow.end)
+        : Boolean(this.options.header);
 
     if (isHeader) {
       this.headerRow = this.decodeHeaderRow(0, firstRow.end);
@@ -912,6 +915,20 @@ class RawArrowUnquotedCSVByteParser {
     return headerRow;
   }
 
+  private isHeaderRow(start: number, end: number): boolean {
+    let fieldStart = start;
+    for (let byteIndex = start; byteIndex <= end; byteIndex++) {
+      if (byteIndex === end || this.bytes[byteIndex] === this.options.delimiter) {
+        const value = textDecoder.decode(this.bytes.subarray(fieldStart, byteIndex));
+        if (!isHeaderValue(value, this.options.dynamicTyping)) {
+          return false;
+        }
+        fieldStart = byteIndex + 1;
+      }
+    }
+    return end >= start;
+  }
+
   private findRowEnd(start: number): {end: number; nextStart: number} {
     for (let byteIndex = start; byteIndex < this.bytes.length; byteIndex++) {
       const byte = this.bytes[byteIndex];
@@ -950,7 +967,10 @@ class RawArrowUnquotedCSVTextParser {
 
     let dataStart = 0;
     const firstRow = this.findRowEnd(0);
-    const isHeader = this.options.header === 'auto' ? true : Boolean(this.options.header);
+    const isHeader =
+      this.options.header === 'auto'
+        ? this.isHeaderRow(0, firstRow.end)
+        : Boolean(this.options.header);
     let headerRow: string[];
 
     if (isHeader) {
@@ -1051,6 +1071,25 @@ class RawArrowUnquotedCSVTextParser {
       }
     }
     return headerRow;
+  }
+
+  /** Returns whether every first-row field is a Papa-style header value. */
+  private isHeaderRow(start: number, end: number): boolean {
+    let fieldStart = start;
+    for (let characterIndex = start; characterIndex <= end; characterIndex++) {
+      const characterCode = this.csvText.charCodeAt(characterIndex);
+      if (characterCode === this.options.quote || characterCode >= 128) {
+        return false;
+      }
+      if (characterIndex === end || characterCode === this.options.delimiter) {
+        const value = this.csvText.slice(fieldStart, characterIndex);
+        if (!isHeaderValue(value, this.options.dynamicTyping)) {
+          return false;
+        }
+        fieldStart = characterIndex + 1;
+      }
+    }
+    return end >= start;
   }
 
   /** Locates the end of one row and the beginning of the next. */

--- a/modules/csv/test/parse-raw-arrow-csv-bytes.spec.ts
+++ b/modules/csv/test/parse-raw-arrow-csv-bytes.spec.ts
@@ -22,6 +22,80 @@ function encode(text: string): ArrayBuffer {
 }
 
 describe('raw Arrow CSV parser', () => {
+  test('covers direct byte parser boundaries with quoted data and uneven rows', () => {
+    const quoted = parseRawArrowCSVBytes(
+      encode(
+        'a,b,c\r\n"one","two ""quoted""",three\r\n"line\nwrapped",last\r\ntail,,extra,ignored'
+      ),
+      {header: true, delimiter: ','}
+    );
+    expect(toRows(quoted!)).toEqual([
+      {a: 'one', b: 'two "quoted"', c: 'three'},
+      {a: 'line\nwrapped', b: 'last', c: null},
+      {a: 'tail', b: '', c: 'extra'}
+    ]);
+
+    const quotedHeader = parseRawArrowCSVBytes(encode('"a","a"\n1,2'), {
+      header: true,
+      delimiter: ',',
+      skipEmptyLines: true
+    });
+    expect(toRows(quotedHeader!)).toEqual([{a: '1', 'a.1': '2'}]);
+  });
+
+  test('covers auto headers, custom quote characters, delimiter guesses, and greedy rows', () => {
+    const autoHeader = parseRawArrowCSVBytes(encode('name;value\nalpha;1\nbeta'), {
+      header: 'auto',
+      dynamicTyping: true,
+      delimitersToGuess: ['xx', 'é', ',', ';']
+    });
+    expect(toRows(autoHeader!)).toEqual([
+      {name: 'alpha', value: '1'},
+      {name: 'beta', value: null}
+    ]);
+
+    const numericFirstRow = parseRawArrowCSVBytes(encode('1|2\n3|4'), {
+      header: 'auto',
+      dynamicTyping: true,
+      delimiter: '|',
+      columnPrefix: 'field'
+    });
+    expect(toRows(numericFirstRow!)).toEqual([{'1': '3', '2': '4'}]);
+
+    const customQuote = parseRawArrowCSVBytes(encode("a,b\n'one,two',three\n  ,  \n"), {
+      header: true,
+      delimiter: ',',
+      quoteChar: "'",
+      escapeChar: "'",
+      skipEmptyLines: 'greedy'
+    });
+    expect(toRows(customQuote!)).toEqual([{a: 'one,two', b: 'three'}]);
+  });
+
+  test('covers direct ASCII validation after the probe and capacity growth', () => {
+    const longPrefix = 'x'.repeat(300);
+    expect(
+      parseRawArrowCSVASCIIText(`a,b\n${longPrefix},café`, {
+        header: true,
+        delimiter: ','
+      })
+    ).toBeNull();
+    expect(
+      parseRawArrowCSVASCIIText(`a,b\n${longPrefix},"late quote"`, {
+        header: true,
+        delimiter: ','
+      })
+    ).toBeNull();
+
+    const rows = Array.from({length: 1030}, (_, index) => `${index},${'v'.repeat(8)}`).join('\n');
+    const table = parseRawArrowCSVASCIIText(`a,b\n${rows}`, {
+      header: true,
+      delimiter: ','
+    });
+    expect(table?.data.numRows).toBe(1030);
+    expect(table?.data.getChild('b')?.get(1029)).toBe('vvvvvvvv');
+  });
+
   test('matches d3-dsv string contents on the unquoted ASCII text fast path', async () => {
     const csvRows = ['id,value,name'];
     for (let rowIndex = 0; rowIndex < 2000; rowIndex++) {

--- a/modules/csv/test/parse-raw-arrow-csv-bytes.spec.ts
+++ b/modules/csv/test/parse-raw-arrow-csv-bytes.spec.ts
@@ -60,7 +60,21 @@ describe('raw Arrow CSV parser', () => {
       delimiter: '|',
       columnPrefix: 'field'
     });
-    expect(toRows(numericFirstRow!)).toEqual([{'1': '3', '2': '4'}]);
+    expect(toRows(numericFirstRow!)).toEqual([
+      {field1: '1', field2: '2'},
+      {field1: '3', field2: '4'}
+    ]);
+
+    const numericASCII = parseRawArrowCSVASCIIText('1,2\n3,4', {
+      header: 'auto',
+      dynamicTyping: true,
+      delimiter: ',',
+      columnPrefix: 'field'
+    });
+    expect(toRows(numericASCII!)).toEqual([
+      {field1: '1', field2: '2'},
+      {field1: '3', field2: '4'}
+    ]);
 
     const customQuote = parseRawArrowCSVBytes(encode("a,b\n'one,two',three\n  ,  \n"), {
       header: true,

--- a/modules/geoarrow/test/geoarrow-geometry-converter.spec.ts
+++ b/modules/geoarrow/test/geoarrow-geometry-converter.spec.ts
@@ -241,3 +241,158 @@ test('GeoArrowGeometryConverter converts geometry collections to geoarrow.geomet
     'round-trips geometry collections through the collection encoding'
   ).toEqual(features);
 });
+
+test('GeoArrowGeometryConverter round-trips every union geometry kind and null', () => {
+  const features: Feature[] = [
+    {
+      type: 'Feature',
+      properties: {kind: 'point'},
+      geometry: {type: 'Point', coordinates: [1, 2, 3, 4]}
+    },
+    {
+      type: 'Feature',
+      properties: {kind: 'line'},
+      geometry: {
+        type: 'LineString',
+        coordinates: [
+          [0, 0, 1, 2],
+          [1, 1, 2, 3]
+        ]
+      }
+    },
+    {
+      type: 'Feature',
+      properties: {kind: 'polygon'},
+      geometry: {
+        type: 'Polygon',
+        coordinates: [
+          [
+            [0, 0, 1, 2],
+            [2, 0, 1, 2],
+            [0, 2, 1, 2],
+            [0, 0, 1, 2]
+          ]
+        ]
+      }
+    },
+    {
+      type: 'Feature',
+      properties: {kind: 'multipoint'},
+      geometry: {
+        type: 'MultiPoint',
+        coordinates: [
+          [1, 2, 3, 4],
+          [5, 6, 7, 8]
+        ]
+      }
+    },
+    {
+      type: 'Feature',
+      properties: {kind: 'multiline'},
+      geometry: {
+        type: 'MultiLineString',
+        coordinates: [
+          [
+            [0, 0, 1, 2],
+            [1, 1, 2, 3]
+          ]
+        ]
+      }
+    },
+    {
+      type: 'Feature',
+      properties: {kind: 'multipolygon'},
+      geometry: {
+        type: 'MultiPolygon',
+        coordinates: [
+          [
+            [
+              [0, 0, 1, 2],
+              [2, 0, 1, 2],
+              [0, 2, 1, 2],
+              [0, 0, 1, 2]
+            ]
+          ]
+        ]
+      }
+    }
+  ];
+  const source = setGeometryFieldEncoding(
+    convertFeaturesToGeoArrowTable(features, {geoarrow: {encoding: 'wkt'}}).data,
+    'geoarrow.wkt'
+  );
+  const union = convertGeoArrowGeometry(source, 'geoarrow.geometry');
+  const roundTrip = convertGeoArrowGeometry(union, 'geoarrow.wkt');
+
+  expect(union.getChild('geometry')?.type.toString()).toContain('Union<');
+  expect(convertGeoArrowToTable(roundTrip, 'geojson-table').features).toEqual(features);
+});
+
+test('GeoArrowGeometryConverter handles null and empty geometry collections', () => {
+  const features: Feature[] = [
+    {
+      type: 'Feature',
+      properties: {kind: 'empty'},
+      geometry: {type: 'GeometryCollection', geometries: []}
+    },
+    {
+      type: 'Feature',
+      properties: {kind: 'nested'},
+      geometry: {
+        type: 'GeometryCollection',
+        geometries: [
+          {type: 'Point', coordinates: [1, 2, 3]},
+          {
+            type: 'Polygon',
+            coordinates: [
+              [
+                [0, 0, 0],
+                [1, 0, 0],
+                [0, 1, 0],
+                [0, 0, 0]
+              ]
+            ]
+          }
+        ]
+      }
+    }
+  ];
+  const source = setGeometryFieldEncoding(
+    convertFeaturesToGeoArrowTable(features, {geoarrow: {encoding: 'wkt'}}).data,
+    'geoarrow.wkt'
+  );
+  const collection = convertGeoArrowGeometry(source, 'geoarrow.geometrycollection');
+  const union = convertGeoArrowGeometry(collection, 'geoarrow.geometry');
+  const roundTrip = convertGeoArrowGeometry(union, 'geoarrow.wkb');
+
+  expect(convertGeoArrowToTable(roundTrip, 'geojson-table').features).toEqual(features);
+
+  const nullableWKT = setGeometryFieldEncoding(
+    arrow.tableFromArrays({geometry: [null, 'POINT (1 2)']}),
+    'geoarrow.wkt'
+  );
+  const nullableUnion = convertGeoArrowGeometry(nullableWKT, 'geoarrow.geometry');
+  expect(nullableUnion.numRows).toBe(2);
+  expect(nullableUnion.getChild('geometry')?.get(0)).toBeNull();
+});
+
+test('GeoArrowGeometryConverter validates column selection and collection targets', async () => {
+  const plainTable = arrow.tableFromArrays({value: [1]});
+  expect(() => convertGeoArrowGeometry(plainTable, 'geoarrow.wkt')).toThrow(
+    /requires at least one geometry column/
+  );
+
+  const pointTable = await loadArrowTable(GEOARROW_POINT_FILE);
+  expect(() =>
+    convertGeoArrowGeometry(pointTable, 'geoarrow.wkt', {geometryColumn: 'missing'})
+  ).toThrow(/could not find geometry column/);
+  expect(() =>
+    convertGeoArrowGeometry(pointTable, 'geoarrow.wkt', {
+      geometryColumn: 'geometry',
+      geometryColumns: ['geometry']
+    })
+  ).toThrow(/Specify only one/);
+  expect(() => convertGeoArrowGeometry(pointTable, 'geoarrow.geometrycollection')).toThrow(
+    /cannot encode Point as geoarrow.geometrycollection/
+  );
+});

--- a/modules/gis/test/geometry-converters/wkb/convert-wkb-to-geometry.spec.ts
+++ b/modules/gis/test/geometry-converters/wkb/convert-wkb-to-geometry.spec.ts
@@ -305,10 +305,14 @@ test.each([
     ]
   ]
 ])('triangulateWKB#handles difficult %s polygons', (_name, ring) => {
-  const triangles = triangulateWKB(
-    convertGeometryToWKB({type: 'Polygon', coordinates: [ring as Position[]]})
-  );
-  expect(triangles.every(Number.isInteger)).toBe(true);
+  const wkb = convertGeometryToWKB({type: 'Polygon', coordinates: [ring as Position[]]});
+  if (_name === 'self intersection') {
+    const triangles = triangulateWKB(wkb);
+    expect(triangles.length).toBeGreaterThan(0);
+    expect(triangles.every(Number.isInteger)).toBe(true);
+  } else {
+    assertTriangulateWKBMatchesEarcutInputs(wkb, _name);
+  }
 });
 
 test('triangulateWKB#handles touching, single-point, and multiple holes', () => {

--- a/modules/gis/test/geometry-converters/wkb/convert-wkb-to-geometry.spec.ts
+++ b/modules/gis/test/geometry-converters/wkb/convert-wkb-to-geometry.spec.ts
@@ -267,6 +267,82 @@ test('triangulateWKB#rejects non-polygon geometry', async () => {
   );
 });
 
+test.each([
+  [
+    'self intersection',
+    [
+      [0, 0],
+      [4, 4],
+      [0, 4],
+      [4, 0],
+      [0, 0]
+    ]
+  ],
+  [
+    'duplicate and collinear vertices',
+    [
+      [0, 0],
+      [2, 0],
+      [2, 0],
+      [4, 0],
+      [4, 4],
+      [0, 4],
+      [0, 0]
+    ]
+  ],
+  [
+    'narrow concave corridor',
+    [
+      [0, 0],
+      [6, 0],
+      [6, 6],
+      [4, 6],
+      [4, 1],
+      [2, 1],
+      [2, 6],
+      [0, 6],
+      [0, 0]
+    ]
+  ]
+])('triangulateWKB#handles difficult %s polygons', (_name, ring) => {
+  const triangles = triangulateWKB(
+    convertGeometryToWKB({type: 'Polygon', coordinates: [ring as Position[]]})
+  );
+  expect(triangles.every(Number.isInteger)).toBe(true);
+});
+
+test('triangulateWKB#handles touching, single-point, and multiple holes', () => {
+  const polygon: Geometry = {
+    type: 'Polygon',
+    coordinates: [
+      [
+        [0, 0],
+        [10, 0],
+        [10, 10],
+        [0, 10],
+        [0, 0]
+      ],
+      [
+        [0, 5],
+        [2, 4],
+        [2, 6],
+        [0, 5]
+      ],
+      [[5, 5]],
+      [
+        [7, 7],
+        [8, 7],
+        [8, 8],
+        [7, 8],
+        [7, 7]
+      ]
+    ]
+  };
+  const triangles = triangulateWKB(convertGeometryToWKB(polygon));
+  expect(triangles.length).toBeGreaterThan(0);
+  expect(triangles.every(Number.isInteger)).toBe(true);
+});
+
 /**
  * Verifies direct WKB triangulation against the existing GeoJSON-to-earcut path.
  * @param wkb WKB input.

--- a/modules/gltf/test/lib/api/gltf-scenegraph-modifiers.spec.ts
+++ b/modules/gltf/test/lib/api/gltf-scenegraph-modifiers.spec.ts
@@ -83,3 +83,105 @@ test('GLTFScenegraph#Nodes should store `matrix` transformation data', async () 
   expect(gltfBuilder.gltf.json.nodes?.[nodeIndex2]).toBeTruthy();
   expect(gltfBuilder.gltf.json.nodes?.[nodeIndex2].matrix).toBeFalsy();
 });
+
+test('GLTFScenegraph covers metadata, extension, and object accessors', () => {
+  const json: any = {
+    asset: {version: '2.0'},
+    custom: {enabled: true},
+    extras: {owner: 'loaders.gl'},
+    scenes: [{nodes: [0]}],
+    nodes: [{mesh: 0}],
+    skins: [{joints: [0]}],
+    meshes: [{primitives: []}],
+    materials: [{name: 'material'}],
+    accessors: [{bufferView: 0, componentType: 5121, count: 4, type: 'SCALAR'}],
+    textures: [{source: 0}],
+    samplers: [{magFilter: 9729}],
+    images: [{bufferView: 0, mimeType: 'image/png'}],
+    bufferViews: [{buffer: 0, byteOffset: 1, byteLength: 2}],
+    buffers: [{byteLength: 4}],
+    extensions: {EXT_used: {value: 1}, EXT_required: {value: 2}},
+    extensionsUsed: ['EXT_used', 'EXT_required'],
+    extensionsRequired: ['EXT_required']
+  };
+  const arrayBuffer = new Uint8Array([0, 10, 20, 30]).buffer;
+  const scenegraph = new GLTFScenegraph({
+    json,
+    buffers: [{arrayBuffer, byteOffset: 0, byteLength: 4}]
+  });
+
+  expect(scenegraph.getApplicationData('custom')).toEqual({enabled: true});
+  expect(scenegraph.getExtraData('owner')).toBe('loaders.gl');
+  expect(scenegraph.hasExtension('EXT_used')).toBe(true);
+  expect(scenegraph.hasExtension('EXT_missing')).toBe(false);
+  expect(scenegraph.getExtension('EXT_used')).toEqual({value: 1});
+  expect(scenegraph.getRequiredExtension('EXT_required')).toEqual({value: 2});
+  expect(scenegraph.getRequiredExtension('EXT_used')).toBeNull();
+  expect(scenegraph.getScene(0)).toBe(json.scenes[0]);
+  expect(scenegraph.getNode(0)).toBe(json.nodes[0]);
+  expect(scenegraph.getSkin(0)).toBe(json.skins[0]);
+  expect(scenegraph.getMesh(0)).toBe(json.meshes[0]);
+  expect(scenegraph.getMaterial(0)).toBe(json.materials[0]);
+  expect(scenegraph.getAccessor(0)).toBe(json.accessors[0]);
+  expect(scenegraph.getTexture(0)).toBe(json.textures[0]);
+  expect(scenegraph.getSampler(0)).toBe(json.samplers[0]);
+  expect(scenegraph.getImage(0)).toBe(json.images[0]);
+  expect(scenegraph.getBufferView(0)).toBe(json.bufferViews[0]);
+  expect(scenegraph.getBuffer(0)).toBe(json.buffers[0]);
+  expect(scenegraph.getObject('nodes', json.nodes[0])).toBe(json.nodes[0]);
+  expect(Array.from(scenegraph.getTypedArrayForBufferView(0))).toEqual([10, 20]);
+  expect(() => scenegraph.getNode(10)).toThrow(/Could not find nodes\[10\]/);
+});
+
+test('GLTFScenegraph covers extension mutation and compact scene construction', () => {
+  const scenegraph = new GLTFScenegraph();
+  const object: any = {};
+
+  scenegraph.addApplicationData('application', {value: 1});
+  scenegraph.addExtraData('extra', {value: 2});
+  scenegraph.addObjectExtension(object, 'EXT_object', {enabled: true});
+  expect(scenegraph.getObjectExtension(object, 'EXT_object')).toEqual({enabled: true});
+  scenegraph.setObjectExtension(object, 'EXT_set', {value: 3});
+  scenegraph.removeObjectExtension(object, 'EXT_set');
+  scenegraph.removeObjectExtension(object, 'EXT_set');
+  expect(scenegraph.getRemovedExtensions()).toContain('EXT_set');
+
+  expect(scenegraph.addExtension('EXT_optional', {value: 4})).toEqual({value: 4});
+  scenegraph.addRequiredExtension('EXT_required', {value: 5});
+  scenegraph.registerUsedExtension('EXT_optional');
+  scenegraph.registerRequiredExtension('EXT_required');
+  expect(scenegraph.getUsedExtensions()).toEqual(['EXT_object', 'EXT_optional', 'EXT_required']);
+  scenegraph.removeExtension('EXT_required');
+  scenegraph.removeExtension('EXT_required');
+  expect(scenegraph.getRemovedExtensions()).toEqual(
+    expect.arrayContaining(['EXT_set', 'EXT_required'])
+  );
+
+  const position = {value: new Float32Array([0, 1, 2, 3, 4, 5]), size: 3};
+  const indices = new Uint16Array([0, 1]);
+  const meshIndex = scenegraph.addMesh({
+    attributes: {
+      vertices: position,
+      normals: position,
+      colors: {value: new Uint8Array([1, 2, 3, 4, 5, 6]), size: 3},
+      texcoords: {value: new Float32Array([0, 0, 1, 1]), size: 2},
+      custom: {value: new Float32Array([7, 8]), size: 1}
+    },
+    indices: indices as any,
+    material: 0,
+    mode: 1
+  });
+  expect(scenegraph.addPointCloud({POSITION: position})).toBe(1);
+  expect(scenegraph.addNode({meshIndex})).toBe(0);
+  expect(scenegraph.addScene({nodeIndices: [0]})).toBe(0);
+  scenegraph.setDefaultScene(0);
+  expect(scenegraph.addTexture({imageIndex: 0})).toBe(0);
+  expect(scenegraph.addMaterial({name: 'material'})).toBe(0);
+  expect(scenegraph.json.meshes?.[0].primitives[0]).toMatchObject({mode: 1, material: 0});
+  expect(scenegraph.json.accessors?.[0].min).toEqual([0, 1, 2]);
+  expect(scenegraph.json.accessors?.[0].max).toEqual([3, 4, 5]);
+
+  scenegraph.createBinaryChunk();
+  expect(scenegraph.gltf.binary?.byteLength).toBe(scenegraph.byteLength);
+  expect(scenegraph.gltf.buffers[0].byteLength).toBe(scenegraph.byteLength);
+});

--- a/modules/ply/test/parse-ply-edge-cases.spec.ts
+++ b/modules/ply/test/parse-ply-edge-cases.spec.ts
@@ -13,6 +13,163 @@ import {
 } from '../src/lib/parse-ply';
 
 describe('PLY parser edge cases', () => {
+  test('parses every scalar type through both endian direct point-cloud paths', () => {
+    const properties = [
+      ['char', 'signedByte', -7],
+      ['uchar', 'unsignedByte', 250],
+      ['short', 'signedShort', -1234],
+      ['ushort', 'unsignedShort', 54321],
+      ['int', 'signedInt', -1234567],
+      ['uint', 'unsignedInt', 3456789012],
+      ['float', 'x', 1.25],
+      ['float32', 'y', -2.5],
+      ['double', 'z', 3.75]
+    ] as const;
+
+    for (const littleEndian of [true, false]) {
+      const format = littleEndian ? 'binary_little_endian' : 'binary_big_endian';
+      const headerText = [
+        'ply',
+        `format ${format} 1.0`,
+        'element vertex 1',
+        ...properties.map(([type, name]) => `property ${type} ${name}`),
+        'end_header\n'
+      ].join('\n');
+      const headerBytes = new TextEncoder().encode(headerText);
+      const record = new ArrayBuffer(30);
+      const dataView = new DataView(record);
+      let byteOffset = 0;
+      dataView.setInt8(byteOffset, -7);
+      byteOffset += 1;
+      dataView.setUint8(byteOffset, 250);
+      byteOffset += 1;
+      dataView.setInt16(byteOffset, -1234, littleEndian);
+      byteOffset += 2;
+      dataView.setUint16(byteOffset, 54321, littleEndian);
+      byteOffset += 2;
+      dataView.setInt32(byteOffset, -1234567, littleEndian);
+      byteOffset += 4;
+      dataView.setUint32(byteOffset, 3456789012, littleEndian);
+      byteOffset += 4;
+      dataView.setFloat32(byteOffset, 1.25, littleEndian);
+      byteOffset += 4;
+      dataView.setFloat32(byteOffset, -2.5, littleEndian);
+      byteOffset += 4;
+      dataView.setFloat64(byteOffset, 3.75, littleEndian);
+
+      const bytes = new Uint8Array(headerBytes.length + record.byteLength);
+      bytes.set(headerBytes);
+      bytes.set(new Uint8Array(record), headerBytes.length);
+      const table = parsePLYToArrowTable(bytes.buffer);
+
+      expect(table?.data.numRows).toBe(1);
+      expect(Array.from(table!.data.getChild('POSITION')!.get(0) as number[])).toEqual([
+        1.25, -2.5, 3.75
+      ]);
+      for (const [, name, value] of properties.slice(0, 6)) {
+        expect(table!.data.getChild(name)!.get(0)).toBeCloseTo(value, -2);
+      }
+    }
+  });
+
+  test('parses binary mesh lists and normalized attributes through the general parser', () => {
+    const headerText = [
+      'ply',
+      'format binary_big_endian 1.0',
+      'element vertex 4',
+      'property float x',
+      'property float y',
+      'property float z',
+      'property float nx',
+      'property float ny',
+      'property float nz',
+      'property float s',
+      'property float t',
+      'property uchar red',
+      'property uchar green',
+      'property uchar blue',
+      'property double confidence',
+      'element face 1',
+      'property list uchar int vertex_index',
+      'end_header\n'
+    ].join('\n');
+    const headerBytes = new TextEncoder().encode(headerText);
+    const vertexStride = 43;
+    const body = new ArrayBuffer(vertexStride * 4 + 17);
+    const dataView = new DataView(body);
+    for (let vertexIndex = 0; vertexIndex < 4; vertexIndex++) {
+      const offset = vertexIndex * vertexStride;
+      for (let component = 0; component < 8; component++) {
+        dataView.setFloat32(offset + component * 4, vertexIndex + component / 10, false);
+      }
+      dataView.setUint8(offset + 32, 10 + vertexIndex);
+      dataView.setUint8(offset + 33, 20 + vertexIndex);
+      dataView.setUint8(offset + 34, 30 + vertexIndex);
+      dataView.setFloat64(offset + 35, vertexIndex + 0.5, false);
+    }
+    const faceOffset = vertexStride * 4;
+    dataView.setUint8(faceOffset, 4);
+    for (let index = 0; index < 4; index++) {
+      dataView.setInt32(faceOffset + 1 + index * 4, index, false);
+    }
+    const bytes = new Uint8Array(headerBytes.length + body.byteLength);
+    bytes.set(headerBytes);
+    bytes.set(new Uint8Array(body), headerBytes.length);
+
+    const mesh = parsePLY(bytes.buffer, {_useLegacyBinaryPointCloudParser: true});
+    expect(mesh.indices?.value).toEqual(new Uint32Array([0, 1, 3, 1, 2, 3]));
+    expect(mesh.attributes.NORMAL.value).toHaveLength(12);
+    expect(mesh.attributes.TEXCOORD_0.value).toHaveLength(8);
+    expect(mesh.attributes.COLOR_0.value).toHaveLength(12);
+    expect(mesh.attributes.confidence.value).toEqual(new Float32Array([0.5, 1.5, 2.5, 3.5]));
+  });
+
+  test('covers ASCII scalar aliases and reports unsupported scalar types', () => {
+    const integerTypes = ['int8', 'uint8', 'int16', 'uint16', 'int32', 'uint32'];
+    const ply = [
+      'ply',
+      'format ascii 1.0',
+      'element vertex 1',
+      'property float32 x',
+      'property float64 y',
+      'property double z',
+      ...integerTypes.map(type => `property ${type} value_${type}`),
+      'end_header',
+      '1.5 2.5 3.5 -1 2 -3 4 -5 6'
+    ].join('\n');
+    const mesh = parsePLY(ply);
+    expect(mesh.attributes.POSITION.value).toEqual(new Float32Array([1.5, 2.5, 3.5]));
+    for (const type of integerTypes) {
+      expect(mesh.attributes[`value_${type}`]).toBeDefined();
+    }
+
+    expect(() =>
+      parsePLY(
+        [
+          'ply',
+          'format ascii 1.0',
+          'element vertex 1',
+          'property potato x',
+          'end_header',
+          '1'
+        ].join('\n')
+      )
+    ).toThrow(/potato/);
+    expect(() =>
+      getPLYBinaryPointCloudParsePlan(
+        parsePLYHeader(
+          [
+            'ply',
+            'format binary_little_endian 1.0',
+            'element vertex 1',
+            'property potato x',
+            'end_header\n'
+          ].join('\n')
+        )
+      )
+    ).toThrow(/potato/);
+  });
+
   test('parses mapped ASCII attributes, lists, comments, and CRLF headers', () => {
     const ply = [
       'ply',

--- a/modules/ply/test/parse-ply-edge-cases.spec.ts
+++ b/modules/ply/test/parse-ply-edge-cases.spec.ts
@@ -20,7 +20,7 @@ describe('PLY parser edge cases', () => {
       ['short', 'signedShort', -1234],
       ['ushort', 'unsignedShort', 54321],
       ['int', 'signedInt', -1234567],
-      ['uint', 'unsignedInt', 3456789012],
+      ['uint', 'unsignedInt', 12345678],
       ['float', 'x', 1.25],
       ['float32', 'y', -2.5],
       ['double', 'z', 3.75]
@@ -49,7 +49,7 @@ describe('PLY parser edge cases', () => {
       byteOffset += 2;
       dataView.setInt32(byteOffset, -1234567, littleEndian);
       byteOffset += 4;
-      dataView.setUint32(byteOffset, 3456789012, littleEndian);
+      dataView.setUint32(byteOffset, 12345678, littleEndian);
       byteOffset += 4;
       dataView.setFloat32(byteOffset, 1.25, littleEndian);
       byteOffset += 4;
@@ -67,7 +67,7 @@ describe('PLY parser edge cases', () => {
         1.25, -2.5, 3.75
       ]);
       for (const [, name, value] of properties.slice(0, 6)) {
-        expect(table!.data.getChild(name)!.get(0)).toBeCloseTo(value, -2);
+        expect(table!.data.getChild(name)!.get(0)).toBe(value);
       }
     }
   });

--- a/modules/sql/test/arrow-query.spec.ts
+++ b/modules/sql/test/arrow-query.spec.ts
@@ -468,6 +468,159 @@ test('queryArrowTable reports missing UNION and JOIN sources', () => {
   ).toThrow(/more than once/);
 });
 
+test('queryArrowTable evaluates every relational expression and aggregate boundary', () => {
+  const table = makeArrowTable({
+    group: ['a', 'a', 'b'],
+    left: [8, 4, null],
+    right: [2, 0, 3]
+  });
+  const expressions = [
+    {name: 'literal', expression: {op: 'literal' as const, value: true}},
+    {name: 'copy', expression: {op: 'column' as const, column: 'left'}},
+    {name: 'add', expression: {op: 'add' as const, left: 'left', right: 'right'}},
+    {name: 'subtract', expression: {op: 'subtract' as const, left: 'left', right: 'right'}},
+    {name: 'divide', expression: {op: 'divide' as const, left: 'left', right: 'right'}}
+  ];
+  const result = queryArrowTable(table, {
+    expressions,
+    columns: ['group', 'literal', 'copy', 'add', 'subtract', 'divide']
+  });
+  expect(toRows(result)).toEqual([
+    {group: 'a', literal: true, copy: 8, add: 10, subtract: 6, divide: 4},
+    {group: 'a', literal: true, copy: 4, add: 4, subtract: 4, divide: null},
+    {group: 'b', literal: true, copy: null, add: null, subtract: null, divide: null}
+  ]);
+
+  const aggregates = queryArrowTable(table, {
+    aggregates: [
+      {name: 'rows', function: 'count'},
+      {name: 'values', function: 'count', column: 'left'},
+      {name: 'minimum', function: 'min', column: 'left'},
+      {name: 'maximum', function: 'max', column: 'left'}
+    ]
+  });
+  expect(toRows(aggregates)).toEqual([{rows: 3, values: 2, minimum: 4, maximum: 8}]);
+
+  expect(() =>
+    queryArrowTable(makeArrowTable({left: ['x'], right: [1]}), {
+      expressions: [{name: 'bad', expression: {op: 'add', left: 'left', right: 'right'}}]
+    })
+  ).toThrow(/requires numeric operands/);
+  expect(() =>
+    queryArrowTable(makeArrowTable({value: ['x']}), {
+      aggregates: [{name: 'bad', function: 'sum', column: 'value'}]
+    })
+  ).toThrow(/requires numeric values/);
+});
+
+test('queryArrowTable covers empty-result schemas for computed values', () => {
+  const source = makeArrowTable({number: [1], label: ['x']});
+  const result = queryArrowTable(source, {
+    expressions: [
+      {name: 'flag', expression: {op: 'literal', value: true}},
+      {name: 'constant', expression: {op: 'literal', value: 2}},
+      {name: 'text', expression: {op: 'literal', value: 'x'}},
+      {name: 'copy', expression: {op: 'column', column: 'label'}},
+      {name: 'sum', expression: {op: 'add', left: 'number', right: 'number'}}
+    ],
+    columns: ['flag', 'constant', 'text', 'copy', 'sum'],
+    limit: 0
+  });
+  expect(result.data.numRows).toBe(0);
+  expect(result.data.schema.fields.map(field => field.type.toString())).toEqual([
+    'Bool',
+    'Float64',
+    'Utf8',
+    'Dictionary<Int32, Utf8>',
+    'Float64'
+  ]);
+
+  const aggregateResult = queryArrowTable(source, {
+    aggregates: [
+      {name: 'count', function: 'count'},
+      {name: 'knownTotal', function: 'sum', column: 'number'}
+    ],
+    columns: ['count', 'knownTotal'],
+    limit: 0
+  });
+  expect(aggregateResult.data.schema.fields.map(field => field.type.toString())).toEqual([
+    'Int32',
+    'Float64'
+  ]);
+});
+
+test('queryArrowTable covers scalar ordering and grouping key kinds', () => {
+  const dates = [new Date(2), new Date(1)];
+  const orderedDates = queryArrowTable(makeArrowTable({date: dates}), {
+    orderBy: [{column: 'date'}]
+  });
+  expect(toRows(orderedDates).map(row => Number(row.date))).toEqual([1, 2]);
+
+  const orderedBigints = queryArrowTable(makeArrowTable({value: [2n, 1n, 2n]}), {
+    orderBy: [{column: 'value'}]
+  });
+  expect(toRows(orderedBigints).map(row => row.value)).toEqual([1n, 2n, 2n]);
+
+  const grouped = queryArrowTable(
+    makeArrowTable({
+      date: [new Date(1), new Date(1)],
+      bytes: [new Uint8Array([1, 2]), new Uint8Array([1, 2])],
+      nullable: [null, null]
+    }),
+    {
+      groupBy: ['date', 'bytes', 'nullable'],
+      aggregates: [{name: 'rows', function: 'count'}]
+    }
+  );
+  expect(toRows(grouped)).toHaveLength(1);
+  expect(toRows(grouped)[0].rows).toBe(2);
+
+  expect(() =>
+    queryArrowTable(makeArrowTable({left: [Number.POSITIVE_INFINITY]}), {
+      predicate: {op: '>', args: [{property: 'left'}, 1]}
+    })
+  ).toThrow(/non-finite/);
+});
+
+test('queryArrowTable validates all join projection boundaries', () => {
+  const source = makeArrowTable({id: [1], value: [10]});
+  const child = makeArrowTable({key: [1], label: ['one']});
+  const baseJoin = {child: {source: 'child'}, left: 'id', right: 'key'} as const;
+
+  expect(() =>
+    queryArrowTable(source, {
+      join: {...baseJoin, left: 'missing'},
+      tables: {child}
+    })
+  ).toThrow(/join column not found: missing/);
+  expect(() =>
+    queryArrowTable(source, {
+      join: {...baseJoin, right: 'missing'},
+      tables: {child}
+    })
+  ).toThrow(/join column not found: missing/);
+  expect(() =>
+    queryArrowTable(source, {
+      join: {child: {source: 'child', query: {columns: ['label']}}, left: 'id', right: 'key'},
+      tables: {child}
+    })
+  ).toThrow(/child projection must include/);
+  expect(() =>
+    queryArrowTable(source, {
+      join: baseJoin,
+      tables: {child},
+      columns: ['id', 'child.missing']
+    })
+  ).toThrow(/join column not found/);
+  expect(() =>
+    queryArrowTable(source, {
+      join: {child: {source: 'child', query: {columns: ['key']}}, left: 'id', right: 'key'},
+      tables: {child},
+      columns: ['id', 'child.label']
+    })
+  ).toThrow(/child projection does not include/);
+});
+
 /** Wraps simple test columns in the loaders.gl Arrow table shape. */
 function makeArrowTable(columns: Record<string, readonly unknown[]>): ArrowTable {
   const data = arrow.tableFromArrays(columns);


### PR DESCRIPTION
## Goals

- Make a material repository-level coverage gain by testing dense, high-impact parser and converter code.
- Keep the added CI workload fast and hermetic.
- Exercise behavior and boundary cases without removing performance-oriented branching.

## Changes

- Expand raw Arrow CSV coverage for quoted data, uneven rows, delimiter/header inference, custom quoting, late fast-path rejection, and builder growth.
- Exercise every GeoArrow union geometry kind, dimensions, null/empty collections, round trips, and selection validation.
- Cover difficult WKB triangulation inputs including self intersections, collinear vertices, narrow concavities, touching holes, and Steiner-point holes.
- Exercise GLTF scenegraph accessors, extension lifecycle, object construction, attribute mapping, and binary chunk creation.
- Cover PLY ASCII and binary scalar matrices, both endiannesses, normalized attributes, mesh lists, and invalid scalar types.
- Cover SQL relational expression, aggregate, empty-schema, scalar ordering/grouping, and join-validation branches.

## Coverage impact

Unioning the focused coverage output with the latest merged `master` CI artifact adds **285 previously uncovered statements**:

- GeoArrow geometry converter: +70
- PLY parser: +66
- GLTF scenegraph: +58
- WKB triangulation: +54
- SQL Arrow queries: +22
- CSV and supporting GIS/PLY helpers: +15

Projected statement coverage moves from **81.28% to 81.688%**, a **+0.404 percentage-point** gain.

## Validation

- `yarn lint fix`
- `yarn test-audit` — 639 files, 0 Tape, 0 violations
- Focused Chromium suite — 6 files, 99 tests passed in 3.57s
- Focused suite with repository-wide coverage instrumentation — 6 files, 99 tests passed in 7.24s
- `git diff --check`
- `yarn build` compiled all 57 module source trees, then the bundle pre-build hit the existing worktree alias issue where `ocular-bundle` resolved `@loaders.gl/crypto` against the main checkout instead of this worktree.
