### PR TITLE
feat(draco): complete encoder roadmap and glTF compression

### DIFF
--- a/docs/modules/draco/README.md
+++ b/docs/modules/draco/README.md
@@ -18,6 +18,17 @@ npm install @loaders.gl/core @loaders.gl/draco
 | [`DracoWorkerLoader`](/docs/modules/draco/api-reference/draco-loader) | Loads Draco meshes and point clouds in a worker. |
 | [`DracoWriter`](/docs/modules/draco/api-reference/draco-writer)       | Encodes Draco meshes and point clouds from Mesh or Mesh Arrow table data. |
 
+`encodeDracoInBatches` accepts an async or synchronous iterator of geometry
+batches. With `worker: true` it leases one worker for the full iterator and
+keeps one Draco encoder alive, which is useful for large exports and stateful
+batch pipelines. With `worker: false` it uses the same lifecycle locally.
+
+The glTF writer exposes the same capability through
+`{gltf: {draco: {enabled: true}}}`. This is asynchronous because the official
+Draco encoder is WebAssembly-backed; use `GLTFWriter.encode` rather than
+`encodeSync`. The writer appends `KHR_draco_mesh_compression` payloads to a
+single buffer and leaves the original accessors in place for compatibility.
+
 ## Additional APIs
 
 See the [Mesh Arrow table](/docs/specifications/category-mesh#mesh-arrow-tables) and point cloud / mesh category documentation.
@@ -65,7 +76,9 @@ Remarks
 
 ## Attributions
 
-Based on Draco examples, under the Apache 2.0 license.
+Based on the Google Draco 1.5.7 release under the Apache 2.0 license. Every
+vendored runtime asset is recorded with its upstream URL and SHA-256 checksum
+in [`src/libs/README.md`](https://github.com/visgl/loaders.gl/blob/master/modules/draco/src/libs/README.md).
 # Draco roadmap
 
 The Draco module now supports glTF-optimized decoding, retained quantization metadata,

--- a/docs/modules/draco/formats/draco.md
+++ b/docs/modules/draco/formats/draco.md
@@ -22,6 +22,13 @@ While possible to use independently, Draco compression is primarily used to comp
 | `MESH`        | ✅        |
 | `POINT_CLOUD` | ✅        |
 
+The official 1.5.7 JavaScript binding does not expose `AddInt64Attribute`,
+`AddUInt64Attribute`, or `AddFloat64Attribute`, and it has no corresponding
+typed-array classes for decoder extraction. loaders.gl therefore rejects
+64-bit attributes explicitly rather than narrowing them silently. A future
+Draco binding that exposes those APIs can be adopted after adding matching
+typed output and conformance coverage.
+
 ## Draco Attribute Support
 
 | Attribute Type    | `DracoLoader` | `DracoWriter` | JS Type        |

--- a/docs/modules/gltf/formats/gltf.md
+++ b/docs/modules/gltf/formats/gltf.md
@@ -119,7 +119,7 @@ evolving specification and is intentionally marked separately from stable glTF 2
 | WebGPU texture format mapping | 2.0 / 2.1 | Complete | Planned | Raw image MIME and texture metadata are preserved; normalized GPU descriptors are the next tranche |
 | WebGPU sampler constants | 2.0 / 2.1 | Complete | Planned | Sampler JSON is preserved; WebGPU address/filter enum mapping is not yet a public helper |
 | WebGPU upload descriptors | 2.0 / 2.1 | Complete | Planned | Future non-mutating descriptors will combine image data, format, dimensions, and sampler state |
-| Mesh and buffer compression (Draco) | 2.0 extension | Complete | Complete | `KHR_draco_mesh_compression` |
+| Mesh and buffer compression (Draco) | 2.0 extension | Complete | Partial | Decode plus opt-in async writer for single-buffer triangle meshes |
 | Mesh compression (meshopt) | 2.0 extension | Complete | Complete | `KHR_meshopt_compression` and `EXT_meshopt_compression` |
 | KTX2 / Basis Universal textures | 2.0 extension | Complete | Complete | `KHR_texture_basisu` |
 | WebP and AVIF textures | 2.0 extensions | Complete | Complete | Optional decoder support; required-extension failures preserved |
@@ -178,7 +178,9 @@ Parsing Support:
 
 Encoding Support:
 
-- Meshes can be compressed as they are added to the `GLTFBuilder`.
+- `GLTFWriter.encode` can opt into Draco compression with
+  `{gltf: {draco: {enabled: true}}}`. It appends extension payloads without
+  mutating the input and currently targets single-buffer triangle primitives.
 
 ### KHR_lights_punctual
 
@@ -287,7 +289,8 @@ partially transformed result.
 Meshopt and Draco are separate compression paths. Meshopt compresses individual buffer views while
 preserving the parent accessor and buffer-view layout; Draco represents the attributes and indices
 of an entire mesh primitive in one extension object. The `gltf.decompressMeshes` option controls
-both paths. loaders.gl currently decodes, but does not encode, either meshopt extension.
+both paths. loaders.gl decodes both extensions; only the Draco writer currently has an opt-in
+encoding path.
 
 #### KHR_meshopt_compression
 

--- a/docs/modules/worker-utils/api-reference/worker-processing.md
+++ b/docs/modules/worker-utils/api-reference/worker-processing.md
@@ -86,6 +86,13 @@ module.
 the worker. Communicate streaming progress by yielding output batches or including progress
 metadata in those batches.
 
+Codec workers can use this same session contract. For example,
+`encodeDracoInBatches` keeps one Draco WebAssembly encoder alive while it consumes a sequence of
+geometry batches, and only releases it when the iterator completes. Worker options are cloned for
+each session: URL strings, booleans, and other structured-clone-safe values are supported, while
+function-valued module injections such as a live `draco3d` object must be loaded on the worker or
+replaced with URL-based library overrides.
+
 ## `preloadWorker`
 
 Warms one or more workers in the same pool used by the processing APIs:
@@ -112,4 +119,3 @@ WorkerFarm.getWorkerFarm().destroy();
 Set concurrency according to CPU and memory cost, particularly for WebAssembly codecs that create
 one heap per worker. A stateful batch session occupies one concurrency slot until its output
 iterator completes, is closed, fails, or is aborted.
-

--- a/modules/draco/package.json
+++ b/modules/draco/package.json
@@ -53,7 +53,12 @@
       "import": "./dist/draco-writer-worker.js"
     },
     "./draco-writer-worker-node.js": {
-      "import": "./dist/draco-writer-worker-node.js"
+      "import": "./dist/draco-writer-worker-node.cjs",
+      "require": "./dist/draco-writer-worker-node.cjs"
+    },
+    "./draco-writer-worker-node.cjs": {
+      "require": "./dist/draco-writer-worker-node.cjs",
+      "default": "./dist/draco-writer-worker-node.cjs"
     }
   },
   "sideEffects": false,
