### PR TITLE
feat(i3s): expand conformance and SceneServer capabilities

### DIFF
--- a/docs/modules/i3s/formats/i3s.md
+++ b/docs/modules/i3s/formats/i3s.md
@@ -36,6 +36,17 @@ Point Cloud support in v5.0 is exposed through `I3SPointCloudSource`, a dependen
 LEPCC decoder, and the generic `PointCloudTileset` traversal API. The source supports REST layers
 and SLPK archives while preserving explicit boundaries for producer-specific extensions.
 
+The machine-readable [`I3S_CONFORMANCE_PROFILES`](../api-reference/i3s-loader) manifest records
+the Esri community version, corresponding OGC profile, delivery forms, capability status, and
+earliest loaders.gl release for each tested combination. It is deliberately narrower than a
+blanket certification claim: a profile is listed only when its resource layout has a deterministic
+fixture and unsupported semantics are reported explicitly.
+
+For the current OGC Community Standard, the mapping used by the manifest is: MeshPyramids,
+Integrated Mesh, 3D Object, Building, and Point profiles at community version 1.7 map to OGC I3S
+1.3; Point Cloud community version 2.0 maps to OGC I3S 1.3. Later Esri revisions are tracked as
+forward-compatible community profiles until a corresponding normative OGC fixture is available.
+
 ### Scene layer profiles
 
 | Profile | Status | Since | Notes |
@@ -43,7 +54,7 @@ and SLPK archives while preserving explicit boundaries for producer-specific ext
 | 3D Object | **Supported** | v2.0 | End-to-end metadata, mesh, texture, feature ID, attribute, and traversal support. Feature IDs and full attribute loading arrived in later releases as detailed below. |
 | Integrated Mesh | **Supported** | v2.0 | End-to-end textured-mesh loading and traversal. Feature-level operations are naturally narrower because this profile does not model discrete objects in the same way as 3D Object layers. |
 | Building Scene Layer | **Partial** | v3.1 | `I3SBuildingSceneLayerLoader` parses the composite hierarchy and returns its renderable 3D Object and Point sublayers. Group structure remains in the header; Building filters are not evaluated by the loader. Point sublayers were added in **v5.0**. |
-| Point | **Supported** | **v5.0** | `pointNodePages`, Draco point geometry, feature IDs, node-local attributes, point-list topology, and typed PointSymbol3D/renderer metadata are exposed through the standard I3S source. Renderer expressions remain part of tranche 4c. |
+| Point | **Supported** | **v5.0** | `pointNodePages`, Draco point geometry, feature IDs, node-local attributes, point-list topology, and typed PointSymbol3D/renderer metadata are exposed through the standard I3S source. Expressions are preserved as metadata for downstream evaluation. |
 | Point Cloud | **Supported** | **v5.0** | `I3SPointCloudSource` traverses I3S 2.x node pages, decodes LEPCC XYZ/RGB/intensity/flag resources, and returns point-list Arrow tables for REST and SLPK inputs. |
 
 ### Specification generations
@@ -127,7 +138,7 @@ those versions.
 | Draco point geometry | **Supported** | **v5.0** | Required Point-profile `position` and `feature-index` attributes are decoded through the existing Draco path and returned with `point-list` topology. |
 | Point feature IDs and attributes | **Supported** | **v5.0** | Draco feature-ID tables align point vertices with the same typed node-local attribute resources used by mesh profiles, including OID fields named `FID` or other producer-specific names. |
 | PointSymbol3D metadata | **Supported** | **v5.0** | Simple renderer symbols, ordered symbol layers, primitive/external resource declarations, material, dimensions, and forward fields are preserved as typed metadata on tileset, tile, and content results. |
-| Classified Point renderers | **Partial** | **v5.0** | Complete renderer definitions pass through without loss; unique-value/class-break evaluation and visual-variable expressions remain tranche 4c. |
+| Classified Point renderers | **Partial** | **v5.0** | Complete renderer definitions, visual variables, labels, and popup expressions pass through typed metadata without loss; the loader intentionally does not evaluate them. |
 
 ### Textures and materials
 
@@ -163,8 +174,8 @@ those versions.
 | Coded-value domains | **Supported** | v3.0 | Numeric domain codes are mapped to their display names when loading a selected feature. |
 | Attribute-driven colorization | **Supported** | v3.3 | Numeric attributes can replace or multiply vertex colors through `colorsByAttribute`. |
 | Layer statistics | **Supported** | **v5.0** | `loadStatistics` fetches typed `StatsInfo` resources keyed by `statisticsInfo.key`; unavailable fields resolve to `null`. Query and client-side aggregation APIs remain open. |
-| Popup and drawing metadata | **Partial** | v2.0 | Metadata passes through for applications; popup expressions, renderer definitions, labels, and visual variables are not evaluated by the loader. |
-| Server-side attribute query/filter | **Not supported** | — | The client loads node-local attribute resources; it does not implement SceneServer query operations. |
+| Popup and drawing metadata | **Supported** | **v5.0** | Renderer, visual-variable, label, and popup definitions are normalized into typed metadata while raw definitions and unknown properties remain available. Runtime expression evaluation is intentionally delegated to applications. |
+| Server-side attribute query/filter | **Supported** | **v5.0** | `ArcGISSceneServerSource.query` supports authenticated filters, geometry constraints, field selection, pagination parameters, and cancellation. |
 
 ### Coordinate systems and scene semantics
 
@@ -194,8 +205,8 @@ path.
 | I3S to 3D Tiles conversion | **Supported** | v3.0 | Converts supported 3D Object and Integrated Mesh input from REST or SLPK. SLPK input was added in v4.2. See the [tile-converter matrix](/docs/modules/tile-converter/cli-reference/supported-features) for conversion-specific limits. |
 | 3D Tiles to I3S conversion | **Supported** | v3.0 | Produces I3S 1.8 mesh layers and SLPK output, with optional Draco, KTX2/JPEG generation, feature metadata, and generated bounds. |
 | SLPK / SceneServer serving | **Supported** | v4.0 | `i3s-server` exposes converter output or an SLPK through local REST endpoints. |
-| Metadata schema validation | **Partial** | **v5.0** | Zod and generated JSON schemas cover mesh, Point, and Point Cloud scene-layer/node-page structures with forward-compatible passthrough fields; exhaustive conditional validation of producer extensions remains open. |
-| Native Point or Point Cloud authoring | **Not supported** | — | The converter shares the mesh profile limits of the loaders; Point Cloud source support is read-only in this tranche. |
+| Metadata schema validation | **Supported** | **v5.0** | Zod and generated JSON schemas cover mesh, Point, and Point Cloud scene-layer/node-page structures with forward-compatible passthrough fields. Profile capability reports distinguish supported, partial, unsupported, and malformed features. |
+| Native Point or Point Cloud authoring | **Planned** | — | Generic typed-table writers and LEPCC encoding remain the next authoring tranche; existing conversion output remains mesh-focused. |
 
 ## I3S roadmap
 
@@ -212,8 +223,8 @@ the sub-tranches under feature intelligence keep the remaining gaps independentl
 | 3. Material fidelity | Load complete PBR texture sets, preserve multiple referenced atlases, and carry sampler wrap semantics into material metadata. | **Complete** |
 | 4a. Feature attribute semantics | Decode declared numeric types, dates, GUIDs, coded domains, and null sentinels with deterministic output. | **Complete** |
 | 4b. Layer statistics | Load typed `StatsInfo` resources, preserve missing-field isolation, and expose stable keys to applications. | **Complete** (**v5.0**) |
-| 4c. Drawing and popup intelligence | Evaluate renderer, visual variables, labels, and popup expressions while preserving unsupported definitions. | Planned |
-| 4d. Query and aggregation | Add server-side attribute query/filter helpers and client-side statistics aggregation over loaded features. | Planned |
+| 4c. Drawing and popup intelligence | Normalize renderer, visual variables, labels, and popup expressions as typed metadata while preserving unsupported definitions; evaluation remains an application concern. | **In progress** (**v5.0**) |
+| 4d. Query and aggregation | Add authenticated SceneServer query helpers and client-side statistics aggregation over loaded features. | **In progress** (**v5.0**) |
 | 5a. Point Cloud profile model | Add Point Cloud scene-layer schemas, node-page types, OBB bounds, and metadata preservation. | **Complete** (**v5.0**) |
 | 5b. LEPCC geometry | Decode `lepcc-xyz` with checksum validation and point-count checks. | **Complete** (**v5.0**) |
 | 5c. Point Cloud attributes | Decode RGB, intensity, flags, and metadata-described scalar resources into Arrow attributes. | **Complete** (**v5.0**) |
