### PR TITLE
fix(orc): write floating streams as raw bytes

### DIFF
--- a/modules/orc/src/lib/encoders/encode-orc.ts
+++ b/modules/orc/src/lib/encoders/encode-orc.ts
@@ -198,7 +198,7 @@ function encodeColumn(type: string, values: unknown[]): EncodedColumn {
     );
     return {
       typeKind,
-      streams: addPresentStream([{kind: 1, column: 0, bytes: encodeByteRLE(bytes)}])
+      streams: addPresentStream([{kind: 1, column: 0, bytes}])
     };
   }
   if (typeKind === ORC_TYPE.BOOLEAN) {

--- a/modules/orc/test/orc-loader.spec.ts
+++ b/modules/orc/test/orc-loader.spec.ts
@@ -556,6 +556,7 @@ function concatBytes(...arrays: Uint8Array[]): Uint8Array {
   return output;
 }
 
+/** Materializes an Arrow column as row values while preserving null entries. */
 function getColumnValues(table: arrow.Table, columnName: string): unknown[] {
   const vector = table.getChild(columnName);
   return Array.from({length: table.numRows}, (_value, index) => vector?.get(index));

--- a/modules/orc/test/orc-loader.spec.ts
+++ b/modules/orc/test/orc-loader.spec.ts
@@ -348,9 +348,15 @@ test('ORC writer round-trips primitive columns, nulls, and multiple stripes', as
   expect(result.shape).toBe('arrow-table');
   if (result.shape !== 'arrow-table') return;
   expect(result.data.numRows).toBe(3);
-  expect(result.data.getChild('enabled')?.toArray()).toEqual([true, false, null]);
-  expect(Array.from(result.data.getChild('count')?.toArray() || [])).toEqual([-50_000, 75_000, 0]);
-  expect(result.data.getChild('label')?.toArray()).toEqual(['repeat', 'repeat', null]);
+  expect(getColumnValues(result.data, 'enabled')).toEqual([true, false, null]);
+  expect(getColumnValues(result.data, 'tiny')).toEqual([-2, 3, null]);
+  expect(getColumnValues(result.data, 'small')).toEqual([300, -400, null]);
+  expect(getColumnValues(result.data, 'count')).toEqual([-50_000, 75_000, null]);
+  expect(getColumnValues(result.data, 'large')).toEqual([123_456, -654_321, null]);
+  expect(getColumnValues(result.data, 'ratio')).toEqual([1.25, -3.5, null]);
+  expect(getColumnValues(result.data, 'score')).toEqual([-2.5, 4.75, null]);
+  expect(getColumnValues(result.data, 'day')).toEqual([20_000, 20_001, null]);
+  expect(getColumnValues(result.data, 'label')).toEqual(['repeat', 'repeat', null]);
   expect(
     result.data
       .getChild('payload')
@@ -548,6 +554,11 @@ function concatBytes(...arrays: Uint8Array[]): Uint8Array {
     offset += array.length;
   }
   return output;
+}
+
+function getColumnValues(table: arrow.Table, columnName: string): unknown[] {
+  const vector = table.getChild(columnName);
+  return Array.from({length: table.numRows}, (_value, index) => vector?.get(index));
 }
 
 function encodeMessage(fields: Array<[number, number | string | Uint8Array]>): Uint8Array {


### PR DESCRIPTION
## Goals

- Correct the ORC floating-point stream encoding identified during review of #3909.
- Strengthen the primitive-column round-trip coverage so this wire-format regression cannot recur.

## Changes

- Write ORC `FLOAT` and `DOUBLE` data streams as raw little-endian IEEE bytes, as required by the ORC specification, instead of applying byte RLE.
- Assert every primitive column in the ORC writer round-trip test, including signed integers, floats, doubles, dates, strings, binary values, booleans, and nulls.

## Validation

- `yarn lint fix`
- `yarn test-audit`
- `yarn build`
- `yarn build-workers`
- `yarn test-node`
- `yarn test-headless`

Follow-up to #3909.
