### PR TITLE
docs(website): add approachable capability introductions

### DIFF
--- a/docs/README.mdx
+++ b/docs/README.mdx
@@ -2,6 +2,12 @@ import {FormatLogoGallery} from '@site/src/components/docs/format-logo-gallery';
 
 # Introduction
 
+:::info Start here
+Choose the loader that matches your data and use the same small set of APIs to load, stream, or
+write it. Modules are independent, so applications install only the formats and capabilities they
+need.
+:::
+
 <img src="https://badge.fury.io/js/%40loaders.gl%2Fcore.svg" /> &nbsp;
 <img src="https://img.shields.io/badge/License-MIT-green.svg" /> &nbsp;
 <img src="https://img.shields.io/npm/dm/@loaders.gl/core.svg" />  &nbsp;

--- a/docs/developer-guide/apache-arrow.md
+++ b/docs/developer-guide/apache-arrow.md
@@ -1,5 +1,11 @@
 # Apache Arrow
 
+:::info Start here
+Apache Arrow gives different tabular formats a shared, typed columnar shape. Use it when you want
+efficient transfer or the same processing code across formats; loaders that return other shapes do
+not require it.
+:::
+
 loaders.gl is adding support for Apache Arrow as its standard in-memory representation of tables.
 
 loaders.gl provides an `ArrowLoader` and an `ArrowWriter` that load and write Arrow files.

--- a/docs/developer-guide/common-scan-architecture.md
+++ b/docs/developer-guide/common-scan-architecture.md
@@ -2,6 +2,12 @@ import {FederatedScanLiveExample} from '@site/src/components/docs/federated-scan
 
 # Common Scan Architecture
 
+:::info Start here
+Describe the data you need with bounds, selected columns, predicates, and limits. loaders.gl applies
+that request across supported local and cloud data sources; the planning details below matter only
+when you need to inspect or optimize execution.
+:::
+
 The loaders.gl common scan architecture is a portable query and execution model for columnar data.
 It allows an application to describe a small relational query once and execute it against an
 in-memory Arrow table, a remote Parquet dataset, a versioned table format, a SQL database, or a GPU

--- a/docs/developer-guide/coordinate-reference-systems.md
+++ b/docs/developer-guide/coordinate-reference-systems.md
@@ -1,5 +1,11 @@
 # Coordinate Reference Systems
 
+:::info Start here
+CRS support keeps the meaning of coordinates attached to loaded data and makes coordinate
+transformations explicit. Most applications can preserve the source metadata first and add
+reprojection only where it is needed.
+:::
+
 Coordinate reference system (CRS) metadata tells an application how coordinates relate to the
 earth. Preserving that metadata is different from transforming coordinates. loaders.gl aims to
 make both explicit: loaders should first discover and retain the source CRS; reprojection only

--- a/docs/developer-guide/loader-categories.md
+++ b/docs/developer-guide/loader-categories.md
@@ -1,5 +1,11 @@
 # Loader Categories
 
+:::info Start here
+Choose a loader category when your application should accept several formats without separate code
+paths for each one. The category defines the common result shape, while each loader handles its own
+file format.
+:::
+
 To simplify working with multiple similar formats, loaders and writers in loaders.gl are grouped into _categories_.
 
 The idea is that many loaders return very similar data (e.g. point clouds loaders), which makes it possible to represent the loaded data in the same data structure, letting applications handle the output from multiple loaders without

--- a/docs/developer-guide/using-streaming-loaders.md
+++ b/docs/developer-guide/using-streaming-loaders.md
@@ -1,5 +1,11 @@
 # Using Batched Loaders
 
+:::info Start here
+Use a batched loader when data is too large to wait for or can be useful before the full download
+finishes. Process each batch with an ordinary `for await...of` loop; no separate streaming framework
+is required.
+:::
+
 A major feature of loaders.gl is the availability of a number of batched (or streaming) loaders.
 
 The advantages and characteristics of streaming are descriped in more detail in the [streaming](./concepts/streaming) concepts section, but the highlights are:

--- a/docs/developer-guide/using-worker-loaders.md
+++ b/docs/developer-guide/using-worker-loaders.md
@@ -1,5 +1,11 @@
 # Using Worker Loaders
 
+:::info Start here
+Worker-enabled loaders keep expensive parsing and decompression away from the browser's UI thread.
+For most applications, choose the loader normally and let loaders.gl manage its worker; the options
+below are available when you need more control.
+:::
+
 Most loaders.gl loaders can perform parsing on JavaScript worker threads.
 This means that the main thread will not block during parsing and can continue
 to respond to user interactions or do parallel processing.

--- a/website/src/components/home/features.jsx
+++ b/website/src/components/home/features.jsx
@@ -8,7 +8,7 @@ const featureCards = [
     eyebrow: 'Query architecture',
     title: 'Read less. Query sooner.',
     description:
-      'A portable scan model brings projection, predicates, range reads, and bounded execution to columnar data in the browser.',
+      'Cloud-native scanning supports range reads, bounding-box filtering, projection, and predicates across most data formats, directly in the browser.',
     href: '/docs/developer-guide/common-scan-architecture',
     linkLabel: 'Explore scan architecture',
     tags: ['projection', 'predicates', 'range reads'],


### PR DESCRIPTION
## Goals

- Give visitors a concise, approachable explanation before each feature page enters its detailed technical material.
- Describe cloud-native scanning in concrete terms on the homepage.

## Changes

- Reworked the scan feature-card copy around range reads, bounding-box filtering, projection, and predicates in the browser.
- Added a short `:::info Start here` introduction to all seven feature-card destinations:
  - scan architecture
  - coordinate reference systems
  - streaming loaders
  - worker loaders
  - Apache Arrow
  - loader catalog
  - loader categories
- Kept each introduction capability-led and explicit about when an application would use it.

## Verification

- `yarn lint fix`
- `cd website && yarn build`
