### PR TITLE
docs(scan): make federation website-first

### DIFF
--- a/docs/developer-guide/common-scan-architecture.md
+++ b/docs/developer-guide/common-scan-architecture.md
@@ -910,6 +910,8 @@ exposing the managed source objects, applies explicit mappings and a named predi
 and shows both the plan and terminal execution telemetry. Source badges below the panel are the
 provenance attached to emitted Arrow batches.
 
+For a guided, end-user version of the same workflow, open the [Federated scan example](/examples/table/federated-scan).
+
 <FederatedScanLiveExample />
 
 ## Point-cloud participation

--- a/docs/modules/arrow/README.md
+++ b/docs/modules/arrow/README.md
@@ -4,7 +4,17 @@
 &emsp;
 ![apache-logo](../../images/logos/apache-logo.png)
 
+<p class="badges">
+  <a href="/docs/developer-guide/common-scan-architecture">
+    <img src="https://img.shields.io/badge/Scan-Supported-2f855a.svg?style=flat-square" alt="Scan supported" />
+  </a>
+</p>
+
 The `@loaders.gl/arrow` module provides support for the [Apache Arrow](/docs/modules/arrow/formats/arrow) and [GeoArrow](/docs/modules/arrow/formats/geoarrow) formats.
+
+Arrow IPC sources expose schema discovery, residual predicates, projection, global limits,
+cancellation, explain output, telemetry, and streaming Arrow batches through the common scan
+contract.
 
 ## Installation
 

--- a/docs/modules/csv/README.md
+++ b/docs/modules/csv/README.md
@@ -1,7 +1,16 @@
 # Overview
 