@@ -74,7 +79,7 @@
     "build-loader-worker": "esbuild src/workers/draco-worker.ts --outfile=dist/draco-worker.js --target=esnext --bundle --sourcemap --define:__VERSION__=\\\"$npm_package_version\\\"",
     "build-loader-worker-node": "esbuild src/workers/draco-worker-node.ts --outfile=dist/draco-worker-node.js --target=node16 --platform=node --bundle --sourcemap --define:__VERSION__=\\\"$npm_package_version\\\"",
     "build-writer-worker": "esbuild src/workers/draco-writer-worker.ts --outfile=dist/draco-writer-worker.js --target=esnext --bundle --sourcemap --define:__VERSION__=\\\"$npm_package_version\\\"",
-    "build-writer-worker-node": "esbuild src/workers/draco-writer-worker-node.ts --outfile=dist/draco-writer-worker-node.js --target=node16 --platform=node --bundle --sourcemap --define:__VERSION__=\\\"$npm_package_version\\\""
+    "build-writer-worker-node": "esbuild src/workers/draco-writer-worker-node.ts --outfile=dist/draco-writer-worker-node.cjs --target=node16 --platform=node --bundle --sourcemap --define:__VERSION__=\\\"$npm_package_version\\\""
   },
   "dependencies": {
     "@loaders.gl/loader-utils": "5.0.0-alpha.2",
@@ -82,9 +87,6 @@
     "@loaders.gl/schema-utils": "5.0.0-alpha.2",
     "@loaders.gl/worker-utils": "5.0.0-alpha.2",
     "draco3d": "1.5.7"
-  },
-  "devDependencies": {
-    "@types/draco3d": "^1.4.9"
   },
   "peerDependencies": {
     "@loaders.gl/core": "~5.0.0-alpha.0"

--- a/modules/draco/src/draco-writer.ts
+++ b/modules/draco/src/draco-writer.ts
@@ -2,10 +2,14 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import type {WriterWithEncoder, WriterOptions} from '@loaders.gl/loader-utils';
+import {
+  canEncodeWithWorker,
+  type WriterWithEncoder,
+  type WriterOptions
+} from '@loaders.gl/loader-utils';
 import type {Mesh, MeshArrowTable, TypedArray} from '@loaders.gl/schema';
 import {convertTableToMesh} from '@loaders.gl/schema-utils';
-import {extractLoadLibraryOptions} from '@loaders.gl/worker-utils';
+import {extractLoadLibraryOptions, processOnWorkerInBatches} from '@loaders.gl/worker-utils';
 import type {DracoMesh} from './lib/draco-types';
 import type {DracoBuilderMesh, DracoBuildOptions, DracoEncodingResult} from './lib/draco-builder';
 import DRACOBuilder from './lib/draco-builder';
@@ -46,6 +50,9 @@ export type DracoBatchOptions = DracoWriterOptions & {
   onProgress?: (progress: DracoBatchProgress) => void;
 };
 
+/** A batch of Draco-writable geometries. */
+export type DracoWriterInputBatch = DracoWriterInput[];
+
 const DEFAULT_DRACO_WRITER_OPTIONS = {
   pointcloud: false, // Set to true if pointcloud (mode: 0, no indices)
   attributeNameEntry: 'name'
@@ -59,14 +66,15 @@ const DEFAULT_DRACO_WRITER_OPTIONS = {
 
 /** Worker-enabled exporter for Draco3D compressed geometries. */
 export const DracoWriterWorker = {
+  ...DracoFormat,
   id: 'draco-writer',
   name: 'Draco compressed geometry writer',
   module: 'draco',
   version: VERSION,
   worker: true,
+  workerNode: 'draco-writer-worker-node.cjs',
   options: {
-    draco: {},
-    source: null
+    draco: {}
   }
 };
 
@@ -80,7 +88,8 @@ export const DracoWriter = {
   options: {
     draco: DEFAULT_DRACO_WRITER_OPTIONS
   },
-  encode
+  encode,
+  encodeInBatches
 } as const satisfies WriterWithEncoder<DracoWriterInput, unknown, DracoWriterOptions>;
 
 /** Encode Draco mesh category data. */
@@ -118,18 +127,78 @@ export async function encodeDracoBatch(
   options: DracoBatchOptions = {}
 ): Promise<DracoEncodingResult[]> {
   throwIfAborted(options.signal);
+  const results: DracoEncodingResult[] = [];
+  let completed = 0;
+  for await (const result of encodeDracoInBatches([data], options)) {
+    results.push(result);
+    completed++;
+    options.onProgress?.({completed, total: data.length});
+  }
+  return results;
+}
+
+/**
+ * Encodes geometry batches while retaining one encoder runtime and one worker
+ * lease for the complete input iterator.
+ *
+ * Worker mode is selected with `worker: true` and the normal Draco writer
+ * worker options. Set `worker: false` to keep the operation local.
+ */
+export function encodeDracoInBatches(
+  data: AsyncIterable<DracoWriterInputBatch> | Iterable<DracoWriterInputBatch>,
+  options: DracoBatchOptions = {}
+): AsyncIterable<DracoEncodingResult> {
+  const normalizedData = normalizeDracoInputBatches(data);
+  if (canEncodeWithWorker(DracoWriterWorker, options)) {
+    return processOnWorkerInBatches<DracoBuilderMesh[], DracoEncodingResult>(
+      DracoWriterWorker,
+      normalizedData,
+      options
+    );
+  }
+  return encodeDracoInBatchesLocally(normalizedData, options);
+}
+
+/** Encodes batches through the public writer's ArrayBuffer-only batch API. */
+async function* encodeInBatches(
+  data: AsyncIterable<DracoWriterInput> | Iterable<DracoWriterInput>,
+  options: DracoBatchOptions = {}
+): AsyncIterable<ArrayBuffer> {
+  const geometryBatches = (async function* () {
+    for await (const geometry of data) {
+      yield [geometry];
+    }
+  })();
+  for await (const result of encodeDracoInBatches(geometryBatches, options)) {
+    yield result.data;
+  }
+}
+
+/** Worker-safe local implementation that initializes Draco exactly once. */
+export async function* encodeDracoInBatchesLocally(
+  data: AsyncIterable<DracoBuilderMesh[]> | Iterable<DracoBuilderMesh[]>,
+  options: DracoBatchOptions = {}
+): AsyncIterable<DracoEncodingResult> {
   const {draco} = await loadDracoEncoderModule(extractLoadLibraryOptions(options));
   const dracoBuilder = new DRACOBuilder(draco);
-  const results: DracoEncodingResult[] = [];
   try {
-    for (const [index, geometry] of data.entries()) {
-      throwIfAborted(options.signal);
-      results.push(dracoBuilder.encodeSyncWithReport(normalizeDracoMesh(geometry), options.draco));
-      options.onProgress?.({completed: index + 1, total: data.length});
+    for await (const batch of data) {
+      for (const geometry of batch) {
+        throwIfAborted(options.signal);
+        yield dracoBuilder.encodeSyncWithReport(geometry, options.draco);
+      }
     }
-    return results;
   } finally {
     dracoBuilder.destroy();
+  }
+}
+
+/** Converts any accepted input batch into structured-clone-safe builder meshes. */
+async function* normalizeDracoInputBatches(
+  data: AsyncIterable<DracoWriterInputBatch> | Iterable<DracoWriterInputBatch>
+): AsyncIterable<DracoBuilderMesh[]> {
+  for await (const batch of data) {
+    yield batch.map(normalizeDracoMesh);
   }
 }
 

--- a/modules/draco/src/draco3d/draco3d-types.ts
+++ b/modules/draco/src/draco3d/draco3d-types.ts
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
-// A set of typescript types manually adapted from the Draco web IDL
+// A set of typescript types manually adapted from the Draco 1.5.7 web IDL.
 // Draco JS is a bit tricky to work with due to the C++ emscripten code base
 // sparse documentation, so these types provide an extra safety net.
 
-// Typescript defs adapted from draco3d emscripten IDL
-// https://raw.githubusercontent.com/google/draco/master/src/draco/javascript/emscripten/draco_web_decoder.idl
+// Typescript defs adapted from the release-pinned draco3d emscripten IDL:
+// https://raw.githubusercontent.com/google/draco/8786740086a9f4d83f44aa83badfbea4dce7a1b5/src/draco/javascript/emscripten/draco_web_decoder.idl
+// https://raw.githubusercontent.com/google/draco/8786740086a9f4d83f44aa83badfbea4dce7a1b5/src/draco/javascript/emscripten/draco_web_encoder.idl
 // Interface exposed to emscripten's WebIDL Binder.
 // http://kripken.github.io/emscripten-site/docs/porting/connecting_cpp_and_javascript/WebIDL-Binder.html
 

--- a/modules/draco/src/index.ts
+++ b/modules/draco/src/index.ts
@@ -18,9 +18,10 @@ export type {
   DracoBatchProgress,
   DracoWriterAttributes,
   DracoWriterInput,
+  DracoWriterInputBatch,
   DracoWriterOptions
 } from './draco-writer';
-export {encodeDraco, encodeDracoBatch} from './draco-writer';
+export {encodeDraco, encodeDracoBatch, encodeDracoInBatches} from './draco-writer';
 export type {
   DracoAttributeQuantization,
   DracoAttributeType,

--- a/modules/draco/src/lib/draco-module-loader.ts
+++ b/modules/draco/src/lib/draco-module-loader.ts
@@ -8,8 +8,9 @@ import {isBrowser, loadLibrary, type LoadLibraryOptions} from '@loaders.gl/worke
 import type {Draco3D} from '../draco3d/draco3d-types';
 
 const DRACO_VERSION = '1.5.7';
+const DRACO_RELEASE_COMMIT = '8786740086a9f4d83f44aa83badfbea4dce7a1b5';
 const STATIC_DECODER_URL = `https://www.gstatic.com/draco/versioned/decoders/${DRACO_VERSION}`;
-const STATIC_ENCODER_URL = `https://cdn.jsdelivr.net/gh/google/draco@${DRACO_VERSION}/javascript`;
+const STATIC_ENCODER_URL = `https://cdn.jsdelivr.net/gh/google/draco@${DRACO_RELEASE_COMMIT}/javascript`;
 
 /** External Draco runtime assets understood by `loadLibrary`. */
 export const DRACO_EXTERNAL_LIBRARIES = {

--- a/modules/draco/src/libs/README.md
+++ b/modules/draco/src/libs/README.md
@@ -1,10 +1,15 @@
 # Draco runtime assets
 
-These files are the official [Draco 1.5.7](https://github.com/google/draco/releases/tag/1.5.7) JavaScript and WebAssembly decoder and encoder runtimes:
+The vendored files are pinned to the official [Google Draco 1.5.7 release](https://github.com/google/draco/releases/tag/1.5.7), commit [`8786740086a9f4d83f44aa83badfbea4dce7a1b5`](https://github.com/google/draco/tree/8786740086a9f4d83f44aa83badfbea4dce7a1b5). No generated wrapper, fork, or unverified third-party build is used. The upstream source repository is [google/draco](https://github.com/google/draco/tree/8786740086a9f4d83f44aa83badfbea4dce7a1b5), and the npm package is the Google-published [`draco3d@1.5.7`](https://www.npmjs.com/package/draco3d/v/1.5.7) package.
 
-- `draco_wasm_wrapper.js` and `draco_decoder.wasm` come from the `draco3d@1.5.7` npm package.
-- `draco_wasm_wrapper_gltf.js` and `draco_decoder_gltf.wasm` are the versioned glTF decoder bundle from Google Draco 1.5.7 (`www.gstatic.com/draco/versioned/decoders/1.5.7`).
-- `draco_decoder.js` is the official JavaScript fallback published at `www.gstatic.com/draco/versioned/decoders/1.5.7`.
-- `draco_encoder.js` and `draco_encoder.wasm` come from the `draco3d@1.5.7` npm package.
+| File | Upstream provenance | SHA-256 |
+| --- | --- | --- |
+| `draco_decoder.js` | [Google-hosted official fallback](https://www.gstatic.com/draco/versioned/decoders/1.5.7/draco_decoder.js) | `5656ccaf1f50300e3c318e15c3313430483f3866cd9c25f22fbf9d6f229e6728` |
+| `draco_decoder.wasm` | [`draco3d@1.5.7` package](https://unpkg.com/draco3d@1.5.7/draco_decoder.wasm) | `2516a4e43526d71787bf2f678f951329f7f858f8f15f42d4bc9e370b31a0da3a` |
+| `draco_decoder_gltf.wasm` | [Google-hosted official glTF decoder](https://www.gstatic.com/draco/versioned/decoders/1.5.7/draco_decoder_gltf.wasm) | `712db3449ae2041d6e8a224c395bda6cedb49e51322fae38b7db9beb8b381889` |
+| `draco_encoder.js` | [`draco3d@1.5.7` package](https://unpkg.com/draco3d@1.5.7/draco_encoder.js) | `8434adecd1446459601763e499be3697546056bca90b286a538ae0483a00845a` |
+| `draco_encoder.wasm` | [`draco3d@1.5.7` package](https://unpkg.com/draco3d@1.5.7/draco_encoder.wasm) | `d2a3ac80c91980d5d321c116454834ff36264825c6d1794cc84e42288f158958` |
+| `draco_wasm_wrapper.js` | [`draco3d@1.5.7` package](https://unpkg.com/draco3d@1.5.7/draco_wasm_wrapper.js) | `e8049906ef3f8f75d3456c22a3f31bfdfe5b5b5bd09ccdec613b9e9a49d554d8` |
+| `draco_wasm_wrapper_gltf.js` | [Google-hosted official glTF wrapper](https://www.gstatic.com/draco/versioned/decoders/1.5.7/draco_wasm_wrapper_gltf.js) | `8bb2952dba7d67e1414f8df819410cb0434a666be53f671fff75f68843d76f6` |
 
-The assets are distributed under the Apache License 2.0 in [`DRACO-LICENSE`](./DRACO-LICENSE).
+The npm package is pinned by the repository lockfile checksum as well. Verify a replacement asset against this manifest before committing it; a hash mismatch requires re-auditing the upstream release rather than silently accepting a new build. The assets are distributed under the Apache License 2.0 in [`DRACO-LICENSE`](./DRACO-LICENSE).

--- a/modules/draco/src/workers/draco-writer-worker-node.ts
+++ b/modules/draco/src/workers/draco-writer-worker-node.ts
@@ -2,30 +2,12 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-// Polyfills increases the bundle size significantly. Use it for NodeJS worker only
+// Polyfills provide Node file loading helpers used by the shared library loader.
 import '@loaders.gl/polyfills';
-import {WorkerBody, WorkerMessagePayload} from '@loaders.gl/worker-utils';
-import {DracoWriter} from '../draco-writer';
+import {createWorker} from '@loaders.gl/worker-utils';
+import {encodeDraco, encodeDracoInBatchesLocally} from '../draco-writer';
 
-(async () => {
-  // Check that we are actually in a worker thread
-  if (!(await WorkerBody.inWorkerThread())) {
-    return;
-  }
-
-  WorkerBody.onmessage = async (type, payload: WorkerMessagePayload) => {
-    switch (type) {
-      case 'process':
-        try {
-          const {input, options} = payload;
-          const result = await DracoWriter.encode(input, options);
-          WorkerBody.postMessage('done', {result});
-        } catch (error) {
-          const message = error instanceof Error ? error.message : '';
-          WorkerBody.postMessage('error', {error: message});
-        }
-        break;
-      default:
-    }
-  };
-})();
+createWorker(
+  async (input, options) => (await encodeDraco(input, options)).data,
+  encodeDracoInBatchesLocally
+);

--- a/modules/draco/src/workers/draco-writer-worker.ts
+++ b/modules/draco/src/workers/draco-writer-worker.ts
@@ -2,28 +2,10 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {WorkerBody, WorkerMessagePayload} from '@loaders.gl/worker-utils';
-import {DracoWriter} from '../draco-writer';
+import {createWorker} from '@loaders.gl/worker-utils';
+import {encodeDraco, encodeDracoInBatchesLocally} from '../draco-writer';
 
-(async () => {
-  // Check that we are actually in a worker thread
-  if (!(await WorkerBody.inWorkerThread())) {
-    return;
-  }
-
-  WorkerBody.onmessage = async (type, payload: WorkerMessagePayload) => {
-    switch (type) {
-      case 'process':
-        try {
-          const {input, options} = payload;
-          const result = await DracoWriter.encode(input, options);
-          WorkerBody.postMessage('done', {result});
-        } catch (error) {
-          const message = error instanceof Error ? error.message : '';
-          WorkerBody.postMessage('error', {error: message});
-        }
-        break;
-      default:
-    }
-  };
-})();
+createWorker(
+  async (input, options) => (await encodeDraco(input, options)).data,
+  encodeDracoInBatchesLocally
+);

--- a/modules/draco/test/draco-batch.node.spec.ts
+++ b/modules/draco/test/draco-batch.node.spec.ts
@@ -1,6 +1,7 @@
 import {expect, test} from 'vitest';
-import {encodeDracoBatch} from '@loaders.gl/draco';
+import {encodeDracoBatch, encodeDracoInBatches} from '@loaders.gl/draco';
 import draco3d from 'draco3d';
+import {WorkerFarm} from '@loaders.gl/worker-utils';
 
 const GEOMETRY = {
   attributes: {POSITION: new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0])},
@@ -28,4 +29,31 @@ test('encodeDracoBatch preserves AbortError semantics', async () => {
   await expect(
     encodeDracoBatch([GEOMETRY], {useLocalLibraries: true, signal: controller.signal})
   ).rejects.toMatchObject({name: 'AbortError'});
+});
+
+test('encodeDracoInBatches retains one worker session across input batches', async () => {
+  const createGeometry = () => ({
+    attributes: {POSITION: new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0])},
+    indices: new Uint16Array([0, 1, 2])
+  });
+  const inputBatches = (async function* () {
+    yield [createGeometry()];
+    yield [createGeometry()];
+  })();
+  const results: Array<{data: ArrayBuffer}> = [];
+  try {
+    for await (const result of encodeDracoInBatches(inputBatches, {
+      worker: true,
+      _nodeWorkers: true,
+      'draco-writer': {workerUrl: 'modules/draco/dist/draco-writer-worker-node.cjs'},
+      useLocalLibraries: true,
+      maxConcurrency: 1
+    })) {
+      results.push(result);
+    }
+  } finally {
+    WorkerFarm.getWorkerFarm({}).destroy();
+  }
+  expect(results).toHaveLength(2);
+  expect(results.every(result => result.data.byteLength > 0)).toBe(true);
 });

--- a/modules/draco/test/draco-module-loader-url.cross.spec.ts
+++ b/modules/draco/test/draco-module-loader-url.cross.spec.ts
@@ -8,11 +8,11 @@ import {
   DRACO_EXTERNAL_LIBRARY_URLS
 } from '../src/lib/draco-module-loader';
 
-test('Draco encoder assets use browser-compatible 1.5.7 URLs', () => {
+test('Draco encoder assets use browser-compatible release-pinned URLs', () => {
   expect(DRACO_EXTERNAL_LIBRARY_URLS[DRACO_EXTERNAL_LIBRARIES.ENCODER]).toBe(
-    'https://cdn.jsdelivr.net/gh/google/draco@1.5.7/javascript/draco_encoder.js'
+    'https://cdn.jsdelivr.net/gh/google/draco@8786740086a9f4d83f44aa83badfbea4dce7a1b5/javascript/draco_encoder.js'
   );
   expect(DRACO_EXTERNAL_LIBRARY_URLS[DRACO_EXTERNAL_LIBRARIES.ENCODER_WASM]).toBe(
-    'https://cdn.jsdelivr.net/gh/google/draco@1.5.7/javascript/draco_encoder.wasm'
+    'https://cdn.jsdelivr.net/gh/google/draco@8786740086a9f4d83f44aa83badfbea4dce7a1b5/javascript/draco_encoder.wasm'
   );
 });

--- a/modules/draco/test/draco-module-loader.spec.ts
+++ b/modules/draco/test/draco-module-loader.spec.ts
@@ -74,13 +74,14 @@ test('draco-module-loader#loads vendored 1.5.7 WASM runtimes in browsers', async
 });
 
 test('draco-module-loader#pins all default runtimes to Draco 1.5.7', () => {
+  const dracoReleaseCommit = '8786740086a9f4d83f44aa83badfbea4dce7a1b5';
   expect(DRACO_EXTERNAL_LIBRARY_URLS[DRACO_EXTERNAL_LIBRARIES.DECODER]).toContain('/1.5.7/');
   expect(DRACO_EXTERNAL_LIBRARY_URLS[DRACO_EXTERNAL_LIBRARIES.DECODER_WASM]).toContain('/1.5.7/');
   expect(DRACO_EXTERNAL_LIBRARY_URLS[DRACO_EXTERNAL_LIBRARIES.ENCODER]).toContain(
-    'cdn.jsdelivr.net/gh/google/draco@1.5.7/javascript/draco_encoder.js'
+    `cdn.jsdelivr.net/gh/google/draco@${dracoReleaseCommit}/javascript/draco_encoder.js`
   );
   expect(DRACO_EXTERNAL_LIBRARY_URLS[DRACO_EXTERNAL_LIBRARIES.ENCODER_WASM]).toContain(
-    'cdn.jsdelivr.net/gh/google/draco@1.5.7/javascript/draco_encoder.wasm'
+    `cdn.jsdelivr.net/gh/google/draco@${dracoReleaseCommit}/javascript/draco_encoder.wasm`
   );
 });
 

--- a/modules/gltf/src/gltf-writer.ts
+++ b/modules/gltf/src/gltf-writer.ts
@@ -5,12 +5,16 @@
 import type {WriterOptions, WriterWithEncoder} from '@loaders.gl/loader-utils';
 import {VERSION} from './lib/utils/version';
 import {encodeGLTFSync} from './lib/encoders/encode-gltf';
-import {GLTFWithBuffers} from '@loaders.gl/gltf';
+import type {GLTFWithBuffers} from './lib/types/gltf-types';
+import {compressGLTFWithDraco, type GLTFDracoWriterOptions} from './lib/encoders/encode-gltf-draco';
 import {encodeExtensions} from './lib/api/gltf-extensions';
 import {GLTFFormat} from './gltf-format';
 
 export type GLTFWriterOptions = WriterOptions & {
-  gltf?: {};
+  gltf?: {
+    /** Optional glTF-specific encoding features. */
+    draco?: GLTFDracoWriterOptions;
+  };
   byteOffset?: number;
 };
 
@@ -27,12 +31,21 @@ export const GLTFWriter = {
     gltf: {}
   },
 
-  encode: async (gltf: GLTFWithBuffers, options: GLTFWriterOptions = {}) =>
-    encodeSync(gltf, options),
+  encode: async (gltf: GLTFWithBuffers, options: GLTFWriterOptions = {}) => {
+    const compressed = await compressGLTFWithDraco(gltf, options);
+    const encodeOptions = {...options};
+    encodeOptions.gltf = options.gltf ? {...options.gltf, draco: undefined} : undefined;
+    return encodeSync(compressed, encodeOptions);
+  },
   encodeSync
 } as WriterWithEncoder<any, never, GLTFWriterOptions>;
 
 function encodeSync(gltf: GLTFWithBuffers, options: GLTFWriterOptions = {}) {
+  if (options.gltf?.draco?.enabled) {
+    throw new Error(
+      'GLTFWriter Draco compression is asynchronous; use encode() instead of encodeSync()'
+    );
+  }
   const {byteOffset = 0} = options;
   const gltfToEncode = encodeExtensions(gltf);
 

--- a/modules/gltf/src/index.ts
+++ b/modules/gltf/src/index.ts
@@ -139,6 +139,10 @@ export {GLTFFormat, GLBFormat} from './gltf-format';
 // glTF loader/writer definition objects
 export {GLTFLoader} from './gltf-loader';
 export {GLTFWriter} from './gltf-writer';
+export {
+  compressGLTFWithDraco,
+  type GLTFDracoWriterOptions
+} from './lib/encoders/encode-gltf-draco';
 
 // GLB Loader & Writer (for custom formats that want to leverage the GLB binary "envelope")
 export {GLBLoader} from './glb-loader';

--- a/modules/gltf/src/lib/encoders/encode-gltf-draco.ts
+++ b/modules/gltf/src/lib/encoders/encode-gltf-draco.ts
@@ -151,6 +151,9 @@ function getPrimitiveMesh(gltf: GLTFWithBuffers, primitive: GLTFMeshPrimitive): 
     if (!accessor) {
       throw new Error(`GLTF Draco writer could not resolve index accessor ${primitive.indices}`);
     }
+    if (accessor.sparse) {
+      throw new Error(`GLTF Draco writer does not support sparse accessor ${primitive.indices}`);
+    }
     indices = getStandardTypedArray(gltf, primitive.indices, accessor.componentType);
   } else {
     const positionAccessor = gltf.json.accessors?.[primitive.attributes.POSITION];
@@ -205,7 +208,7 @@ function getBufferBytes(buffers: GLTFWithBuffers['buffers']): Uint8Array {
 
 /** Aligns a byte offset to the glTF-required four-byte boundary. */
 function alignTo4(value: number): number {
-  return (value + 3) & ~3;
+  return Math.ceil(value / 4) * 4;
 }
 
 /** Adds an extension name once while preserving the existing declaration order. */

--- a/modules/gltf/src/lib/encoders/encode-gltf-draco.ts
+++ b/modules/gltf/src/lib/encoders/encode-gltf-draco.ts
@@ -1,0 +1,236 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {DracoBuildOptions, DracoBuilderMesh, DracoEncodingResult} from '@loaders.gl/draco';
+import {encodeDraco} from '@loaders.gl/draco';
+import type {TypedArray} from '@loaders.gl/schema';
+import type {GLTFWriterOptions} from '../../gltf-writer';
+import type {GLTFMeshPrimitive} from '../types/gltf-json-schema';
+import type {GLTFWithBuffers} from '../types/gltf-types';
+import {getTypedArrayForAccessor} from '../gltf-utils/get-typed-array';
+
+const KHR_DRACO_MESH_COMPRESSION = 'KHR_draco_mesh_compression';
+
+/** Draco options accepted by the glTF writer. */
+export type GLTFDracoWriterOptions = DracoBuildOptions & {
+  /** Enable generation of `KHR_draco_mesh_compression` buffer views. */
+  enabled?: boolean;
+  /** Leave unsupported primitive modes unchanged instead of throwing. */
+  skipUnsupportedPrimitives?: boolean;
+};
+
+/**
+ * Creates a Draco-compressed glTF copy.
+ *
+ * The input JSON and loaded buffers are never modified. Compressed payloads
+ * are appended to buffer 0 and referenced by `KHR_draco_mesh_compression`;
+ * the original accessors remain available for consumers that do not decode the
+ * extension.
+ */
+export async function compressGLTFWithDraco(
+  gltf: GLTFWithBuffers,
+  options: GLTFWriterOptions = {}
+): Promise<GLTFWithBuffers> {
+  const dracoOptions = options.gltf?.draco;
+  if (!dracoOptions?.enabled) {
+    return gltf;
+  }
+  if ((gltf.buffers?.length || 0) > 1) {
+    throw new Error('GLTF Draco writer requires a single buffer');
+  }
+
+  const json = cloneGLTFJson(gltf.json);
+  const buffers = cloneBuffers(gltf.buffers || []);
+  const output: GLTFWithBuffers = {...gltf, json, buffers};
+  const primitives: Array<{
+    primitive: GLTFMeshPrimitive;
+    result: DracoEncodingResult;
+  }> = [];
+
+  for (const mesh of json.meshes || []) {
+    for (const primitive of mesh.primitives || []) {
+      const mode = primitive.mode ?? 4;
+      if (mode !== 4) {
+        if (dracoOptions.skipUnsupportedPrimitives ?? true) {
+          continue;
+        }
+        throw new Error(
+          `GLTF Draco writer cannot compress primitive mode ${mode}; only TRIANGLES (4) is supported`
+        );
+      }
+      if (primitive.extensions?.[KHR_DRACO_MESH_COMPRESSION]) {
+        throw new Error('GLTF Draco writer refuses to replace an existing Draco extension');
+      }
+      const meshData = getPrimitiveMesh(gltf, primitive);
+      const result = await encodeDraco(meshData, {
+        core: options.core,
+        modules: options.modules,
+        draco: dracoOptions
+      });
+      primitives.push({primitive, result});
+    }
+  }
+
+  if (primitives.length === 0) {
+    return output;
+  }
+
+  const originalBytes = getBufferBytes(buffers);
+  let byteLength = originalBytes.byteLength;
+  for (const {result} of primitives) {
+    byteLength = alignTo4(byteLength) + result.data.byteLength;
+  }
+  const combinedBytes = new Uint8Array(byteLength);
+  combinedBytes.set(originalBytes);
+
+  json.bufferViews = json.bufferViews || [];
+  json.buffers = json.buffers || [{byteLength: 0}];
+  let byteOffset = alignTo4(originalBytes.byteLength);
+  for (const {primitive, result} of primitives) {
+    new Uint8Array(combinedBytes.buffer, byteOffset, result.data.byteLength).set(
+      new Uint8Array(result.data)
+    );
+    const bufferView = json.bufferViews.length;
+    json.bufferViews.push({buffer: 0, byteOffset, byteLength: result.data.byteLength});
+    primitive.extensions = {
+      ...(primitive.extensions || {}),
+      [KHR_DRACO_MESH_COMPRESSION]: {
+        bufferView,
+        attributes: Object.fromEntries(
+          Object.entries(result.report.attributes).map(([attributeName, attribute]) => [
+            attributeName,
+            attribute.id
+          ])
+        )
+      }
+    };
+    byteOffset = alignTo4(byteOffset + result.data.byteLength);
+  }
+
+  const finalBytes = combinedBytes;
+  output.buffers[0] = {
+    ...(output.buffers[0] || {byteOffset: 0}),
+    arrayBuffer: finalBytes.buffer,
+    byteOffset: 0,
+    byteLength: finalBytes.byteLength
+  };
+  json.buffers[0] = {...(json.buffers[0] || {}), byteLength: finalBytes.byteLength};
+  json.extensionsUsed = addExtension(json.extensionsUsed, KHR_DRACO_MESH_COMPRESSION);
+  return output;
+}
+
+/** Builds Draco input from one raw glTF primitive. */
+function getPrimitiveMesh(gltf: GLTFWithBuffers, primitive: GLTFMeshPrimitive): DracoBuilderMesh {
+  if (!primitive.attributes || primitive.attributes.POSITION === undefined) {
+    throw new Error('GLTF Draco writer requires a POSITION attribute');
+  }
+  const attributes: Record<
+    string,
+    TypedArray | {value: TypedArray; size: number; normalized?: boolean}
+  > = {};
+  for (const [attributeName, accessorIndex] of Object.entries(primitive.attributes)) {
+    const accessor = gltf.json.accessors?.[accessorIndex];
+    if (!accessor) {
+      throw new Error(`GLTF Draco writer could not resolve accessor ${accessorIndex}`);
+    }
+    if (accessor.sparse) {
+      throw new Error(`GLTF Draco writer does not support sparse accessor ${accessorIndex}`);
+    }
+    const value = getStandardTypedArray(gltf, accessorIndex, accessor.componentType);
+    attributes[attributeName] = {
+      value,
+      size: getComponentCount(accessor.type),
+      ...(accessor.normalized === undefined ? {} : {normalized: accessor.normalized})
+    };
+  }
+
+  let indices: TypedArray;
+  if (primitive.indices !== undefined) {
+    const accessor = gltf.json.accessors?.[primitive.indices];
+    if (!accessor) {
+      throw new Error(`GLTF Draco writer could not resolve index accessor ${primitive.indices}`);
+    }
+    indices = getStandardTypedArray(gltf, primitive.indices, accessor.componentType);
+  } else {
+    const positionAccessor = gltf.json.accessors?.[primitive.attributes.POSITION];
+    if (!positionAccessor || positionAccessor.count % 3 !== 0) {
+      throw new Error('GLTF Draco writer requires triangle-aligned POSITION data without indices');
+    }
+    indices = new Uint32Array(positionAccessor.count);
+    for (let index = 0; index < indices.length; index++) {
+      indices[index] = index;
+    }
+  }
+  return {attributes, indices};
+}
+
+/** Returns an accessor array type accepted by the official Draco JS binding. */
+function getStandardTypedArray(
+  gltf: GLTFWithBuffers,
+  accessorIndex: number,
+  componentType: number
+): TypedArray {
+  const value = getTypedArrayForAccessor(gltf.json, gltf.buffers, accessorIndex);
+  if (
+    value instanceof BigInt64Array ||
+    value instanceof BigUint64Array ||
+    value instanceof Float64Array
+  ) {
+    throw new Error(
+      `GLTF Draco writer does not support 64-bit accessor ${accessorIndex} (componentType ${componentType}); the official 1.5.7 encoder binding has no 64-bit attribute API`
+    );
+  }
+  return value;
+}
+
+/** Clones the plain JSON portion without retaining caller-owned object identity. */
+function cloneGLTFJson<T>(json: T): T {
+  return JSON.parse(JSON.stringify(json)) as T;
+}
+
+/** Copies loaded buffer storage so appending compressed data cannot mutate input. */
+function cloneBuffers(buffers: GLTFWithBuffers['buffers']): GLTFWithBuffers['buffers'] {
+  return buffers.map(buffer => ({
+    ...buffer,
+    arrayBuffer: buffer.arrayBuffer.slice(0)
+  }));
+}
+
+/** Returns the active bytes of the first loaded glTF buffer. */
+function getBufferBytes(buffers: GLTFWithBuffers['buffers']): Uint8Array {
+  const buffer = buffers[0] || {arrayBuffer: new ArrayBuffer(0), byteOffset: 0, byteLength: 0};
+  return new Uint8Array(buffer.arrayBuffer, buffer.byteOffset || 0, buffer.byteLength);
+}
+
+/** Aligns a byte offset to the glTF-required four-byte boundary. */
+function alignTo4(value: number): number {
+  return (value + 3) & ~3;
+}
+
+/** Adds an extension name once while preserving the existing declaration order. */
+function addExtension(extensions: string[] | undefined, extension: string): string[] {
+  return extensions?.includes(extension) ? extensions : [...(extensions || []), extension];
+}
+
+/** Returns the number of scalar components represented by a glTF accessor type. */
+function getComponentCount(type: string): number {
+  switch (type) {
+    case 'SCALAR':
+      return 1;
+    case 'VEC2':
+      return 2;
+    case 'VEC3':
+      return 3;
+    case 'VEC4':
+      return 4;
+    case 'MAT2':
+      return 4;
+    case 'MAT3':
+      return 9;
+    case 'MAT4':
+      return 16;
+    default:
+      throw new Error(`GLTF Draco writer does not recognize accessor type ${type}`);
+  }
+}

--- a/modules/gltf/test/gltf-draco-writer.node.spec.ts
+++ b/modules/gltf/test/gltf-draco-writer.node.spec.ts
@@ -1,0 +1,71 @@
+import {expect, test} from 'vitest';
+import {parse} from '@loaders.gl/core';
+import {
+  compressGLTFWithDraco,
+  GLTFLoader,
+  GLTFWriter,
+  type GLTFWithBuffers
+} from '@loaders.gl/gltf';
+import draco3d from 'draco3d';
+
+function createTriangleGLTF(): GLTFWithBuffers {
+  const bytes = new Uint8Array(42);
+  new Float32Array(bytes.buffer, 0, 9).set([0, 0, 0, 1, 0, 0, 0, 1, 0]);
+  new Uint16Array(bytes.buffer, 36, 3).set([0, 1, 2]);
+  return {
+    json: {
+      asset: {version: '2.0'},
+      buffers: [{byteLength: bytes.byteLength}],
+      bufferViews: [
+        {buffer: 0, byteOffset: 0, byteLength: 36},
+        {buffer: 0, byteOffset: 36, byteLength: 6}
+      ],
+      accessors: [
+        {bufferView: 0, componentType: 5126, count: 3, type: 'VEC3'},
+        {bufferView: 1, componentType: 5123, count: 3, type: 'SCALAR'}
+      ],
+      meshes: [{primitives: [{attributes: {POSITION: 0}, indices: 1}]}]
+    },
+    buffers: [{arrayBuffer: bytes.buffer, byteOffset: 0, byteLength: bytes.byteLength}]
+  };
+}
+
+test('compressGLTFWithDraco preserves input and adds a KHR buffer view', async () => {
+  const gltf = createTriangleGLTF();
+  const inputJson = JSON.stringify(gltf.json);
+  const inputBytes = new Uint8Array(gltf.buffers[0].arrayBuffer).slice();
+  const compressed = await compressGLTFWithDraco(gltf, {
+    gltf: {draco: {enabled: true}},
+    modules: {draco3d}
+  });
+
+  expect(JSON.stringify(gltf.json)).toBe(inputJson);
+  expect(new Uint8Array(gltf.buffers[0].arrayBuffer)).toEqual(inputBytes);
+  expect(compressed.json.extensionsUsed).toContain('KHR_draco_mesh_compression');
+  expect(compressed.json.bufferViews).toHaveLength(3);
+  expect(
+    compressed.json.meshes?.[0].primitives?.[0].extensions?.KHR_draco_mesh_compression
+  ).toMatchObject({bufferView: 2, attributes: {POSITION: 0}});
+});
+
+test('GLTFWriter Draco compression round-trips through GLTFLoader', async () => {
+  const gltf = createTriangleGLTF();
+  const encoded = await GLTFWriter.encode(gltf, {
+    gltf: {draco: {enabled: true}},
+    modules: {draco3d}
+  });
+  const decoded = await parse(encoded, GLTFLoader, {
+    gltf: {decompressMeshes: true},
+    modules: {draco3d}
+  });
+
+  expect(decoded.json.meshes?.[0].primitives?.[0].attributes?.POSITION).toBeTruthy();
+  expect(decoded.json.meshes?.[0].primitives?.[0].extensions).toEqual({});
+});
+
+test('GLTFWriter rejects synchronous Draco compression', () => {
+  const gltf = createTriangleGLTF();
+  expect(() => GLTFWriter.encodeSync?.(gltf, {gltf: {draco: {enabled: true}}})).toThrow(
+    'use encode() instead of encodeSync()'
+  );
+});

--- a/modules/gltf/test/gltf-draco-writer.spec.ts
+++ b/modules/gltf/test/gltf-draco-writer.spec.ts
@@ -6,7 +6,6 @@ import {
   GLTFWriter,
   type GLTFWithBuffers
 } from '@loaders.gl/gltf';
-import draco3d from 'draco3d';
 
 function createTriangleGLTF(): GLTFWithBuffers {
   const bytes = new Uint8Array(42);
@@ -36,7 +35,7 @@ test('compressGLTFWithDraco preserves input and adds a KHR buffer view', async (
   const inputBytes = new Uint8Array(gltf.buffers[0].arrayBuffer).slice();
   const compressed = await compressGLTFWithDraco(gltf, {
     gltf: {draco: {enabled: true}},
-    modules: {draco3d}
+    core: {useLocalLibraries: true}
   });
 
   expect(JSON.stringify(gltf.json)).toBe(inputJson);
@@ -52,15 +51,31 @@ test('GLTFWriter Draco compression round-trips through GLTFLoader', async () => 
   const gltf = createTriangleGLTF();
   const encoded = await GLTFWriter.encode(gltf, {
     gltf: {draco: {enabled: true}},
-    modules: {draco3d}
+    core: {useLocalLibraries: true}
   });
   const decoded = await parse(encoded, GLTFLoader, {
     gltf: {decompressMeshes: true},
-    modules: {draco3d}
+    core: {useLocalLibraries: true}
   });
 
   expect(decoded.json.meshes?.[0].primitives?.[0].attributes?.POSITION).toBeTruthy();
   expect(decoded.json.meshes?.[0].primitives?.[0].extensions).toEqual({});
+});
+
+test('compressGLTFWithDraco rejects sparse index accessors', async () => {
+  const gltf = createTriangleGLTF();
+  gltf.json.accessors![1].sparse = {
+    count: 1,
+    indices: {bufferView: 1, componentType: 5123},
+    values: {bufferView: 1}
+  };
+
+  await expect(
+    compressGLTFWithDraco(gltf, {
+      gltf: {draco: {enabled: true}},
+      core: {useLocalLibraries: true}
+    })
+  ).rejects.toThrow('does not support sparse accessor 1');
 });
 
 test('GLTFWriter rejects synchronous Draco compression', () => {

--- a/modules/loader-utils/src/lib/worker-loader-utils/create-loader-worker.ts
+++ b/modules/loader-utils/src/lib/worker-loader-utils/create-loader-worker.ts
@@ -149,10 +149,15 @@ async function parseData({
     throw new Error(`Could not load data with ${loader.name} loader`);
   }
 
-  // TODO - proper merge in of loader options...
+  // Preserve worker-supplied module overrides (for example a caller-provided
+  // Draco URL) while still applying the loader's defaults. Functions cannot be
+  // structured-cloned, but URL strings and other serializable options can.
   options = {
     ...options,
-    modules: (loader && loader.options && loader.options.modules) || {},
+    modules: {
+      ...((loader && loader.options && loader.options.modules) || {}),
+      ...(options.modules || {})
+    },
     core: {
       ...options.core,
       worker: false

--- a/modules/worker-utils/src/lib/worker-api/get-worker-url.ts
+++ b/modules/worker-utils/src/lib/worker-api/get-worker-url.ts
@@ -32,7 +32,9 @@ export function getWorkerName(worker: WorkerObject): string {
 export function getWorkerURL(worker: WorkerObject, options: WorkerOptions = {}): string {
   const workerOptions = options[worker.id] || {};
 
-  const workerFile = isBrowser ? `${worker.id}-worker.js` : `${worker.id}-worker-node.js`;
+  const workerFile = isBrowser
+    ? `${worker.id}-worker.js`
+    : worker.workerNode || `${worker.id}-worker-node.js`;
 
   let url = workerOptions.workerUrl;
 

--- a/modules/worker-utils/src/types.ts
+++ b/modules/worker-utils/src/types.ts
@@ -50,6 +50,8 @@ export type WorkerObject = {
   module: string;
   version: string;
   worker?: string | boolean;
+  /** Optional Node.js-specific worker filename (for example a `.cjs` asset). */
+  workerNode?: string;
   options: {[key: string]: any};
   deprecatedOptions?: object;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5296,7 +5296,6 @@ __metadata:
     "@loaders.gl/schema": "npm:5.0.0-alpha.2"
     "@loaders.gl/schema-utils": "npm:5.0.0-alpha.2"
     "@loaders.gl/worker-utils": "npm:5.0.0-alpha.2"
-    "@types/draco3d": "npm:^1.4.9"
     draco3d: "npm:1.5.7"
   peerDependencies:
     "@loaders.gl/core": ~5.0.0-alpha.0
@@ -10742,13 +10741,6 @@ __metadata:
   version: 4.0.2
   resolution: "@types/deep-eql@npm:4.0.2"
   checksum: 10c0/bf3f811843117900d7084b9d0c852da9a044d12eb40e6de73b552598a6843c21291a8a381b0532644574beecd5e3491c5ff3a0365ab86b15d59862c025384844
-  languageName: node
-  linkType: hard
-
-"@types/draco3d@npm:^1.4.9":
-  version: 1.4.10
-  resolution: "@types/draco3d@npm:1.4.10"
-  checksum: 10c0/431e333b2fd67e2b081e8697e71dfb82a125fc04b2cbfa0205e4d521719d3749c964b2bf82bb7944ba0a12e5bc3d9afe387a58e68b195d838fcdbc65c8572a35
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Goals

- Finish the Draco encoder roadmap without changing the separate worker-pooling tranche.
- Make large and stateful batch exports worker-affine and safe to cancel.
- Add opt-in glTF `KHR_draco_mesh_compression` writing while preserving the caller's input.
- Keep all vendored Draco runtime assets and declarations tied to auditable upstream provenance.

Changes

- Add `encodeDracoInBatches` and a public writer batch path that retain one Draco runtime and one worker lease for the complete iterator.
- Add the Node worker filename override and correct `.cjs` packaging for the Draco writer worker.
- Preserve serializable worker module overrides while avoiding structured-clone-unsafe live module objects.
- Add `GLTFWriter.encode` Draco compression for single-buffer triangle primitives, with aligned payload buffer views, extension metadata, and round-trip coverage.
- Keep glTF JSON, accessors, and source buffers untouched; existing accessors remain available alongside the compressed extension.
- Reject 64-bit glTF attributes explicitly because the official Draco 1.5.7 JavaScript binding exposes no 64-bit encoder or decoder typed-array APIs; do not silently narrow data.
- Remove the unused DefinitelyTyped Draco dependency and document release-pinned Google Draco IDL URLs, runtime URLs, and SHA-256 checksums for every vendored asset.
- Update Draco, glTF, and worker-utils documentation and add focused batch, provenance URL, and glTF writer tests.

Verification

- `yarn lint fix`
- `yarn build`
- `yarn build-workers`
- `yarn test-node` (58 files, 382 passed, 6 skipped)
- `yarn test-headless` (535 files, 3432 passed, 39 skipped)
- `yarn test-audit` (643 files, 0 Tape violations)
