### PR TITLE
fix(website): stabilize styled-components SSR classes

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -7,6 +7,24 @@ const {themes} = require('prism-react-renderer');
 const lightCodeTheme = themes.github;
 const darkCodeTheme = themes.dracula;
 
+/** Creates the existing SWC loader with deterministic styled-components IDs. */
+function createJavaScriptLoader(isServer) {
+  const {getSwcLoaderOptions, swcLoader} = require('@docusaurus/faster');
+  const options = getSwcLoaderOptions({isServer, bundlerName: 'rspack'});
+  options.jsc.experimental = {
+    plugins: [
+      [
+        require.resolve('@swc/plugin-styled-components'),
+        {
+          displayName: true,
+          ssr: true
+        }
+      ]
+    ]
+  };
+  return {loader: swcLoader, options};
+}
+
 /** @type {import('@docusaurus/types').Config} */
 const siteUrl = process.env.DOCUSAURUS_URL || 'https://loaders.gl';
 const baseUrl = process.env.DOCUSAURUS_BASE_URL || '/';
@@ -66,7 +84,15 @@ const config = {
   trailingSlash: false,
 
   future: {
-    v4: true
+    v4: true,
+    // Use a custom SWC loader below so styled-components receives stable SSR IDs.
+    faster: {
+      swcJsLoader: false
+    }
+  },
+
+  webpack: {
+    jsLoader: createJavaScriptLoader
   },
 
   markdown: {

--- a/website/package.json
+++ b/website/package.json
@@ -110,6 +110,7 @@
     "@docusaurus/plugin-client-redirects": "^3.10.2",
     "@docusaurus/plugin-content-docs": "^3.10.2",
     "@docusaurus/tsconfig": "^3.10.2",
+    "@swc/plugin-styled-components": "12.19.0",
     "@types/node": "^25.3.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8816,6 +8816,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@swc/plugin-styled-components@npm:12.19.0":
+  version: 12.19.0
+  resolution: "@swc/plugin-styled-components@npm:12.19.0"
+  dependencies:
+    "@swc/counter": "npm:^0.1.3"
+  checksum: 10c0/9a4b99af5274ddfcb3eb7b8fe27fe9f318c468667df0d8fd3d4d8e40a161d2c09bce6006399a2a94e6a183e615d88b13d7bc335ad3f7e4b993f756ed272e458d
+  languageName: node
+  linkType: hard
+
 "@swc/types@npm:^0.1.27":
   version: 0.1.27
   resolution: "@swc/types@npm:0.1.27"
@@ -28026,6 +28035,7 @@ __metadata:
     "@probe.gl/react-bench": "npm:^4.0.2"
     "@probe.gl/stats": "npm:^4.1.1"
     "@probe.gl/stats-widget": "npm:^4.0.2"
+    "@swc/plugin-styled-components": "npm:12.19.0"
     "@turf/turf": "npm:^6.5.0"
     "@types/node": "npm:^25.3.0"
     "@types/react": "npm:^19.0.0"


### PR DESCRIPTION
## Goals

- Restore styling in production Docusaurus builds by keeping styled-components class IDs stable between server rendering and client hydration.
- Preserve the existing SWC/Rspack build path for both the root release site and the `/next/` master preview.

## Changes

- Added the SWC styled-components transform with deterministic SSR IDs and display names.
- Kept Docusaurus's faster build defaults while replacing only its JavaScript loader configuration.
- Pinned the styled-components SWC plugin to the version compatible with the repository's current SWC runtime.
- Updated the Yarn lockfile.

## Verification

- `yarn lint fix`
- `yarn build`
- `yarn build-workers`
- `yarn test-node` — 378 passed
- `yarn test-headless` — 3,437 passed
- `cd website && yarn build`
- `cd website && DOCUSAURUS_BASE_URL=/next/ yarn build`
- Browser-verified hydrated styling at `/` and at a static `/next/` mount.