+<p class="badges">
+  <a href="/docs/developer-guide/common-scan-architecture">
+    <img src="https://img.shields.io/badge/Scan-Supported-2f855a.svg?style=flat-square" alt="Scan supported" />
+  </a>
+</p>
+
 The `@loaders.gl/csv` module handles tabular data stored in CSV and TSV format
 [CSV/DSV file format](https://en.wikipedia.org/wiki/Comma-separated_values).
+
+CSV sources support metadata discovery, streaming projection and limits, and correct residual
+predicates through the common scan contract.
 
 ## Installation
 

--- a/docs/modules/flatgeobuf/README.md
+++ b/docs/modules/flatgeobuf/README.md
@@ -6,9 +6,15 @@
   <img src="https://img.shields.io/badge/From-v3.1-blue.svg?style=flat-square" alt="From-v3.1" />
   <img src="https://img.shields.io/badge/arrow_output-From_v5.0-blue.svg?style=flat-square" alt="arrow output from v5.0" />
   <img src="https://img.shields.io/badge/source_loader-From_v5.0-blue.svg?style=flat-square" alt="source loader from v5.0" />
+  <a href="/docs/developer-guide/common-scan-architecture">
+    <img src="https://img.shields.io/badge/Scan-Supported-2f855a.svg?style=flat-square" alt="Scan supported" />
+  </a>
 </p>
 
 The `@loaders.gl/flatgeobuf` module handles the [FlatGeobuf](http://flatgeobuf.org/) format, a binary FlatBuffers-encoded format that defines geospatial geometries.
+
+FlatGeobuf sources support schema discovery, bounding-box pruning, residual predicates, projection,
+limits, cancellation, and Arrow feature batches through the common scan contract.
 
 ## Installation
 

--- a/docs/modules/geopackage/README.md
+++ b/docs/modules/geopackage/README.md
@@ -2,7 +2,17 @@
 
 ![ogc-logo](../../images/logos/ogc-logo-60.png)
 
+<p class="badges">
+  <a href="/docs/developer-guide/common-scan-architecture">
+    <img src="https://img.shields.io/badge/Scan-Supported-2f855a.svg?style=flat-square" alt="Scan supported" />
+  </a>
+</p>
+
 The `@loaders.gl/geopackage` module handles the OGC [GeoPackage](https://www.geopackage.org/) format.
+
+`GeoPackageSource` discovers selected feature-table fields and returns Arrow batches with residual
+projection, predicate, and limit semantics. Spatial-index and SQL pushdown remain format-specific
+optimizations.
 
 ## Installation
 

--- a/docs/modules/json/README.md
+++ b/docs/modules/json/README.md
@@ -1,5 +1,11 @@
 # Overview
 
+<p class="badges">
+  <a href="/docs/developer-guide/common-scan-architecture">
+    <img src="https://img.shields.io/badge/Scan-Supported-2f855a.svg?style=flat-square" alt="Scan supported" />
+  </a>
+</p>
+
 The `@loaders.gl/json` module parses JSON, tabular JSON, and geospatial formats that use JSON encoding. It includes:
 
 - `JSONLoader` for arbitrary JSON documents.
@@ -9,6 +15,9 @@ The `@loaders.gl/json` module parses JSON, tabular JSON, and geospatial formats 
 
 The JSON loaders also support batched parsing which can be useful when loading very large tabular JSON files
 to avoid blocking for tens of seconds.
+
+NDJSON sources expose schema discovery, streaming projection and limits, and correct residual
+predicates through the common scan contract.
 
 `JSONLoader` exposes `json.backend: 'fast'` as an experimental opt-in backend for streaming extraction. This keeps atomic JSON parsing on the standard `JSON.parse` path while using the faster streaming parser for `loadInBatches`.
 

--- a/modules/geopackage/test/geopackage-scan-metadata.spec.ts
+++ b/modules/geopackage/test/geopackage-scan-metadata.spec.ts
@@ -1,9 +1,18 @@
 import {fetchFile, isBrowser} from '@loaders.gl/core';
 import * as arrow from 'apache-arrow';
 import {expect, test} from 'vitest';
-import {GeoPackageDataSource} from '../src/geopackage-source-loader';
+import {GeoPackageDataSource, GeoPackageSource} from '../src/geopackage-source-loader';
 
 const GEOPACKAGE_FIXTURE = '@loaders.gl/geopackage/test/data/rivers_multi.gpkg';
+
+test('GeoPackage source loader exposes URL detection and a data source factory', () => {
+  expect(GeoPackageSource.testURL('rivers.gpkg')).toBe(true);
+  expect(GeoPackageSource.testURL('rivers.gpkg?table=features')).toBe(true);
+  expect(GeoPackageSource.testURL('rivers.sqlite')).toBe(false);
+
+  const source = GeoPackageSource.createDataSource(new Blob([]), {geopackage: {}});
+  expect(source).toBeInstanceOf(GeoPackageDataSource);
+});
 
 test.runIf(isBrowser)(
   'GeoPackage source exposes shared scan metadata for the default table',

--- a/website/src/components/docs/federated-scan-live-example.tsx
+++ b/website/src/components/docs/federated-scan-live-example.tsx
@@ -160,12 +160,38 @@ export function FederatedScanLiveExample(): JSX.Element {
 
   return (
     <ExampleFrame>
+      <ExampleIntro>
+        <IntroEyebrow>Website-first scan walkthrough</IntroEyebrow>
+        <IntroTitle>One query, three source formats</IntroTitle>
+        <IntroText>
+          Discover schemas, reconcile names, and stream a bounded Arrow result without loading a
+          database or handing application code a format-specific query API.
+        </IntroText>
+        <Pipeline aria-label="Federated scan pipeline">
+          <PipelineStep>Discover</PipelineStep>
+          <PipelineArrow>→</PipelineArrow>
+          <PipelineStep>Map + validate</PipelineStep>
+          <PipelineArrow>→</PipelineArrow>
+          <PipelineStep>Append in order</PipelineStep>
+          <PipelineArrow>→</PipelineArrow>
+          <PipelineStep>Arrow batches</PipelineStep>
+        </Pipeline>
+      </ExampleIntro>
       <ExampleHeader>
         <div>
           <strong>Heterogeneous weather history</strong>
-          <div>CSV + NDJSON + Arrow IPC → ordered Arrow batches</div>
+          <div>CSV + NDJSON + Arrow IPC · local fixtures · no server query engine</div>
         </div>
-        <Status $failed={Boolean(results.error)}>
+        <ResetButton
+          type="button"
+          onClick={() => {
+            setValue(DEFAULT_STATE);
+            setSubmittedValue(DEFAULT_STATE);
+          }}
+        >
+          Reset example
+        </ResetButton>
+        <Status $failed={Boolean(results.error)} aria-live="polite">
           {results.error ? 'Failed' : loading ? 'Planning…' : `${results.rows?.length || 0} rows`}
         </Status>
       </ExampleHeader>
@@ -184,8 +210,8 @@ export function FederatedScanLiveExample(): JSX.Element {
           setSubmittedValue(nextValue);
         }}
       />
-      {results.error ? <ErrorMessage>{results.error}</ErrorMessage> : null}
-      {results.rows?.length ? <RowsPreview rows={results.rows} /> : null}
+      {results.error ? <ErrorMessage role="alert">{results.error}</ErrorMessage> : null}
+      {results.rows ? <RowsPreview rows={results.rows} /> : null}
     </ExampleFrame>
   );
 }
@@ -196,18 +222,22 @@ function RowsPreview({rows}: {rows: readonly Record<string, unknown>[]}): JSX.El
   return (
     <Preview>
       <strong>Bounded Arrow result</strong>
-      <table>
-        <thead>
-          <tr>{columns.map(column => <th key={column}>{column}</th>)}</tr>
-        </thead>
-        <tbody>
-          {rows.map((row, rowIndex) => (
-            <tr key={rowIndex}>
-              {columns.map(column => <td key={column}>{String(row[column] ?? 'null')}</td>)}
-            </tr>
-          ))}
-        </tbody>
-      </table>
+      {rows.length ? (
+        <table>
+          <thead>
+            <tr>{columns.map(column => <th key={column}>{column}</th>)}</tr>
+          </thead>
+          <tbody>
+            {rows.map((row, rowIndex) => (
+              <tr key={rowIndex}>
+                {columns.map(column => <td key={column}>{String(row[column] ?? 'null')}</td>)}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      ) : (
+        <EmptyResult>No rows matched this query. The scan completed successfully.</EmptyResult>
+      )}
     </Preview>
   );
 }
@@ -240,15 +270,67 @@ function getSourceTitle(sourceId: string): string {
 const ExampleFrame = styled.section`
   margin: 18px 0;
 `;
+const ExampleIntro = styled.div`
+  border: 1px solid #b2ddff;
+  border-radius: 10px;
+  padding: 16px;
+  background: linear-gradient(135deg, #f0f9ff, #ffffff 70%);
+`;
+const IntroEyebrow = styled.div`
+  color: #175cd3;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+`;
+const IntroTitle = styled.h3`
+  margin: 5px 0 4px;
+  color: #101828;
+`;
+const IntroText = styled.p`
+  max-width: 760px;
+  margin: 0;
+  color: #475467;
+`;
+const Pipeline = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  margin-top: 13px;
+`;
+const PipelineStep = styled.span`
+  border-radius: 999px;
+  padding: 5px 9px;
+  color: #175cd3;
+  background: #dff3ff;
+  font-size: 0.74rem;
+  font-weight: 600;
+`;
+const PipelineArrow = styled.span`
+  color: #98a2b3;
+`;
 const ExampleHeader = styled.div`
   display: flex;
+  align-items: center;
   justify-content: space-between;
   gap: 12px;
+  margin: 14px 0 8px;
   color: #475467;
 
   strong {
     color: #101828;
   }
+`;
+const ResetButton = styled.button`
+  margin-left: auto;
+  border: 1px solid #b2ddff;
+  border-radius: 5px;
+  padding: 5px 8px;
+  color: #175cd3;
+  background: white;
+  cursor: pointer;
+  font-size: 0.74rem;
 `;
 const Status = styled.span<{$failed: boolean}>`
   align-self: flex-start;
@@ -284,4 +366,9 @@ const Preview = styled.div`
     text-align: left;
     font-size: 0.78rem;
   }
+`;
+const EmptyResult = styled.p`
+  margin: 8px 0 0;
+  color: #667085;
+  font-size: 0.82rem;
 `;

--- a/website/src/components/docs/federated-scan-panel.tsx
+++ b/website/src/components/docs/federated-scan-panel.tsx
@@ -232,26 +232,67 @@ export function FederatedScanPanel({
 
 /** Renders planned and actual execution data without hiding source-specific fields. */
 function ExecutionResults({results}: {results: FederatedScanPanelResults}): JSX.Element {
+  const telemetry = results.telemetry;
   return (
-    <ResultsGrid>
-      <ResultCard>
-        <strong>Explain</strong>
-        <Code>{formatJson(results.explanation || {})}</Code>
-      </ResultCard>
-      <ResultCard>
-        <strong>Actual telemetry</strong>
-        <Code>{formatJson(results.telemetry || {})}</Code>
-      </ResultCard>
-      <ResultCard>
-        <strong>Batch provenance</strong>
-        <Provenance>
-          {results.provenance?.map((sourceId, index) => (
-            <span key={`${sourceId}-${index}`}>{sourceId}</span>
-          )) || 'No batches yet'}
-        </Provenance>
-      </ResultCard>
-    </ResultsGrid>
+    <ExecutionSection aria-label="Scan execution results">
+      <ExecutionSummary>
+        <SummaryMetric>
+          <MetricLabel>Result rows</MetricLabel>
+          <MetricValue>{telemetry ? telemetry.rowsReturned : '—'}</MetricValue>
+        </SummaryMetric>
+        <SummaryMetric>
+          <MetricLabel>Sources read</MetricLabel>
+          <MetricValue>
+            {telemetry ? `${telemetry.sourcesRead}/${telemetry.sourcesPlanned}` : '—'}
+          </MetricValue>
+        </SummaryMetric>
+        <SummaryMetric>
+          <MetricLabel>Batches</MetricLabel>
+          <MetricValue>{telemetry ? telemetry.batchesRead : '—'}</MetricValue>
+        </SummaryMetric>
+        <SummaryMetric>
+          <MetricLabel>Execution</MetricLabel>
+          <MetricValue>{telemetry ? formatStatus(telemetry.status) : '—'}</MetricValue>
+        </SummaryMetric>
+      </ExecutionSummary>
+      <ResultsGrid>
+        <ResultCard>
+          <CardHeading>Explain plan</CardHeading>
+          <CardHint>Schema reconciliation and physical source capabilities.</CardHint>
+          <Details>
+            <summary>View plan JSON</summary>
+            <Code>{formatJson(results.explanation || {})}</Code>
+          </Details>
+        </ResultCard>
+        <ResultCard>
+          <CardHeading>Execution telemetry</CardHeading>
+          <CardHint>
+            {telemetry
+              ? `${telemetry.rowsRead} rows read · ${telemetry.rowsTested || 0} tested · ${telemetry.durationMilliseconds} ms`
+              : 'No execution yet.'}
+          </CardHint>
+          <Details>
+            <summary>View telemetry JSON</summary>
+            <Code>{formatJson(telemetry || {})}</Code>
+          </Details>
+        </ResultCard>
+        <ResultCard>
+          <CardHeading>Batch provenance</CardHeading>
+          <CardHint>Source order is preserved in every emitted Arrow batch.</CardHint>
+          <Provenance>
+            {results.provenance?.map((sourceId, index) => (
+              <span key={`${sourceId}-${index}`}>{sourceId}</span>
+            )) || 'No batches yet'}
+          </Provenance>
+        </ResultCard>
+      </ResultsGrid>
+    </ExecutionSection>
   );
+}
+
+/** Formats an execution status for the compact results summary. */
+function formatStatus(status: ScanExecutionTelemetry['status']): string {
+  return status.replace('-', ' ');
 }
 
 /** Parses a JSON object and reports a panel-specific validation error. */
@@ -405,12 +446,55 @@ const ResultsGrid = styled.div`
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
   gap: 10px;
 `;
+const ExecutionSection = styled.section`
+  display: grid;
+  gap: 10px;
+`;
+const ExecutionSummary = styled.div`
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 8px;
+`;
+const SummaryMetric = styled.div`
+  border: 1px solid #b2ddff;
+  border-radius: 6px;
+  padding: 9px;
+  background: #f0f9ff;
+`;
+const MetricLabel = styled.div`
+  color: #475467;
+  font-size: 0.72rem;
+`;
+const MetricValue = styled.div`
+  margin-top: 2px;
+  color: #175cd3;
+  font-size: 1rem;
+  font-weight: 700;
+  text-transform: capitalize;
+`;
 const ResultCard = styled.div`
   min-width: 0;
   border: 1px solid #d0d5dd;
   border-radius: 6px;
   padding: 10px;
   background: white;
+`;
+const CardHeading = styled.strong`
+  display: block;
+`;
+const CardHint = styled.div`
+  margin-top: 4px;
+  color: #667085;
+  font-size: 0.72rem;
+`;
+const Details = styled.details`
+  margin-top: 8px;
+  color: #475467;
+  font-size: 0.72rem;
+
+  summary {
+    cursor: pointer;
+  }
 `;
 const Code = styled.pre`
   max-height: 260px;

--- a/website/src/examples-sidebar.js
+++ b/website/src/examples-sidebar.js
@@ -26,6 +26,7 @@ const sidebars = {
       items: [
         'table/arrow',
         'table/arrow-scan',
+        'table/federated-scan',
         'table/parquet',
         'table/avro',
         'table/orc',

--- a/website/src/examples/index.mdx
+++ b/website/src/examples/index.mdx
@@ -21,6 +21,7 @@ Check the [loader catalog](/docs/modules/arrow/api-reference/arrow-loader) to se
   getThumbnail={item => {
     const thumbnails = {
       'table/arrow': '/images/examples/table/arrow.jpg',
+      'table/federated-scan': '/images/examples/table/arrow.jpg',
       'table/bson': '/images/examples/table/bson.jpg',
       'table/json': '/images/examples/table/json.svg',
       'table/xml': '/images/examples/table/xml.svg',

--- a/website/src/examples/table/federated-scan.mdx
+++ b/website/src/examples/table/federated-scan.mdx
@@ -1,0 +1,52 @@
+---
+title: "Federated scan"
+hide_title: true
+---
+
+import {FederatedScanLiveExample} from '@site/src/components/docs/federated-scan-live-example';
+
+<p className="badges">
+  <img src="https://img.shields.io/badge/From-v5.0-blue.svg?style=flat-square" alt="From-v5.0" />
+  <a href="/docs/developer-guide/common-scan-architecture">
+    <img src="https://img.shields.io/badge/Scan-Federation-2f855a.svg?style=flat-square" alt="Scan federation" />
+  </a>
+</p>
+
+# Federated scan
+
+This is the end-user path for combining compatible sources. The example registers CSV, NDJSON,
+and Arrow IPC sources with `DataSourceManager`, discovers their schemas, maps their physical names
+to one output schema, and executes one ordered `UNION ALL`-style scan.
+
+<FederatedScanLiveExample />
+
+## What to try
+
+- Move a source up or down to see that batch provenance follows the selected order.
+- Change the predicate parameter or projection and apply the query again.
+- Switch to the union schema policy to see how missing fields become typed nulls.
+- Expand the explain and telemetry panels to inspect planning and actual execution separately.
+
+The fixtures are intentionally tiny and local to the browser, so the example is deterministic and
+does not require a server, database ingestion, or credentials. The same immutable query shape is
+usable with remote Parquet, Iceberg, Delta, and application-owned sources.
+
+## The application pattern
+
+```ts
+const source = new FederatedTableScanSource(dataSourceManager, {
+  name: 'weather-history',
+  schemaPolicy: 'strict',
+  sources: [
+    {dataSourceId: 'recent', columnMapping: {station_id: 'stationId'}},
+    {dataSourceId: 'archive'}
+  ]
+});
+
+for await (const batch of source.read({columns: ['stationId', 'temperature'], limit: 100})) {
+  consumeArrowBatch(batch.data, batch.metadata);
+}
+```
+
+Use [the scan architecture guide](/docs/developer-guide/common-scan-architecture) for the
+portable semantics, support matrix, and format-specific pushdown behavior.


### PR DESCRIPTION
## Goals

Make the Scan 5.0 story discoverable and verifiable from the website first: give users a polished heterogeneous federation example, expose execution evidence in a readable form, and make format support visible from the format catalog.

## Changes

- add a dedicated `Federated scan` example and sidebar entry;
- demonstrate CSV, NDJSON, and Arrow IPC source discovery, explicit mappings, ordered append, named predicates, bounded Arrow output, explain, telemetry, and provenance;
- improve the shared federation panel with result metrics, execution status, accessible error/empty states, and expandable diagnostic JSON;
- add reset and pipeline guidance to the live example so the main workflow is easy to repeat;
- add consistent Scan-supported badges and concise support notes to Arrow, CSV, NDJSON, FlatGeobuf, and GeoPackage landing pages;
- link the architecture guide directly to the end-user example and reuse an existing thumbnail in the examples index.

## Validation

- `yarn lint fix`
- `yarn build`
- `cd website && yarn build` (passes; existing Docusaurus HTML-minifier/broken-link warnings remain in unrelated pages)
- `yarn test-node` — 372 passed, 6 skipped
- `yarn build-workers`
- `yarn test-headless` — 3291 passed, 39 skipped

This branch is intentionally stacked on `codex/scan-5-release-completion` so the website experience can be reviewed independently while the foundational runtime PR lands.