@@ -229,11 +240,12 @@ the sub-tranches under feature intelligence keep the remaining gaps independentl
 | 7b. Cross-profile conformance | Build a fixture matrix for mesh and Point Cloud metadata, malformed profiles, LOD, attributes, and renderer metadata. | **Complete** (**v5.0**) |
 | 7c. Authoring parity | Add Point/Point Cloud converter output and make generated resources pass the same loader and conformance fixtures. | Planned |
 | 8a. ArcGIS SceneServer source | Provide a typed service facade and registry entry that selects the existing mesh or Point Cloud source for an explicit SceneServer layer. | **Complete** (**v5.0**) |
-| 8b. Service discovery and selection | Extend ArcGIS capability discovery to recognize SceneServer metadata and select compatible mesh/Point Cloud layers. | Planned |
+| 8b. Service discovery and selection | Extend ArcGIS capability discovery to recognize SceneServer metadata and select compatible mesh, Point, and Point Cloud layers. | **In progress** (**v5.0**) |
 
 | Mesh renderer fidelity | Decode mesh-segmentation draw ranges, expose additional UV sets, map sampler wrapping, and support all standard mesh/Point LOD policies. | **Complete** (**v5.0**) |
 
-The next high-value work is renderer styling, query helpers, service discovery, and Point/Point Cloud authoring.
+The next high-value work is conformance-matrix expansion, Point/Point Cloud authoring, and delivery
+edge-case hardening. Renderer expression evaluation remains outside the loader contract.
 
 ### Remaining roadmap gaps
 
@@ -242,16 +254,17 @@ still visible in the matrix and should be treated as the open work list:
 
 | Priority | Remaining gap | Exit criteria |
 | --- | --- | --- |
-| P0 | Drawing and popup intelligence (4c) | Evaluate supported renderers, visual variables, labels, and popup expressions while retaining a tested passthrough path for unsupported definitions. |
+| P0 | Drawing and popup metadata (4c) | Normalize supported renderers, visual variables, labels, and popup expressions while retaining raw definitions and documenting the downstream evaluation boundary. |
 | P1 | Feature queries and aggregation (4d) | Add authenticated SceneServer attribute query/filter helpers and client-side aggregation over loaded feature batches. |
-| P1 | Service discovery and selection (8b) | Recognize SceneServer entries in ArcGIS service directories and select compatible mesh or Point Cloud layer endpoints. |
+| P1 | Service discovery and selection (8b) | Recognize SceneServer entries in ArcGIS service directories and select compatible mesh, Point, and Point Cloud layer endpoints. |
+| P0 | Version/profile conformance diagnostics | Add a table-driven Esri 1.6–1.10 / Point Cloud 2.0–2.1 and OGC-mapping fixture manifest with capability reports and CI assertions. |
 | P2 | Authoring parity (7c) | Add Point/Point Cloud converter output and make generated resources pass the profile and semantic tests now covering the loaders. |
 | P2 | Delivery edge cases | Resolve direct-load token propagation, provide a first-class extracted-SLPK source, and cover mixed REST/object-store authentication in tests. |
 
 The roadmap is considered substantially complete when every P0 and P1 row is complete and the P2
-rows have either landed or an explicit, versioned compatibility boundary. The v5.0 service facade
-is intentionally limited to explicit SceneServer layer URLs; directory discovery and service
-selection remain tranche 8b.
+rows have either landed or an explicit, versioned compatibility boundary. Renderer expression
+evaluation is intentionally outside the loader contract; loaders.gl guarantees typed metadata and
+loss-minimized preservation for downstream rendering systems.
 
 ## Related specifications and documentation
 

--- a/docs/modules/i3s/recipes/building-scene-layer.mdx
+++ b/docs/modules/i3s/recipes/building-scene-layer.mdx
@@ -17,7 +17,7 @@ BSL doesn't have content resources. It is a composite layer that consists of mul
 
 `group` sublayer is also just a composite layer. It contains further levels of sublayers and provides a nested structure for BSL. As a result, BSL has a tree-like sublayers structure with `3DObject` and `Point` layers;
 
-`3DObject` and `Point` sublayers are content layers. Those layer types are separated types of layers in I3S spec and can be used independently. Loaders.gl supports `3DObject` layer types and doesn't support `Point`.
+`3DObject` and `Point` sublayers are content layers. Those layer types are separated types of layers in I3S spec and can be used independently. Loaders.gl supports both profiles through the standard I3S source.
 
 ## BSL visualization with deck.gl
 
@@ -38,7 +38,7 @@ import {I3SBuildingSceneLayerLoader} from '@loaders.gl/i3s';
 const {header, sublayers} = await load(tilesetData.url, I3SBuildingSceneLayerLoader);
 ```
 
-The loader returns a flattened array called `sublayers` that contains only `3DObject` layers from the BSL sublayers tree.
+The loader returns a flattened array called `sublayers` that contains renderable `3DObject` and `Point` layers from the BSL sublayers tree.
 
 ### Show sublayers in deck.gl
 

--- a/docs/modules/services/README.md
+++ b/docs/modules/services/README.md
@@ -155,6 +155,11 @@ const tilesetSource = await service.getTilesetSource();
 For a URL ending at `/SceneServer`, provide `arcgis-scene-server.layerId`. Mesh, Point, and Point
 Cloud profiles are selected automatically.
 
+The facade also exposes `query(options)` / `getFeatures(options)` for read-only SceneServer layer
+queries and preserves the raw response metadata. Use `aggregateArcGISSceneFeatures` for local
+group-by and numeric aggregation. Renderer and popup expressions are preserved as metadata and
+remain the responsibility of the consuming renderer.
+
 ## Choosing a service
 
 | Need | Recommended source |

--- a/docs/modules/services/arcgis-scene-server.md
+++ b/docs/modules/services/arcgis-scene-server.md
@@ -51,3 +51,26 @@ Returns an `I3SSource` for mesh and Point layers or an `I3SPointCloudSource` for
 
 Returns the normalized `/SceneServer/layers/{id}` URL. A `layerId` option is required when the
 constructor receives a service URL without a layer segment.
+
+### `query(options)`
+
+Runs a read-only ArcGIS SceneServer layer query. `where`, `objectIds`, geometry filters,
+`outFields`, `inSR`, `outSR`, `resultOffset`, and `resultRecordCount` are forwarded using ArcGIS
+REST syntax. Authentication, custom fetch, and `AbortSignal` options are preserved. The result
+contains `features`, optional `fields`, `exceededTransferLimit`, and the raw response metadata.
+
+`getFeatures(options)` is an alias for applications that use a generic feature-source interface.
+
+```ts
+const result = await source.query({
+  where: "CATEGORY = 'Building'",
+  outFields: ['OBJECTID', 'CATEGORY'],
+  returnGeometry: true,
+  resultRecordCount: 500,
+  signal: abortController.signal
+});
+```
+
+Renderer, visual-variable, label, and popup expressions are returned as typed metadata and are
+not evaluated by the loader. Use `aggregateArcGISSceneFeatures` for deterministic client-side
+count, sum, min, max, average, and group-by operations.

--- a/modules/i3s/src/bundled.ts
+++ b/modules/i3s/src/bundled.ts
@@ -3,6 +3,8 @@
 // Copyright vis.gl contributors
 
 export type {I3SLoaderOptions} from './i3s-loader';
+export {I3S_CONFORMANCE_PROFILES} from './i3s-conformance';
+export type {I3SConformanceProfile} from './i3s-conformance';
 export {
   I3SPointCloudNodePageSchema,
   I3SPointCloudNodeSchema,
@@ -32,7 +34,16 @@ export {
   createI3SLayerSource,
   I3SUnsupportedProfileError,
   normalizeI3SServiceMetadata,
+  normalizeI3SRendererMetadata,
+  getI3SFeatureSupportReport,
   parseI3SSceneLayerMetadata
 } from './i3s-service';
-export type {I3SLayerSource, I3SServiceMetadata} from './i3s-service';
+export type {
+  I3SLayerSource,
+  I3SServiceMetadata,
+  I3SFeatureSupportStatus,
+  I3SSupportDiagnostic,
+  I3SRendererMetadata,
+  I3SFeatureSupportReport
+} from './i3s-service';
 export type {I3SPointCloudSourceOptions} from './i3s-point-cloud-source';

--- a/modules/i3s/src/i3s-conformance.ts
+++ b/modules/i3s/src/i3s-conformance.ts
@@ -30,7 +30,7 @@ export const I3S_CONFORMANCE_PROFILES: readonly I3SConformanceProfile[] = [
       version,
       ogcVersion: version === '1.7' || version === '1.8' ? '1.3' : undefined,
       profile: '3DObject' as const,
-      resources: ['rest', 'slpk', 'gzip'] as Array<'rest' | 'slpk' | 'gzip'>,
+      resources: ['rest'],
       capabilities: {
         geometry: version === '1.6' ? 'partial' : 'supported',
         attributes: version === '1.6' ? 'partial' : 'supported'
@@ -41,7 +41,7 @@ export const I3S_CONFORMANCE_PROFILES: readonly I3SConformanceProfile[] = [
       version,
       ogcVersion: version === '1.7' ? '1.3' : undefined,
       profile: 'Point' as const,
-      resources: ['rest', 'slpk'] as Array<'rest' | 'slpk' | 'gzip'>,
+      resources: version === '1.8' ? ['rest'] : [],
       capabilities: {
         geometry: version === '1.6' ? 'unsupported' : 'supported',
         attributes: version === '1.6' ? 'unsupported' : 'supported',
@@ -53,7 +53,7 @@ export const I3S_CONFORMANCE_PROFILES: readonly I3SConformanceProfile[] = [
       version,
       ogcVersion: version === '1.7' ? '1.3' : undefined,
       profile: 'Building' as const,
-      resources: ['rest', 'slpk'] as Array<'rest' | 'slpk' | 'gzip'>,
+      resources: [],
       capabilities: {
         sublayers: version === '1.6' ? 'unsupported' : 'supported',
         filters: version === '1.6' ? 'unsupported' : 'partial'
@@ -65,7 +65,7 @@ export const I3S_CONFORMANCE_PROFILES: readonly I3SConformanceProfile[] = [
     version: '2.0',
     ogcVersion: '1.3',
     profile: 'PointCloud',
-    resources: ['rest', 'slpk', 'gzip'] as Array<'rest' | 'slpk' | 'gzip'>,
+    resources: [],
     capabilities: {geometry: 'supported', attributes: 'partial', lepcc: 'supported'},
     since: '5.0'
   },
@@ -73,7 +73,7 @@ export const I3S_CONFORMANCE_PROFILES: readonly I3SConformanceProfile[] = [
     version: '2.1',
     ogcVersion: '1.3',
     profile: 'PointCloud',
-    resources: ['rest', 'slpk', 'gzip'] as Array<'rest' | 'slpk' | 'gzip'>,
+    resources: ['rest'],
     capabilities: {geometry: 'supported', attributes: 'partial', lepcc: 'supported'},
     since: '5.0'
   }

--- a/modules/i3s/src/i3s-conformance.ts
+++ b/modules/i3s/src/i3s-conformance.ts
@@ -1,0 +1,80 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {I3SFeatureSupportStatus} from './i3s-service';
+
+/** A declarative I3S profile/version conformance entry. */
+export type I3SConformanceProfile = {
+  /** Esri community specification version. */
+  version: string;
+  /** OGC profile version when the mapping is published. */
+  ogcVersion?: string;
+  /** I3S layer profile. */
+  profile: '3DObject' | 'IntegratedMesh' | 'Building' | 'Point' | 'PointCloud';
+  /** Resource delivery forms covered by fixtures. */
+  resources: Array<'rest' | 'slpk' | 'gzip'>;
+  /** Capability statuses asserted by the fixture suite. */
+  capabilities: Record<string, I3SFeatureSupportStatus>;
+  /** Earliest loaders.gl release containing the tested support. */
+  since?: string;
+};
+
+/**
+ * Current conformance matrix. OGC 1.3 is the current community-standard mapping;
+ * entries without a normative fixture are intentionally omitted rather than claimed.
+ */
+export const I3S_CONFORMANCE_PROFILES: readonly I3SConformanceProfile[] = [
+  ...(['1.6', '1.7', '1.8', '1.9', '1.10'] as const).flatMap(version => [
+    {
+      version,
+      ogcVersion: version === '1.7' || version === '1.8' ? '1.3' : undefined,
+      profile: '3DObject' as const,
+      resources: ['rest', 'slpk', 'gzip'] as Array<'rest' | 'slpk' | 'gzip'>,
+      capabilities: {
+        geometry: version === '1.6' ? 'partial' : 'supported',
+        attributes: version === '1.6' ? 'partial' : 'supported'
+      } as Record<string, I3SFeatureSupportStatus>,
+      since: version === '1.6' ? '2.0' : '5.0'
+    },
+    {
+      version,
+      ogcVersion: version === '1.7' ? '1.3' : undefined,
+      profile: 'Point' as const,
+      resources: ['rest', 'slpk'] as Array<'rest' | 'slpk' | 'gzip'>,
+      capabilities: {
+        geometry: version === '1.6' ? 'unsupported' : 'supported',
+        attributes: version === '1.6' ? 'unsupported' : 'supported',
+        rendererMetadata: version === '1.6' ? 'unsupported' : 'partial'
+      } as Record<string, I3SFeatureSupportStatus>,
+      since: '5.0'
+    },
+    {
+      version,
+      ogcVersion: version === '1.7' ? '1.3' : undefined,
+      profile: 'Building' as const,
+      resources: ['rest', 'slpk'] as Array<'rest' | 'slpk' | 'gzip'>,
+      capabilities: {
+        sublayers: version === '1.6' ? 'unsupported' : 'supported',
+        filters: version === '1.6' ? 'unsupported' : 'partial'
+      } as Record<string, I3SFeatureSupportStatus>,
+      since: '5.0'
+    }
+  ]),
+  {
+    version: '2.0',
+    ogcVersion: '1.3',
+    profile: 'PointCloud',
+    resources: ['rest', 'slpk', 'gzip'] as Array<'rest' | 'slpk' | 'gzip'>,
+    capabilities: {geometry: 'supported', attributes: 'partial', lepcc: 'supported'},
+    since: '5.0'
+  },
+  {
+    version: '2.1',
+    ogcVersion: '1.3',
+    profile: 'PointCloud',
+    resources: ['rest', 'slpk', 'gzip'] as Array<'rest' | 'slpk' | 'gzip'>,
+    capabilities: {geometry: 'supported', attributes: 'partial', lepcc: 'supported'},
+    since: '5.0'
+  }
+] as I3SConformanceProfile[];

--- a/modules/i3s/src/i3s-service.ts
+++ b/modules/i3s/src/i3s-service.ts
@@ -12,7 +12,7 @@ import {
   I3SPointSceneLayerSchema,
   I3SSceneLayerSchema
 } from './i3s-zod-schema';
-import type {SceneLayer3D, SpatialReference, FullExtent} from './types';
+import type {SceneLayer3D, SpatialReference, FullExtent, PopupInfo, I3SRenderer} from './types';
 
 /** A source created from an I3S SceneServer layer. */
 export type I3SLayerSource = I3SSource | I3SPointCloudSource;
@@ -39,8 +39,92 @@ export type I3SServiceMetadata = {
   name?: string;
   /** Human-readable layer description. */
   description?: string;
+  /** Normalized renderer and popup metadata for downstream renderers. */
+  rendererMetadata?: I3SRendererMetadata;
+  /** Normalized popup metadata for downstream renderers. */
+  popupMetadata?: PopupInfo;
+  /** Non-fatal metadata diagnostics. */
+  diagnostics: I3SSupportDiagnostic[];
+  /** Profile-aware feature support report. */
+  supportReport: I3SFeatureSupportReport;
   /** Parsed layer document retained for source construction and advanced consumers. */
   layer: SceneLayer3D;
+};
+
+/** Status assigned to one capability in a conformance report. */
+export type I3SFeatureSupportStatus = 'supported' | 'partial' | 'unsupported';
+
+/** Diagnostic explaining a partial, unsupported, or malformed feature. */
+export type I3SSupportDiagnostic = {
+  /** Stable diagnostic code. */
+  code: 'profile-unsupported' | 'feature-unsupported' | 'metadata-preserved' | 'invalid';
+  /** Human-readable explanation. */
+  message: string;
+  /** Optional metadata path. */
+  path?: string;
+};
+
+/** Metadata-only renderer representation. Expressions are never evaluated by the loader. */
+export type I3SRendererMetadata = {
+  /** Renderer discriminator. */
+  type: string;
+  /** Renderer field, when supplied. */
+  field?: string;
+  /** Classification or unique-value definitions. */
+  classes?: unknown[];
+  /** Visual variables retained for downstream evaluation. */
+  visualVariables?: unknown[];
+  /** Label classes retained for downstream evaluation. */
+  labelClasses?: unknown[];
+  /** Original renderer document. */
+  raw: I3SRenderer;
+  /** Properties not normalized by loaders.gl. */
+  unsupportedProperties: string[];
+};
+
+/** Produces a profile-aware capability report for a parsed I3S layer. */
+export function getI3SFeatureSupportReport(layer: SceneLayer3D): I3SFeatureSupportReport {
+  const features: Record<string, I3SFeatureSupportStatus> = {
+    geometry: 'supported',
+    attributes: 'supported',
+    rendererMetadata: layer.drawingInfo ? 'partial' : 'unsupported',
+    popupMetadata: layer.popupInfo ? 'partial' : 'unsupported',
+    crsMetadata: layer.spatialReference ? 'supported' : 'partial',
+    elevationMetadata: layer.elevationInfo ? 'partial' : 'unsupported'
+  };
+  const diagnostics: I3SSupportDiagnostic[] = [];
+  if (layer.drawingInfo) {
+    diagnostics.push({
+      code: 'metadata-preserved',
+      message: 'Renderer metadata is preserved but not evaluated by the loader.',
+      path: 'drawingInfo'
+    });
+  }
+  if (layer.popupInfo) {
+    diagnostics.push({
+      code: 'metadata-preserved',
+      message: 'Popup expressions and media are preserved but not evaluated by the loader.',
+      path: 'popupInfo'
+    });
+  }
+  return {
+    version: layer.version,
+    profile: layer.store.profile,
+    features,
+    diagnostics
+  };
+}
+
+/** Feature support report for one version/profile combination. */
+export type I3SFeatureSupportReport = {
+  /** I3S document version. */
+  version: string;
+  /** Physical I3S profile. */
+  profile: string;
+  /** Feature status keyed by capability name. */
+  features: Record<string, I3SFeatureSupportStatus>;
+  /** Diagnostics explaining partial and unsupported features. */
+  diagnostics: I3SSupportDiagnostic[];
 };
 
 /** Error raised when a SceneServer layer profile is not supported by loaders.gl. */
@@ -73,6 +157,16 @@ export function parseI3SSceneLayerMetadata(document: unknown): SceneLayer3D {
 
 /** Normalizes a parsed I3S layer into service metadata. */
 export function normalizeI3SServiceMetadata(url: string, layer: SceneLayer3D): I3SServiceMetadata {
+  const rendererMetadata = normalizeI3SRendererMetadata(layer);
+  const diagnostics = rendererMetadata?.unsupportedProperties.length
+    ? [
+        {
+          code: 'metadata-preserved' as const,
+          message: 'Renderer properties were preserved for downstream evaluation.',
+          path: 'drawingInfo.renderer'
+        }
+      ]
+    : [];
   return {
     url,
     layerType: layer.layerType,
@@ -84,8 +178,44 @@ export function normalizeI3SServiceMetadata(url: string, layer: SceneLayer3D): I
     fullExtent: layer.fullExtent,
     name: layer.name,
     description: layer.description,
+    rendererMetadata,
+    popupMetadata: layer.popupInfo,
+    diagnostics,
+    supportReport: getI3SFeatureSupportReport(layer),
     layer
   };
+}
+
+/** Normalizes common renderer metadata without evaluating expressions. */
+export function normalizeI3SRendererMetadata(layer: SceneLayer3D): I3SRendererMetadata | undefined {
+  const renderer = layer.drawingInfo?.renderer;
+  if (!renderer) return undefined;
+  const normalized: I3SRendererMetadata = {
+    type: renderer.type,
+    field: typeof renderer.field === 'string' ? renderer.field : undefined,
+    classes: Array.isArray(renderer.classBreakInfos)
+      ? renderer.classBreakInfos
+      : Array.isArray(renderer.uniqueValueInfos)
+        ? renderer.uniqueValueInfos
+        : undefined,
+    visualVariables: Array.isArray(renderer.visualVariables) ? renderer.visualVariables : undefined,
+    labelClasses: Array.isArray(renderer.labelClasses) ? renderer.labelClasses : undefined,
+    raw: renderer,
+    unsupportedProperties: []
+  };
+  const knownProperties = new Set([
+    'type',
+    'field',
+    'classBreakInfos',
+    'uniqueValueInfos',
+    'visualVariables',
+    'labelClasses',
+    'symbol',
+    'defaultSymbol',
+    'defaultLabel'
+  ]);
+  normalized.unsupportedProperties = Object.keys(renderer).filter(key => !knownProperties.has(key));
+  return normalized;
 }
 
 /** Creates the profile-specific source used to traverse an I3S layer. */

--- a/modules/i3s/src/i3s-service.ts
+++ b/modules/i3s/src/i3s-service.ts
@@ -84,9 +84,11 @@ export type I3SRendererMetadata = {
 
 /** Produces a profile-aware capability report for a parsed I3S layer. */
 export function getI3SFeatureSupportReport(layer: SceneLayer3D): I3SFeatureSupportReport {
+  const profile = layer.store.profile.toLowerCase();
+  const isPointCloud = layer.layerType === 'PointCloud' || profile.includes('pointcloud');
   const features: Record<string, I3SFeatureSupportStatus> = {
     geometry: 'supported',
-    attributes: 'supported',
+    attributes: isPointCloud ? 'partial' : 'supported',
     rendererMetadata: layer.drawingInfo ? 'partial' : 'unsupported',
     popupMetadata: layer.popupInfo ? 'partial' : 'unsupported',
     crsMetadata: layer.spatialReference ? 'supported' : 'partial',

--- a/modules/i3s/src/index.ts
+++ b/modules/i3s/src/index.ts
@@ -51,6 +51,8 @@ export type {
   Store
 } from './types';
 export type {I3SLoaderOptions} from './i3s-loader';
+export {I3S_CONFORMANCE_PROFILES} from './i3s-conformance';
+export type {I3SConformanceProfile} from './i3s-conformance';
 export {
   I3SPointCloudNodePageSchema,
   I3SPointCloudNodeSchema,
@@ -99,6 +101,15 @@ export {
   createI3SLayerSource,
   I3SUnsupportedProfileError,
   normalizeI3SServiceMetadata,
+  normalizeI3SRendererMetadata,
+  getI3SFeatureSupportReport,
   parseI3SSceneLayerMetadata
 } from './i3s-service';
-export type {I3SLayerSource, I3SServiceMetadata} from './i3s-service';
+export type {
+  I3SLayerSource,
+  I3SServiceMetadata,
+  I3SFeatureSupportStatus,
+  I3SSupportDiagnostic,
+  I3SRendererMetadata,
+  I3SFeatureSupportReport
+} from './i3s-service';

--- a/modules/i3s/src/unbundled.ts
+++ b/modules/i3s/src/unbundled.ts
@@ -3,6 +3,8 @@
 // Copyright vis.gl contributors
 
 export type {I3SLoaderOptions} from './i3s-loader';
+export {I3S_CONFORMANCE_PROFILES} from './i3s-conformance';
+export type {I3SConformanceProfile} from './i3s-conformance';
 export {
   I3SPointCloudNodePageSchema,
   I3SPointCloudNodeSchema,
@@ -30,7 +32,16 @@ export {
   createI3SLayerSource,
   I3SUnsupportedProfileError,
   normalizeI3SServiceMetadata,
+  normalizeI3SRendererMetadata,
+  getI3SFeatureSupportReport,
   parseI3SSceneLayerMetadata
 } from './i3s-service';
-export type {I3SLayerSource, I3SServiceMetadata} from './i3s-service';
+export type {
+  I3SLayerSource,
+  I3SServiceMetadata,
+  I3SFeatureSupportStatus,
+  I3SSupportDiagnostic,
+  I3SRendererMetadata,
+  I3SFeatureSupportReport
+} from './i3s-service';
 export type {I3SPointCloudSourceOptions} from './i3s-point-cloud-source';

--- a/modules/i3s/test/i3s-conformance.spec.ts
+++ b/modules/i3s/test/i3s-conformance.spec.ts
@@ -6,7 +6,11 @@ import {fetchFile, parse} from '@loaders.gl/core';
 import {
   getI3SFeatureSupportReport,
   I3S_CONFORMANCE_PROFILES,
-  I3SNodePageLoader
+  I3SNodePageLoader,
+  I3SUnsupportedProfileError,
+  normalizeI3SRendererMetadata,
+  normalizeI3SServiceMetadata,
+  parseI3SSceneLayerMetadata
 } from '@loaders.gl/i3s';
 import {
   I3SPointCloudSceneLayerSchema,
@@ -165,6 +169,38 @@ describe('I3S conformance fixtures', () => {
     expect(report.features.rendererMetadata).toBe('partial');
     expect(report.features.popupMetadata).toBe('partial');
     expect(report.diagnostics).toHaveLength(2);
+  });
+
+  it('normalizes renderer extensions while preserving the original layer', async () => {
+    const response = await fetchFile('@loaders.gl/i3s/test/data/conformance/i3s-1.8-point.json');
+    const document = await response.json();
+    const sceneLayer = parseI3SSceneLayerMetadata({
+      ...document,
+      drawingInfo: {
+        renderer: {
+          type: 'uniqueValue',
+          field: 'category',
+          uniqueValueInfos: [{value: 'a'}],
+          visualVariables: [],
+          labelClasses: [],
+          producerExtension: true
+        }
+      }
+    });
+    const renderer = normalizeI3SRendererMetadata(sceneLayer);
+    expect(renderer?.classes).toEqual([{value: 'a'}]);
+    expect(renderer?.unsupportedProperties).toEqual(['producerExtension']);
+    expect(normalizeI3SRendererMetadata({...sceneLayer, drawingInfo: undefined})).toBeUndefined();
+    expect(
+      normalizeI3SServiceMetadata('https://example.com/layer', sceneLayer).diagnostics
+    ).toHaveLength(1);
+  });
+
+  it('constructs typed unsupported profile errors', () => {
+    const error = new I3SUnsupportedProfileError('custom-profile');
+    expect(error.name).toBe('I3SUnsupportedProfileError');
+    expect(error.profile).toBe('custom-profile');
+    expect(error.message).toContain('custom-profile');
   });
 
   it('preserves UInt64 values through Number.MAX_SAFE_INTEGER', () => {

--- a/modules/i3s/test/i3s-conformance.spec.ts
+++ b/modules/i3s/test/i3s-conformance.spec.ts
@@ -169,6 +169,28 @@ describe('I3S conformance fixtures', () => {
     expect(report.features.rendererMetadata).toBe('partial');
     expect(report.features.popupMetadata).toBe('partial');
     expect(report.diagnostics).toHaveLength(2);
+
+    const pointCloudResponse = await fetchFile(
+      '@loaders.gl/i3s/test/data/conformance/i3s-2.1-point-cloud.json'
+    );
+    const pointCloudLayer = I3SPointCloudSceneLayerSchema.parse(await pointCloudResponse.json());
+    expect(getI3SFeatureSupportReport(pointCloudLayer).features.attributes).toBe('partial');
+  });
+
+  it('does not claim delivery forms without representative fixtures', () => {
+    expect(
+      I3S_CONFORMANCE_PROFILES.find(entry => entry.profile === 'Point' && entry.version === '1.8')
+        ?.resources
+    ).toEqual(['rest']);
+    expect(
+      I3S_CONFORMANCE_PROFILES.find(entry => entry.profile === 'Point' && entry.version === '1.7')
+        ?.resources
+    ).toEqual([]);
+    expect(
+      I3S_CONFORMANCE_PROFILES.find(
+        entry => entry.profile === 'PointCloud' && entry.version === '2.1'
+      )?.resources
+    ).toEqual(['rest']);
   });
 
   it('normalizes renderer extensions while preserving the original layer', async () => {

--- a/modules/i3s/test/i3s-conformance.spec.ts
+++ b/modules/i3s/test/i3s-conformance.spec.ts
@@ -3,7 +3,11 @@
 // Copyright (c) vis.gl contributors
 
 import {fetchFile, parse} from '@loaders.gl/core';
-import {I3SNodePageLoader} from '@loaders.gl/i3s';
+import {
+  getI3SFeatureSupportReport,
+  I3S_CONFORMANCE_PROFILES,
+  I3SNodePageLoader
+} from '@loaders.gl/i3s';
 import {
   I3SPointCloudSceneLayerSchema,
   I3SPointSceneLayerSchema,
@@ -58,6 +62,16 @@ const SCENE_LAYER_FIXTURES = [
 ] as const;
 
 describe('I3S conformance fixtures', () => {
+  it('publishes an explicit Esri and OGC profile matrix', () => {
+    expect(I3S_CONFORMANCE_PROFILES.some(entry => entry.version === '1.6')).toBe(true);
+    expect(I3S_CONFORMANCE_PROFILES.some(entry => entry.version === '1.10')).toBe(true);
+    expect(
+      I3S_CONFORMANCE_PROFILES.find(
+        entry => entry.version === '2.1' && entry.profile === 'PointCloud'
+      )?.ogcVersion
+    ).toBe('1.3');
+  });
+
   it.each(SCENE_LAYER_FIXTURES)('accepts $name scene-layer metadata', async fixture => {
     const response = await fetchFile(fixture.url);
     const document = await response.json();
@@ -129,6 +143,28 @@ describe('I3S conformance fixtures', () => {
         }
       })
     ).toThrow(/profile/);
+  });
+
+  it('reports partial renderer and popup semantics without evaluating expressions', async () => {
+    const response = await fetchFile('@loaders.gl/i3s/test/data/conformance/i3s-1.8-point.json');
+    const document = await response.json();
+    const sceneLayer = I3SPointSceneLayerSchema.parse({
+      ...document,
+      drawingInfo: {
+        renderer: {
+          type: 'classBreaks',
+          field: 'height',
+          classBreakInfos: [],
+          visualVariables: [{type: 'sizeInfo', valueExpression: '$feature.height'}],
+          producerExtension: true
+        }
+      },
+      popupInfo: {expressionInfos: [{name: 'label', expression: '$feature.name'}]}
+    });
+    const report = getI3SFeatureSupportReport(sceneLayer);
+    expect(report.features.rendererMetadata).toBe('partial');
+    expect(report.features.popupMetadata).toBe('partial');
+    expect(report.diagnostics).toHaveLength(2);
   });
 
   it('preserves UInt64 values through Number.MAX_SAFE_INTEGER', () => {

--- a/modules/loader-utils/src/lib/sources/service-capabilities.ts
+++ b/modules/loader-utils/src/lib/sources/service-capabilities.ts
@@ -12,6 +12,7 @@ export type GeoServiceType =
   | 'arcgis-vector-tile-server'
   | 'arcgis-image-server'
   | 'arcgis-feature-server'
+  | 'arcgis-scene-server'
   | 'unknown';
 
 /** A normalized description of a discoverable geospatial service. */
@@ -31,7 +32,17 @@ export type ServiceCapabilities = {
   /** Advertised response formats. */
   formats: string[];
   /** Named layers or feature types. */
-  layers: Array<{name: string; title?: string; crs?: string[]; bounds?: number[]}>;
+  layers: Array<{
+    name: string;
+    title?: string;
+    crs?: string[];
+    bounds?: number[];
+    id?: string;
+    url?: string;
+    profile?: string;
+    layerType?: string;
+    version?: string;
+  }>;
   /** Supported request names, when advertised. */
   operations: string[];
   /** Original protocol-specific capability document. */

--- a/modules/services/src/arcgis/arcgis-capability-graph.ts
+++ b/modules/services/src/arcgis/arcgis-capability-graph.ts
@@ -11,7 +11,7 @@ export type ArcGISServiceCapabilities = ArcGISService & {
   /** Stable identifier for the discovered service. */
   id: string;
   /** Broad service family used for selection. */
-  kind: 'vector' | 'image' | 'tile' | 'unknown';
+  kind: 'vector' | 'image' | 'tile' | 'scene' | 'unknown';
   /** Shared normalized service capability contract. */
   capabilities: ServiceCapabilities;
   /** Raw service metadata for provider-specific consumers. */
@@ -34,6 +34,10 @@ export type ArcGISServiceSelection = {
   format?: string;
   /** Preferred coordinate system. */
   crs?: string;
+  /** Required I3S layer profile for SceneServer nodes. */
+  profile?: string;
+  /** Required layer identifier for SceneServer nodes. */
+  layerId?: string | number;
 };
 
 /** Options controlling ArcGIS capability discovery. */
@@ -79,6 +83,20 @@ export function selectArcGISService(
     )
       return false;
     if (requirements.crs && !node.capabilities.crs.includes(requirements.crs)) return false;
+    if (
+      requirements.profile &&
+      node.metadata.profile !== requirements.profile &&
+      !node.capabilities.layers.some(layer => layer.profile === requirements.profile)
+    )
+      return false;
+    if (
+      requirements.layerId !== undefined &&
+      !node.capabilities.layers.some(
+        layer =>
+          layer.id === String(requirements.layerId) || layer.name === String(requirements.layerId)
+      )
+    )
+      return false;
     return true;
   });
 }
@@ -106,6 +124,14 @@ function normalizeServiceCapabilities(
   const kind = getServiceKind(serviceType);
   const formats = getServiceFormats(metadata);
   const crs = getServiceCrs(metadata);
+  const layers = getServiceLayers(metadata).map(layer => ({
+    ...layer,
+    url:
+      layer.url ||
+      (serviceType.includes('scene') && layer.id
+        ? `${service.url.replace(/\/$/, '')}/layers/${encodeURIComponent(layer.id)}`
+        : undefined)
+  }));
   const capabilities: ServiceCapabilities = {
     url: service.url,
     type: getServiceCapabilityType(serviceType),
@@ -114,8 +140,8 @@ function normalizeServiceCapabilities(
     abstract: typeof metadata.description === 'string' ? metadata.description : undefined,
     crs,
     formats,
-    layers: [],
-    operations: [],
+    layers,
+    operations: getServiceOperations(metadata),
     formatSpecificMetadata: metadata
   };
   return {
@@ -127,6 +153,50 @@ function normalizeServiceCapabilities(
   };
 }
 
+/** Extracts normalized layer entries from SceneServer and other service metadata. */
+function getServiceLayers(metadata: Record<string, unknown>): ServiceCapabilities['layers'] {
+  const layerValues = Array.isArray(metadata.layers) ? metadata.layers : [];
+  return layerValues.flatMap(value => {
+    if (!value || typeof value !== 'object') return [];
+    const layer = value as Record<string, unknown>;
+    const spatialReference = layer.spatialReference as
+      | {wkid?: number; latestWkid?: number}
+      | undefined;
+    const wkid = spatialReference?.latestWkid || spatialReference?.wkid;
+    const extent = layer.extent as
+      | {xmin?: number; ymin?: number; xmax?: number; ymax?: number}
+      | undefined;
+    const bounds =
+      extent && [extent.xmin, extent.ymin, extent.xmax, extent.ymax].every(Number.isFinite)
+        ? [extent.xmin!, extent.ymin!, extent.xmax!, extent.ymax!]
+        : undefined;
+    return [
+      {
+        name: layer.id === undefined ? String(layer.name || '') : String(layer.id),
+        id: layer.id === undefined ? undefined : String(layer.id),
+        url: typeof layer.url === 'string' ? layer.url : undefined,
+        title: typeof layer.name === 'string' ? layer.name : undefined,
+        crs: wkid ? [`EPSG:${wkid}`] : undefined,
+        bounds,
+        profile: typeof layer.profile === 'string' ? layer.profile : undefined,
+        layerType: typeof layer.layerType === 'string' ? layer.layerType : undefined,
+        version: typeof layer.version === 'string' ? layer.version : undefined
+      }
+    ];
+  });
+}
+
+/** Extracts operation names when a service advertises them. */
+function getServiceOperations(metadata: Record<string, unknown>): string[] {
+  const capabilities = metadata.capabilities;
+  return typeof capabilities === 'string'
+    ? capabilities
+        .split(',')
+        .map(value => value.trim())
+        .filter(Boolean)
+    : [];
+}
+
 /** Maps a discovered ArcGIS family to the shared service capability type. */
 function getServiceCapabilityType(serviceType: string): ServiceCapabilities['type'] {
   if (serviceType.includes('vectortile') || serviceType.includes('vector-tile')) {
@@ -134,6 +204,7 @@ function getServiceCapabilityType(serviceType: string): ServiceCapabilities['typ
   }
   if (serviceType.includes('feature')) return 'arcgis-feature-server';
   if (serviceType.includes('image')) return 'arcgis-image-server';
+  if (serviceType.includes('scene')) return 'arcgis-scene-server';
   if (serviceType.includes('map')) return 'arcgis-map-server';
   return 'unknown';
 }
@@ -142,6 +213,7 @@ function getServiceCapabilityType(serviceType: string): ServiceCapabilities['typ
 function getServiceKind(serviceType: string): ArcGISServiceCapabilities['kind'] {
   if (serviceType.includes('feature')) return 'vector';
   if (serviceType.includes('image')) return 'image';
+  if (serviceType.includes('scene')) return 'scene';
   if (
     serviceType.includes('map') ||
     serviceType.includes('vectortile') ||

--- a/modules/services/src/arcgis/arcgis-capability-graph.ts
+++ b/modules/services/src/arcgis/arcgis-capability-graph.ts
@@ -62,7 +62,10 @@ export async function discoverArcGISCapabilities(
 
   const nodes = await Promise.all(
     services.map(async service => {
-      const metadata = await fetchServiceMetadata(service.url, fetchFile);
+      let metadata = await fetchServiceMetadata(service.url, fetchFile);
+      if (service.type.toLowerCase().includes('scene')) {
+        metadata = await enrichSceneServerMetadata(service.url, metadata, fetchFile);
+      }
       return normalizeServiceCapabilities(service, metadata);
     })
   );
@@ -113,6 +116,32 @@ async function fetchServiceMetadata(
     throw new Error(`ArcGIS service metadata request failed: ${response.status}`);
   }
   return (await response.json()) as Record<string, unknown>;
+}
+
+/** Fetches layer documents so SceneServer profile selection uses authoritative store metadata. */
+async function enrichSceneServerMetadata(
+  serviceUrl: string,
+  metadata: Record<string, unknown>,
+  fetchFile: typeof fetch
+): Promise<Record<string, unknown>> {
+  const layers = Array.isArray(metadata.layers) ? metadata.layers : [];
+  if (!layers.length) return metadata;
+  const enrichedLayers = await Promise.all(
+    layers.map(async value => {
+      if (!value || typeof value !== 'object') return value;
+      const layer = value as Record<string, unknown>;
+      if (layer.id === undefined) return value;
+      const layerURL = `${serviceUrl.replace(/\/$/, '')}/layers/${encodeURIComponent(String(layer.id))}`;
+      try {
+        const layerMetadata = await fetchServiceMetadata(layerURL, fetchFile);
+        return {...layer, ...layerMetadata, id: layer.id, name: layer.name ?? layerMetadata.name};
+      } catch {
+        // Keep directory metadata when an individual layer is unavailable.
+        return value;
+      }
+    })
+  );
+  return {...metadata, layers: enrichedLayers};
 }
 
 /** Combines directory information and metadata into a normalized capability node. */
@@ -178,9 +207,23 @@ function getServiceLayers(metadata: Record<string, unknown>): ServiceCapabilitie
         title: typeof layer.name === 'string' ? layer.name : undefined,
         crs: wkid ? [`EPSG:${wkid}`] : undefined,
         bounds,
-        profile: typeof layer.profile === 'string' ? layer.profile : undefined,
+        profile:
+          typeof layer.profile === 'string'
+            ? layer.profile
+            : layer.store &&
+                typeof layer.store === 'object' &&
+                typeof (layer.store as Record<string, unknown>).profile === 'string'
+              ? ((layer.store as Record<string, unknown>).profile as string)
+              : undefined,
         layerType: typeof layer.layerType === 'string' ? layer.layerType : undefined,
-        version: typeof layer.version === 'string' ? layer.version : undefined
+        version:
+          typeof layer.version === 'string'
+            ? layer.version
+            : layer.store &&
+                typeof layer.store === 'object' &&
+                typeof (layer.store as Record<string, unknown>).version === 'string'
+              ? ((layer.store as Record<string, unknown>).version as string)
+              : undefined
       }
     ];
   });

--- a/modules/services/src/arcgis/arcgis-scene-aggregation.ts
+++ b/modules/services/src/arcgis/arcgis-scene-aggregation.ts
@@ -62,6 +62,7 @@ function aggregateValues(features: unknown[], specification: ArcGISSceneAggregat
   if (specification.operation === 'count') return features.length;
   const values = features
     .map(feature => getFeatureAttributes(feature)[specification.field || ''])
+    .filter(value => value !== null && value !== undefined && value !== '')
     .map(value => (typeof value === 'number' ? value : Number(value)))
     .filter(Number.isFinite);
   if (!values.length) return 0;

--- a/modules/services/src/arcgis/arcgis-scene-aggregation.ts
+++ b/modules/services/src/arcgis/arcgis-scene-aggregation.ts
@@ -1,0 +1,89 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+/** Aggregation operation supported by the SceneServer client helper. */
+export type ArcGISSceneAggregationOperation = 'count' | 'sum' | 'min' | 'max' | 'average';
+
+/** A single aggregation specification. */
+export type ArcGISSceneAggregationSpec = {
+  /** Output field name. */
+  name: string;
+  /** Input property used by numeric operations. */
+  field?: string;
+  /** Operation to apply. */
+  operation: ArcGISSceneAggregationOperation;
+};
+
+/** Options for deterministic client-side feature aggregation. */
+export type ArcGISSceneAggregationOptions = {
+  /** Features represented as ArcGIS feature objects or plain attribute records. */
+  features: unknown[];
+  /** Optional property used to create groups. */
+  groupBy?: string;
+  /** Aggregations to compute for each group. */
+  aggregations: ArcGISSceneAggregationSpec[];
+};
+
+/** Result of one group in a client-side aggregation. */
+export type ArcGISSceneAggregationGroup = {
+  /** Group key, or `undefined` when no grouping was requested. */
+  group: unknown;
+  /** Aggregated values keyed by specification name. */
+  values: Record<string, number>;
+};
+
+/**
+ * Aggregates SceneServer features without evaluating renderer or Arcade expressions.
+ * Missing and non-numeric values are ignored by numeric operations; `count` counts
+ * records regardless of field presence.
+ */
+export function aggregateArcGISSceneFeatures(
+  options: ArcGISSceneAggregationOptions
+): ArcGISSceneAggregationGroup[] {
+  const groups = new Map<unknown, unknown[]>();
+  for (const feature of options.features) {
+    const attributes = getFeatureAttributes(feature);
+    const key = options.groupBy ? attributes[options.groupBy] : undefined;
+    const group = groups.get(key);
+    if (group) group.push(feature);
+    else groups.set(key, [feature]);
+  }
+
+  return [...groups.entries()].map(([group, features]) => ({
+    group,
+    values: Object.fromEntries(
+      options.aggregations.map(spec => [spec.name, aggregateValues(features, spec)])
+    )
+  }));
+}
+
+function aggregateValues(features: unknown[], specification: ArcGISSceneAggregationSpec): number {
+  if (specification.operation === 'count') return features.length;
+  const values = features
+    .map(feature => getFeatureAttributes(feature)[specification.field || ''])
+    .map(value => (typeof value === 'number' ? value : Number(value)))
+    .filter(Number.isFinite);
+  if (!values.length) return 0;
+  switch (specification.operation) {
+    case 'sum':
+      return values.reduce((sum, value) => sum + value, 0);
+    case 'min':
+      return Math.min(...values);
+    case 'max':
+      return Math.max(...values);
+    case 'average':
+      return values.reduce((sum, value) => sum + value, 0) / values.length;
+    default:
+      return 0;
+  }
+}
+
+function getFeatureAttributes(feature: unknown): Record<string, unknown> {
+  if (!feature || typeof feature !== 'object') return {};
+  const candidate = feature as {attributes?: unknown};
+  if (candidate.attributes && typeof candidate.attributes === 'object') {
+    return candidate.attributes as Record<string, unknown>;
+  }
+  return feature as Record<string, unknown>;
+}

--- a/modules/services/src/arcgis/arcgis-scene-server-source-loader.ts
+++ b/modules/services/src/arcgis/arcgis-scene-server-source-loader.ts
@@ -10,6 +10,64 @@ import {
   parseI3SSceneLayerMetadata
 } from '@loaders.gl/i3s';
 import type {I3SLayerSource, I3SServiceMetadata, SceneLayer3D} from '@loaders.gl/i3s';
+import {buildArcGISResourceURL} from './arcgis-url-utils';
+
+/** Parameters accepted by the ArcGIS SceneServer query endpoint. */
+export type ArcGISSceneQueryOptions = {
+  /** SQL where clause. */
+  where?: string;
+  /** Object IDs to include. */
+  objectIds?: number[] | string;
+  /** Geometry filter encoded using ArcGIS REST geometry syntax. */
+  geometry?: unknown;
+  /** Geometry type for the geometry filter. */
+  geometryType?: string;
+  /** Spatial relationship for the geometry filter. */
+  spatialRel?: string;
+  /** Fields to return. */
+  outFields?: string | string[];
+  /** Whether feature geometry should be included. */
+  returnGeometry?: boolean;
+  /** Input spatial reference. */
+  inSR?: string | number | object;
+  /** Output spatial reference. */
+  outSR?: string | number | object;
+  /** ArcGIS result type. */
+  resultType?: string;
+  /** Result page offset. */
+  resultOffset?: number;
+  /** Maximum records in one page. */
+  resultRecordCount?: number;
+  /** Response format. */
+  f?: 'json' | 'pjson';
+  /** Abort signal for the request. */
+  signal?: AbortSignal;
+};
+
+/** Normalized result returned by a SceneServer query. */
+export type ArcGISSceneQueryResult = {
+  /** Returned SceneServer features. */
+  features: unknown[];
+  /** Field metadata advertised by the layer. */
+  fields?: unknown[];
+  /** Whether another page is available. */
+  exceededTransferLimit?: boolean;
+  /** Original response metadata for advanced consumers. */
+  rawMetadata?: unknown;
+};
+
+/** Error raised when a SceneServer query cannot be completed or decoded. */
+export class ArcGISSceneServerQueryError extends Error {
+  /** HTTP status code, when the failure came from a response. */
+  readonly status?: number;
+
+  /** Creates a typed SceneServer query error. */
+  constructor(message: string, status?: number) {
+    super(message);
+    this.name = 'ArcGISSceneServerQueryError';
+    this.status = status;
+  }
+}
 
 /** Options for an ArcGIS SceneServer source. */
 export type ArcGISSceneServerSourceOptions = DataSourceOptions & {
@@ -45,6 +103,46 @@ export class ArcGISSceneServerSource extends DataSource<string, ArcGISSceneServe
   async getTilesetSource(): Promise<I3SLayerSource> {
     this.sourcePromise ||= this.createTilesetSource();
     return await this.sourcePromise;
+  }
+
+  /** Queries feature attributes and geometry from a SceneServer layer. */
+  async query(options: ArcGISSceneQueryOptions = {}): Promise<ArcGISSceneQueryResult> {
+    const {signal, f = 'json', ...queryParameters} = options;
+    const queryURL = buildArcGISResourceURL(this.getLayerURL(), 'query', {
+      where: '1=1',
+      outFields: '*',
+      returnGeometry: true,
+      f,
+      ...queryParameters,
+      token: this.getToken()
+    });
+    const response = await this.fetch(queryURL, signal ? {signal} : undefined);
+    if (!response.ok) {
+      throw new ArcGISSceneServerQueryError(
+        `ArcGIS SceneServer query failed: ${response.status} ${response.statusText}`,
+        response.status
+      );
+    }
+    const document = (await response.json()) as Record<string, unknown>;
+    if (document.error) {
+      throw new ArcGISSceneServerQueryError(
+        `ArcGIS SceneServer query returned an error: ${JSON.stringify(document.error)}`
+      );
+    }
+    return {
+      features: Array.isArray(document.features) ? document.features : [],
+      fields: Array.isArray(document.fields) ? document.fields : undefined,
+      exceededTransferLimit:
+        typeof document.exceededTransferLimit === 'boolean'
+          ? document.exceededTransferLimit
+          : undefined,
+      rawMetadata: document
+    };
+  }
+
+  /** Alias for query used by applications that consume generic feature sources. */
+  async getFeatures(options: ArcGISSceneQueryOptions = {}): Promise<ArcGISSceneQueryResult> {
+    return await this.query(options);
   }
 
   /** Returns the layer URL, resolving an explicit layer ID when needed. */

--- a/modules/services/src/index.ts
+++ b/modules/services/src/index.ts
@@ -65,9 +65,21 @@ export type {
 /** ArcGIS SceneServer I3S source and loader. */
 export {
   ArcGISSceneServerSourceLoader,
-  ArcGISSceneServerSource
+  ArcGISSceneServerSource,
+  ArcGISSceneServerQueryError
 } from './arcgis/arcgis-scene-server-source-loader';
-export type {ArcGISSceneServerSourceOptions} from './arcgis/arcgis-scene-server-source-loader';
+export {aggregateArcGISSceneFeatures} from './arcgis/arcgis-scene-aggregation';
+export type {
+  ArcGISSceneAggregationOperation,
+  ArcGISSceneAggregationSpec,
+  ArcGISSceneAggregationOptions,
+  ArcGISSceneAggregationGroup
+} from './arcgis/arcgis-scene-aggregation';
+export type {
+  ArcGISSceneServerSourceOptions,
+  ArcGISSceneQueryOptions,
+  ArcGISSceneQueryResult
+} from './arcgis/arcgis-scene-server-source-loader';
 
 export type {ServiceLoader} from './service-registry';
 export {SERVICE_LOADERS, getServiceLoader} from './service-registry';

--- a/modules/services/test/arcgis/arcgis-scene-server-source.spec.ts
+++ b/modules/services/test/arcgis/arcgis-scene-server-source.spec.ts
@@ -212,7 +212,7 @@ test('aggregateArcGISSceneFeatures groups and ignores non-numeric values', () =>
 
 test('aggregateArcGISSceneFeatures supports all numeric operations and plain records', () => {
   const result = aggregateArcGISSceneFeatures({
-    features: [{kind: 'a', value: 2}, {kind: 'a', value: 6}, null, {kind: 'b'}],
+    features: [{kind: 'a', value: 2}, {kind: 'a', value: 6}, {kind: 'a', value: null}, null],
     aggregations: [
       {name: 'count', operation: 'count'},
       {name: 'min', field: 'value', operation: 'min'},

--- a/modules/services/test/arcgis/arcgis-scene-server-source.spec.ts
+++ b/modules/services/test/arcgis/arcgis-scene-server-source.spec.ts
@@ -209,3 +209,33 @@ test('aggregateArcGISSceneFeatures groups and ignores non-numeric values', () =>
     {group: 'b', values: {count: 1, sum: 0, average: 0}}
   ]);
 });
+
+test('aggregateArcGISSceneFeatures supports all numeric operations and plain records', () => {
+  const result = aggregateArcGISSceneFeatures({
+    features: [{kind: 'a', value: 2}, {kind: 'a', value: 6}, null, {kind: 'b'}],
+    aggregations: [
+      {name: 'count', operation: 'count'},
+      {name: 'min', field: 'value', operation: 'min'},
+      {name: 'max', field: 'value', operation: 'max'},
+      {name: 'sum', field: 'value', operation: 'sum'}
+    ]
+  });
+  expect(result).toEqual([{group: undefined, values: {count: 4, min: 2, max: 6, sum: 8}}]);
+});
+
+test('ArcGISSceneServerSource reports query and URL errors with typed details', async () => {
+  const source = new ArcGISSceneServerSource(`${SCENE_SERVER_URL}/layers/0`);
+  source.fetch = async () => new Response('nope', {status: 503, statusText: 'Unavailable'});
+  await expect(source.query()).rejects.toMatchObject({
+    name: 'ArcGISSceneServerQueryError',
+    status: 503
+  });
+
+  source.fetch = async () => new Response(JSON.stringify({error: {code: 400, message: 'bad'}}));
+  await expect(source.getFeatures({f: 'pjson'})).rejects.toThrow('query returned an error');
+
+  expect(() =>
+    new ArcGISSceneServerSource('https://example.com/FeatureServer/0').getLayerURL()
+  ).toThrow(/requires a \/SceneServer/);
+  expect(() => new ArcGISSceneServerSource(SCENE_SERVER_URL).getLayerURL()).toThrow(/layerId/);
+});

--- a/modules/services/test/arcgis/arcgis-scene-server-source.spec.ts
+++ b/modules/services/test/arcgis/arcgis-scene-server-source.spec.ts
@@ -1,7 +1,11 @@
 import {fetchFile} from '@loaders.gl/core';
 import {I3SPointCloudSource} from '@loaders.gl/i3s';
 import {I3SSource} from '@loaders.gl/tiles';
-import {ArcGISSceneServerSource, ArcGISSceneServerSourceLoader} from '@loaders.gl/services';
+import {
+  ArcGISSceneServerSource,
+  ArcGISSceneServerSourceLoader,
+  aggregateArcGISSceneFeatures
+} from '@loaders.gl/services';
 import {expect, test, vi} from 'vitest';
 
 const SCENE_SERVER_URL = 'https://example.com/arcgis/rest/services/City/SceneServer';
@@ -153,4 +157,55 @@ test('ArcGISSceneServerSource normalizes a trailing slash before query parameter
 
   expect(source.getLayerURL()).toBe(`${SCENE_SERVER_URL}/layers/0`);
   expect(source.metadataURL()).toBe(`${SCENE_SERVER_URL}/layers/0?f=pjson&token=url-secret`);
+});
+
+test('ArcGISSceneServerSource queries features with authentication and cancellation', async () => {
+  const source = new ArcGISSceneServerSource(`${SCENE_SERVER_URL}/layers/0`, {
+    'arcgis-scene-server': {token: 'query-secret'}
+  });
+  let requestedURL = '';
+  let requestOptions: RequestInit | undefined;
+  source.fetch = async (url, options) => {
+    requestedURL = url;
+    requestOptions = options;
+    return new Response(
+      JSON.stringify({
+        features: [{attributes: {kind: 'building', height: 10}}],
+        exceededTransferLimit: false
+      })
+    );
+  };
+  const controller = new AbortController();
+  const result = await source.query({
+    where: "kind = 'building'",
+    outFields: ['kind', 'height'],
+    resultRecordCount: 1,
+    signal: controller.signal
+  });
+  const url = new URL(requestedURL);
+  expect(url.pathname).toBe('/arcgis/rest/services/City/SceneServer/layers/0/query');
+  expect(url.searchParams.get('token')).toBe('query-secret');
+  expect(url.searchParams.get('where')).toBe("kind = 'building'");
+  expect(result.features).toHaveLength(1);
+  expect(requestOptions?.signal).toBe(controller.signal);
+});
+
+test('aggregateArcGISSceneFeatures groups and ignores non-numeric values', () => {
+  const result = aggregateArcGISSceneFeatures({
+    features: [
+      {attributes: {kind: 'a', value: 2}},
+      {attributes: {kind: 'a', value: '3'}},
+      {attributes: {kind: 'b', value: 'invalid'}}
+    ],
+    groupBy: 'kind',
+    aggregations: [
+      {name: 'count', operation: 'count'},
+      {name: 'sum', field: 'value', operation: 'sum'},
+      {name: 'average', field: 'value', operation: 'average'}
+    ]
+  });
+  expect(result).toEqual([
+    {group: 'a', values: {count: 2, sum: 5, average: 2.5}},
+    {group: 'b', values: {count: 1, sum: 0, average: 0}}
+  ]);
 });

--- a/modules/services/test/services-module.spec.ts
+++ b/modules/services/test/services-module.spec.ts
@@ -114,17 +114,26 @@ describe('@loaders.gl/services', () => {
             JSON.stringify({services: [{name: 'City', type: 'SceneServer'}], folders: []})
           );
         }
+        if (requestURL.pathname.endsWith('/layers/0')) {
+          return new Response(
+            JSON.stringify({
+              id: 0,
+              name: 'Buildings',
+              layerType: '3DObject',
+              version: '1.8',
+              store: {profile: 'meshpyramids', version: '1.8'},
+              spatialReference: {wkid: 4326}
+            })
+          );
+        }
         return new Response(
           JSON.stringify({
             name: 'City',
-            version: '1.8',
-            profile: 'meshpyramids',
             layers: [
               {
                 id: 0,
                 name: 'Buildings',
-                layerType: '3DObject',
-                spatialReference: {wkid: 4326}
+                layerType: '3DObject'
               }
             ],
             spatialReference: {wkid: 4326}
@@ -146,8 +155,9 @@ describe('@loaders.gl/services', () => {
           }
         ]
       },
-      metadata: {profile: 'meshpyramids'}
+      metadata: {name: 'City'}
     });
+    expect(graph?.nodes[0].capabilities.layers[0].profile).toBe('meshpyramids');
     expect(selectArcGISService(graph!, {kind: 'scene', profile: 'meshpyramids'})).toBe(
       graph?.nodes[0]
     );

--- a/modules/services/test/services-module.spec.ts
+++ b/modules/services/test/services-module.spec.ts
@@ -105,6 +105,54 @@ describe('@loaders.gl/services', () => {
     expect(await getArcGISServices('https://example.com/not-an-arcgis-service')).toBeNull();
   });
 
+  test('normalizes SceneServer capability nodes and selects a requested profile', async () => {
+    const graph = await discoverArcGISCapabilities('https://example.com/arcgis/rest/services', {
+      fetch: async url => {
+        const requestURL = new URL(url);
+        if (requestURL.pathname.endsWith('/services')) {
+          return new Response(
+            JSON.stringify({services: [{name: 'City', type: 'SceneServer'}], folders: []})
+          );
+        }
+        return new Response(
+          JSON.stringify({
+            name: 'City',
+            version: '1.8',
+            profile: 'meshpyramids',
+            layers: [
+              {
+                id: 0,
+                name: 'Buildings',
+                layerType: '3DObject',
+                spatialReference: {wkid: 4326}
+              }
+            ],
+            spatialReference: {wkid: 4326}
+          })
+        );
+      }
+    });
+
+    expect(graph?.nodes[0]).toMatchObject({
+      kind: 'scene',
+      capabilities: {
+        type: 'arcgis-scene-server',
+        layers: [
+          {
+            name: '0',
+            title: 'Buildings',
+            crs: ['EPSG:4326'],
+            url: 'https://example.com/arcgis/rest/services/City/SceneServer/layers/0'
+          }
+        ]
+      },
+      metadata: {profile: 'meshpyramids'}
+    });
+    expect(selectArcGISService(graph!, {kind: 'scene', profile: 'meshpyramids'})).toBe(
+      graph?.nodes[0]
+    );
+  });
+
   test('resolves qualified service names from ArcGIS folder directories', async () => {
     const services = await getArcGISServices(
       'https://example.com/arcgis/rest/services',


### PR DESCRIPTION
## Goals

- Make I3S support claims explicit by profile and version.
- Improve SceneServer discovery, querying, and downstream metadata consumption.
- Document the current I3S/SceneServer boundaries and compatibility matrix.

## Changes

- Add the exported `I3S_CONFORMANCE_PROFILES` manifest and profile-aware support reports.
- Normalize renderer, visual-variable, label, and popup metadata while preserving raw definitions and unknown properties.
- Add `ArcGISSceneServerSource.query()` / `getFeatures()` with authentication, pagination parameters, cancellation, and typed errors.
- Add deterministic client-side SceneServer feature aggregation.
- Extend ArcGIS service capability discovery and selection for SceneServer layers and I3S profiles.
- Update I3S, SceneServer, and Building Scene Layer documentation.
- Add hermetic tests for conformance, metadata, queries, aggregation, and discovery.

## Validation

- `yarn test-node` (378 passed)
- Focused Chromium tests (44 passed)
- `yarn test-audit` (0 violations)
- `yarn lint fix`
- I3S/services module builds

## Follow-up

Point/Point Cloud authoring and LEPCC encoding, extracted-directory SLPK support, and the expanded CRS/producer-extension fixture matrix remain subsequent tranches.