### PR TITLE
feat(website): add capability-first docs heroes

### DIFF
--- a/docs/README.mdx
+++ b/docs/README.mdx
@@ -1,12 +1,19 @@
 import {FormatLogoGallery} from '@site/src/components/docs/format-logo-gallery';
+import {CapabilityHero} from '@site/src/components/docs/capability-hero';
 
 # Introduction
 
-:::info Start here
+<CapabilityHero capability="loaders" />
+
+## Explore formats
+
+<FormatLogoGallery />
+
+## Start here
+
 Choose the loader that matches your data and use the same small set of APIs to load, stream, or
 write it. Modules are independent, so applications install only the formats and capabilities they
 need.
-:::
 
 <img src="https://badge.fury.io/js/%40loaders.gl%2Fcore.svg" /> &nbsp;
 <img src="https://img.shields.io/badge/License-MIT-green.svg" /> &nbsp;
@@ -35,10 +42,6 @@ Docs for older versions are available on github:
     <i>loaders.gl is an OpenJS Foundation / Linux Foundation project.</i>
   </div>
 </div>
-
-## Supported File Formats
-
-<FormatLogoGallery />
 
 ## Overview
 

--- a/docs/developer-guide/apache-arrow.md
+++ b/docs/developer-guide/apache-arrow.md
@@ -1,10 +1,17 @@
+import {CapabilityHero} from '@site/src/components/docs/capability-hero';
+import {CategoryDataConcept} from '@site/src/components/home/concepts';
+
 # Apache Arrow
 
-:::info Start here
+<CapabilityHero capability="arrow" />
+
+<CategoryDataConcept initialCategoryId="table" initialRepresentationId="arrow" />
+
+## Start here
+
 Apache Arrow gives different tabular formats a shared, typed columnar shape. Use it when you want
 efficient transfer or the same processing code across formats; loaders that return other shapes do
 not require it.
-:::
 
 loaders.gl is adding support for Apache Arrow as its standard in-memory representation of tables.
 

--- a/docs/developer-guide/common-scan-architecture.md
+++ b/docs/developer-guide/common-scan-architecture.md
@@ -1,12 +1,19 @@
 import {FederatedScanLiveExample} from '@site/src/components/docs/federated-scan-live-example';
+import {CapabilityHero} from '@site/src/components/docs/capability-hero';
 
 # Common Scan Architecture
 
-:::info Start here
+<CapabilityHero capability="scan" />
+
+## Try a scan
+
+<FederatedScanLiveExample />
+
+## Start here
+
 Describe the data you need with bounds, selected columns, predicates, and limits. loaders.gl applies
 that request across supported local and cloud data sources; the planning details below matter only
 when you need to inspect or optimize execution.
-:::
 
 The loaders.gl common scan architecture is a portable query and execution model for columnar data.
 It allows an application to describe a small relational query once and execute it against an
@@ -911,12 +918,10 @@ Parallel scheduling, managed-source joins, optimizer-selected source order, sche
 distributed aggregation are explicit non-goals. The in-memory relational executor can still join
 or union already supplied Arrow tables; that is a separate materialized execution path.
 
-The browser example below registers real CSV, NDJSON, and Arrow IPC sources, discovers them without
+The interactive example near the top of this page registers real CSV, NDJSON, and Arrow IPC sources, discovers them without
 exposing the managed source objects, applies explicit mappings and a named predicate parameter,
 and shows both the plan and terminal execution telemetry. Source badges below the panel are the
 provenance attached to emitted Arrow batches.
-
-<FederatedScanLiveExample />
 
 ## Point-cloud participation
 

--- a/docs/developer-guide/coordinate-reference-systems.md
+++ b/docs/developer-guide/coordinate-reference-systems.md
@@ -1,10 +1,14 @@
+import {CapabilityHero} from '@site/src/components/docs/capability-hero';
+
 # Coordinate Reference Systems
 
-:::info Start here
+<CapabilityHero capability="crs" />
+
+## Start here
+
 CRS support keeps the meaning of coordinates attached to loaded data and makes coordinate
 transformations explicit. Most applications can preserve the source metadata first and add
 reprojection only where it is needed.
-:::
 
 Coordinate reference system (CRS) metadata tells an application how coordinates relate to the
 earth. Preserving that metadata is different from transforming coordinates. loaders.gl aims to

--- a/docs/developer-guide/loader-categories.md
+++ b/docs/developer-guide/loader-categories.md
@@ -1,10 +1,17 @@
+import {CapabilityHero} from '@site/src/components/docs/capability-hero';
+import {CategoryDataConcept} from '@site/src/components/home/concepts';
+
 # Loader Categories
 
-:::info Start here
+<CapabilityHero capability="categories" />
+
+<CategoryDataConcept />
+
+## Start here
+
 Choose a loader category when your application should accept several formats without separate code
 paths for each one. The category defines the common result shape, while each loader handles its own
 file format.
-:::
 
 To simplify working with multiple similar formats, loaders and writers in loaders.gl are grouped into _categories_.
 

--- a/docs/developer-guide/using-streaming-loaders.md
+++ b/docs/developer-guide/using-streaming-loaders.md
@@ -1,10 +1,17 @@
+import {CapabilityHero} from '@site/src/components/docs/capability-hero';
+import {StreamingConcept} from '@site/src/components/home/concepts';
+
 # Using Batched Loaders
 
-:::info Start here
+<CapabilityHero capability="streaming" />
+
+<StreamingConcept />
+
+## Start here
+
 Use a batched loader when data is too large to wait for or can be useful before the full download
 finishes. Process each batch with an ordinary `for await...of` loop; no separate streaming framework
 is required.
-:::
 
 A major feature of loaders.gl is the availability of a number of batched (or streaming) loaders.
 

--- a/docs/developer-guide/using-worker-loaders.md
+++ b/docs/developer-guide/using-worker-loaders.md
@@ -1,10 +1,14 @@
+import {CapabilityHero} from '@site/src/components/docs/capability-hero';
+
 # Using Worker Loaders
 
-:::info Start here
+<CapabilityHero capability="workers" />
+
+## Start here
+
 Worker-enabled loaders keep expensive parsing and decompression away from the browser's UI thread.
 For most applications, choose the loader normally and let loaders.gl manage its worker; the options
 below are available when you need more control.
-:::
 
 Most loaders.gl loaders can perform parsing on JavaScript worker threads.
 This means that the main thread will not block during parsing and can continue

--- a/website/src/components/docs/capability-hero.jsx
+++ b/website/src/components/docs/capability-hero.jsx
@@ -1,0 +1,54 @@
+import React from 'react';
+
+import {FEATURE_CARDS, RenderFeatureVisual} from '../home/features';
+import styles from './capability-hero.module.css';
+
+const TONE_COLORS = {
+  violet: {accent: '#9b8cff', glow: 'rgba(117, 95, 255, 0.35)'},
+  orange: {accent: '#ffb36b', glow: 'rgba(255, 133, 74, 0.32)'},
+  mint: {accent: '#75e0ba', glow: 'rgba(48, 198, 143, 0.25)'},
+  blue: {accent: '#70c7ff', glow: 'rgba(37, 137, 255, 0.3)'},
+  cyan: {accent: '#51e2f4', glow: 'rgba(0, 192, 230, 0.28)'},
+  pink: {accent: '#f693c6', glow: 'rgba(236, 86, 161, 0.28)'},
+  yellow: {accent: '#f0d877', glow: 'rgba(231, 177, 38, 0.28)'}
+};
+
+/**
+ * Renders the welcoming capability card shared by a homepage tentpole and its documentation page.
+ * @param {{capability: string}} props Component properties.
+ * @returns {React.ReactElement} The documentation capability hero.
+ */
+export function CapabilityHero({capability}) {
+  const feature = FEATURE_CARDS.find((candidate) => candidate.id === capability);
+
+  if (!feature) {
+    throw new Error(`Unknown capability hero: ${capability}`);
+  }
+
+  const colors = TONE_COLORS[feature.tone];
+
+  return (
+    <section
+      className={styles.hero}
+      style={{'--card-accent': colors.accent, '--card-glow': colors.glow}}
+      aria-label={`${feature.eyebrow}: ${feature.title}`}
+    >
+      <div className={styles.body}>
+        <p className={styles.eyebrow}>
+          {feature.eyebrow}
+          {feature.badge && <span className={styles.badge}>{feature.badge}</span>}
+        </p>
+        <h2 className={styles.title}>{feature.title}</h2>
+        <p className={styles.description}>{feature.description}</p>
+        <div className={styles.tags} aria-label="Capability highlights">
+          {feature.tags.map((tag) => (
+            <span className={styles.tag} key={tag}>
+              {tag}
+            </span>
+          ))}
+        </div>
+      </div>
+      <RenderFeatureVisual type={feature.visual} wide />
+    </section>
+  );
+}

--- a/website/src/components/docs/capability-hero.module.css
+++ b/website/src/components/docs/capability-hero.module.css
@@ -1,0 +1,114 @@
+.hero {
+  background: linear-gradient(145deg, rgba(26, 39, 56, 0.99), rgba(17, 27, 41, 0.98));
+  border: 1px solid rgba(172, 198, 217, 0.24);
+  border-radius: 24px;
+  box-shadow: 0 24px 64px rgba(13, 21, 33, 0.2);
+  color: #f4f8fb;
+  isolation: isolate;
+  margin: 1.5rem 0 2rem;
+  min-height: 310px;
+  overflow: hidden;
+  padding: 34px;
+  position: relative;
+}
+
+.hero::before {
+  background: radial-gradient(circle, var(--card-glow) 0%, transparent 68%);
+  content: '';
+  height: 460px;
+  pointer-events: none;
+  position: absolute;
+  right: -145px;
+  top: -190px;
+  width: 460px;
+  z-index: -1;
+}
+
+.body {
+  max-width: 52%;
+  position: relative;
+  z-index: 1;
+}
+
+.eyebrow {
+  align-items: center;
+  color: var(--card-accent);
+  display: flex;
+  flex-wrap: wrap;
+  font-size: 0.72rem;
+  font-weight: 800;
+  gap: 0.55rem;
+  letter-spacing: 0.13em;
+  line-height: 1.3;
+  margin: 0 0 0.9rem;
+  text-transform: uppercase;
+}
+
+.badge {
+  background: color-mix(in srgb, var(--card-accent) 14%, transparent);
+  border: 1px solid color-mix(in srgb, var(--card-accent) 54%, transparent);
+  border-radius: 999px;
+  color: #fff;
+  font-size: 0.52rem;
+  letter-spacing: 0.08em;
+  line-height: 1;
+  padding: 0.3rem 0.42rem;
+}
+
+.title {
+  color: #fff;
+  font-size: clamp(2rem, 4.5vw, 3.3rem);
+  font-weight: 800;
+  letter-spacing: -0.052em;
+  line-height: 0.98;
+  margin: 0 0 1rem;
+  max-width: 32rem;
+}
+
+.description {
+  color: rgba(229, 240, 247, 0.72);
+  font-size: 0.98rem;
+  line-height: 1.65;
+  margin: 0;
+  max-width: 34rem;
+}
+
+.tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  margin-top: 1.5rem;
+}
+
+.tag {
+  border: 1px solid rgba(206, 228, 240, 0.22);
+  border-radius: 999px;
+  color: rgba(229, 240, 247, 0.68);
+  font-size: 0.68rem;
+  font-weight: 700;
+  line-height: 1;
+  padding: 0.52rem 0.65rem;
+}
+
+@media (max-width: 760px) {
+  .hero {
+    min-height: 430px;
+    padding: 26px;
+  }
+
+  .body {
+    max-width: 100%;
+  }
+
+  .description {
+    max-width: 100%;
+  }
+}
+
+@media (max-width: 480px) {
+  .hero {
+    border-radius: 18px;
+    min-height: 440px;
+    padding: 22px;
+  }
+}

--- a/website/src/components/docs/federated-scan-live-example.tsx
+++ b/website/src/components/docs/federated-scan-live-example.tsx
@@ -107,9 +107,9 @@ export function FederatedScanLiveExample(): JSX.Element {
           sources: selectedSources,
           outputSchema: {
             fields: [
-              {name: 'stationId', type: 'utf8', nullable: false},
-              {name: 'temperature', type: 'float64', nullable: false},
-              {name: 'period', type: 'utf8', nullable: false}
+              {name: 'stationId', type: 'utf8', nullable: true},
+              {name: 'temperature', type: 'float64', nullable: true},
+              {name: 'period', type: 'utf8', nullable: true}
             ],
             metadata: {}
           }

--- a/website/src/components/home/concepts.jsx
+++ b/website/src/components/home/concepts.jsx
@@ -753,13 +753,187 @@ const Note = styled.div`
   padding: 14px 16px;
 `;
 
-/** Renders the homepage section that explains loaders.gl concept flows. */
-export default function Concepts() {
-  const [selectedCategoryId, setSelectedCategoryId] = useState(categoryTabs[0].id);
-  const [selectedRepresentationId, setSelectedRepresentationId] = useState(representationTabs[0].id);
+/**
+ * Renders the interactive loader-category decode/data/encode explorer.
+ * @param {{initialCategoryId?: string, initialRepresentationId?: string}} props Component properties.
+ */
+export function CategoryDataConcept({
+  initialCategoryId = categoryTabs[0].id,
+  initialRepresentationId = representationTabs[0].id
+} = {}) {
+  const [selectedCategoryId, setSelectedCategoryId] = useState(initialCategoryId);
+  const [selectedRepresentationId, setSelectedRepresentationId] = useState(initialRepresentationId);
   const selectedCategory = categoryTabs.find((category) => category.id === selectedCategoryId);
   const selectedRepresentation = selectedCategory.representations[selectedRepresentationId];
 
+  return (
+    <WidePanel>
+      <PanelHeader>
+        <PanelLabel>Category data</PanelLabel>
+        <PanelTitle>Load many formats into one application path.</PanelTitle>
+        <PanelText>
+          Category data lets related loaders return compatible structures, so rendering, analysis,
+          and export code can be shared.
+        </PanelText>
+      </PanelHeader>
+      <Diagram>
+        <TabRow>
+          <TabList role="tablist" aria-label="Loader category tabs">
+            {categoryTabs.map((category) => (
+              <TabButton
+                key={category.id}
+                type="button"
+                role="tab"
+                aria-selected={selectedCategory.id === category.id}
+                $active={selectedCategory.id === category.id}
+                onClick={() => setSelectedCategoryId(category.id)}
+              >
+                {category.label}
+              </TabButton>
+            ))}
+          </TabList>
+          <RepresentationTabs role="tablist" aria-label="Data representation tabs">
+            {representationTabs.map((representation) => (
+              <TabButton
+                key={representation.id}
+                type="button"
+                role="tab"
+                aria-selected={selectedRepresentationId === representation.id}
+                $active={selectedRepresentationId === representation.id}
+                onClick={() => setSelectedRepresentationId(representation.id)}
+              >
+                {representation.label}
+              </TabButton>
+            ))}
+          </RepresentationTabs>
+        </TabRow>
+        <Flow>
+          <ConceptColumn>
+            <StageLabel>Decode</StageLabel>
+            <LoaderGrid>
+              {selectedRepresentation.loaders.length > 0 ? (
+                selectedRepresentation.loaders.map((loader) => (
+                  <LinkedNode
+                    key={loader}
+                    to={loaderDocumentationLinks[loader]}
+                    $compactText={loader.length > 20}
+                  >
+                    <span>{loader}</span>
+                    <LinkMark aria-hidden="true">↗</LinkMark>
+                  </LinkedNode>
+                ))
+              ) : (
+                <EmptyNode>
+                  No {selectedRepresentationId === 'arrow' ? 'Arrow table' : 'plain'} loaders
+                </EmptyNode>
+              )}
+            </LoaderGrid>
+          </ConceptColumn>
+          <Connector />
+          <ConceptColumn>
+            <StageLabel>Data</StageLabel>
+            <DataCategoryNode
+              to={categoryDocumentationLinks[selectedCategory.id]}
+              $background="rgba(0, 173, 230, 0.12)"
+              $border="rgba(0, 173, 230, 0.55)"
+            >
+              <span>{selectedRepresentation.data}</span>
+              <NodeMeta>
+                <TinyLabel>{selectedRepresentation.detail}</TinyLabel>
+                <LinkMark aria-hidden="true">↗</LinkMark>
+              </NodeMeta>
+            </DataCategoryNode>
+          </ConceptColumn>
+          <Connector />
+          <ConceptColumn>
+            <StageLabel>Encode</StageLabel>
+            <WriterStack>
+              {selectedRepresentation.writers.length > 0 ? (
+                selectedRepresentation.writers.map((writer) => (
+                  <LinkedCategoryNode
+                    key={writer}
+                    to={writerDocumentationLinks[writer]}
+                    $compactText={writer.length > 20}
+                    $background="rgba(53, 173, 107, 0.12)"
+                    $border="rgba(53, 173, 107, 0.55)"
+                  >
+                    <span>{writer}</span>
+                    <LinkMark aria-hidden="true">↗</LinkMark>
+                  </LinkedCategoryNode>
+                ))
+              ) : (
+                <EmptyNode>
+                  No {selectedRepresentationId === 'arrow' ? 'Arrow table' : 'plain'} writers
+                </EmptyNode>
+              )}
+            </WriterStack>
+          </ConceptColumn>
+        </Flow>
+      </Diagram>
+    </WidePanel>
+  );
+}
+
+/** Renders the streaming loader pipeline used on the homepage and streaming guide. */
+export function StreamingConcept() {
+  return (
+    <WidePanel>
+      <PanelHeader>
+        <PanelLabel>Streaming loaders</PanelLabel>
+        <PanelTitle>Stream data in batches.</PanelTitle>
+        <PanelText>
+          Batched loaders let applications process results as bytes arrive, without holding a large
+          file in one string or ArrayBuffer.
+        </PanelText>
+      </PanelHeader>
+      <Diagram>
+        <StreamingFlow>
+          <ConceptColumn>
+            <StageLabel>Streaming loaders</StageLabel>
+            <LoaderGrid>
+              {streamingLoaders.map((loader) => (
+                <LinkedNode key={loader} to={loaderDocumentationLinks[loader]}>
+                  <span>{loader}</span>
+                  <LinkMark aria-hidden="true">↗</LinkMark>
+                </LinkedNode>
+              ))}
+            </LoaderGrid>
+          </ConceptColumn>
+          <Connector />
+          <ConceptColumn>
+            <StageLabel>Incremental processing</StageLabel>
+            <DataSourceNode $background="rgba(0, 173, 230, 0.1)" $border="rgba(0, 173, 230, 0.45)">
+              <span>Process while loading</span>
+              <MethodGrid>
+                {streamingProcessingBlocks.map((block) => (
+                  <CompactNode key={block}>{block}</CompactNode>
+                ))}
+              </MethodGrid>
+            </DataSourceNode>
+          </ConceptColumn>
+          <Connector />
+          <ConceptColumn>
+            <StageLabel>Batches</StageLabel>
+            <Stack>
+              {streamingOutputs.map((output) => (
+                <CategoryNode
+                  key={output}
+                  $background="rgba(53, 173, 107, 0.12)"
+                  $border="rgba(53, 173, 107, 0.55)"
+                >
+                  {output}
+                </CategoryNode>
+              ))}
+            </Stack>
+          </ConceptColumn>
+        </StreamingFlow>
+      </Diagram>
+    </WidePanel>
+  );
+}
+
+/** Renders the homepage section that explains loaders.gl concept flows. */
+export default function Concepts() {
   return (
     <ConceptsSection>
       <Content>
@@ -785,110 +959,7 @@ export default function Concepts() {
         </LinkBar>
 
         <PanelGrid>
-          <WidePanel>
-            <PanelHeader>
-              <PanelLabel>Category data</PanelLabel>
-              <PanelTitle>Load many formats into one application path.</PanelTitle>
-              <PanelText>
-                Category data lets related loaders return compatible structures, so rendering,
-                analysis, and export code can be shared.
-              </PanelText>
-            </PanelHeader>
-            <Diagram>
-              <TabRow>
-                <TabList role="tablist" aria-label="Loader category tabs">
-                  {categoryTabs.map((category) => (
-                    <TabButton
-                      key={category.id}
-                      type="button"
-                      role="tab"
-                      aria-selected={selectedCategory.id === category.id}
-                      $active={selectedCategory.id === category.id}
-                      onClick={() => setSelectedCategoryId(category.id)}
-                    >
-                      {category.label}
-                    </TabButton>
-                  ))}
-                </TabList>
-                <RepresentationTabs role="tablist" aria-label="Data representation tabs">
-                  {representationTabs.map((representation) => (
-                    <TabButton
-                      key={representation.id}
-                      type="button"
-                      role="tab"
-                      aria-selected={selectedRepresentationId === representation.id}
-                      $active={selectedRepresentationId === representation.id}
-                      onClick={() => setSelectedRepresentationId(representation.id)}
-                    >
-                      {representation.label}
-                    </TabButton>
-                  ))}
-                </RepresentationTabs>
-              </TabRow>
-              <Flow>
-                <ConceptColumn>
-                  <StageLabel>Decode</StageLabel>
-                  <LoaderGrid>
-                    {selectedRepresentation.loaders.length > 0 ? (
-                      selectedRepresentation.loaders.map((loader) => (
-                        <LinkedNode
-                          key={loader}
-                          to={loaderDocumentationLinks[loader]}
-                          $compactText={loader.length > 20}
-                        >
-                          <span>{loader}</span>
-                          <LinkMark aria-hidden="true">↗</LinkMark>
-                        </LinkedNode>
-                      ))
-                    ) : (
-                      <EmptyNode>
-                        No {selectedRepresentationId === 'arrow' ? 'Arrow table' : 'plain'} loaders
-                      </EmptyNode>
-                    )}
-                  </LoaderGrid>
-                </ConceptColumn>
-                <Connector />
-                <ConceptColumn>
-                  <StageLabel>Data</StageLabel>
-                  <DataCategoryNode
-                    to={categoryDocumentationLinks[selectedCategory.id]}
-                    $background="rgba(0, 173, 230, 0.12)"
-                    $border="rgba(0, 173, 230, 0.55)"
-                  >
-                    <span>{selectedRepresentation.data}</span>
-                    <NodeMeta>
-                      <TinyLabel>{selectedRepresentation.detail}</TinyLabel>
-                      <LinkMark aria-hidden="true">↗</LinkMark>
-                    </NodeMeta>
-                  </DataCategoryNode>
-                </ConceptColumn>
-                <Connector />
-                <ConceptColumn>
-                  <StageLabel>Encode</StageLabel>
-                  <WriterStack>
-                    {selectedRepresentation.writers.length > 0 ? (
-                      selectedRepresentation.writers.map((writer) => (
-                        <LinkedCategoryNode
-                          key={writer}
-                          to={writerDocumentationLinks[writer]}
-                          $compactText={writer.length > 20}
-                          $background="rgba(53, 173, 107, 0.12)"
-                          $border="rgba(53, 173, 107, 0.55)"
-                        >
-                          <span>{writer}</span>
-                          <LinkMark aria-hidden="true">↗</LinkMark>
-                        </LinkedCategoryNode>
-                      ))
-                    ) : (
-                      <EmptyNode>
-                        No {selectedRepresentationId === 'arrow' ? 'Arrow table' : 'plain'} writers
-                      </EmptyNode>
-                    )}
-                  </WriterStack>
-                </ConceptColumn>
-              </Flow>
-            </Diagram>
-          </WidePanel>
+          <CategoryDataConcept />
 
           <Panel>
             <PanelHeader>
@@ -952,58 +1023,7 @@ export default function Concepts() {
             </Diagram>
           </Panel>
 
-          <WidePanel>
-            <PanelHeader>
-              <PanelLabel>Streaming loaders</PanelLabel>
-              <PanelTitle>Stream data in batches.</PanelTitle>
-              <PanelText>
-                Batched loaders let applications process results as bytes arrive, without holding a
-                large file in one string or ArrayBuffer.
-              </PanelText>
-            </PanelHeader>
-            <Diagram>
-              <StreamingFlow>
-                <ConceptColumn>
-                  <StageLabel>Streaming loaders</StageLabel>
-                  <LoaderGrid>
-                    {streamingLoaders.map((loader) => (
-                      <LinkedNode key={loader} to={loaderDocumentationLinks[loader]}>
-                        <span>{loader}</span>
-                        <LinkMark aria-hidden="true">↗</LinkMark>
-                      </LinkedNode>
-                    ))}
-                  </LoaderGrid>
-                </ConceptColumn>
-                <Connector />
-                <ConceptColumn>
-                  <StageLabel>Incremental processing</StageLabel>
-                  <DataSourceNode $background="rgba(0, 173, 230, 0.1)" $border="rgba(0, 173, 230, 0.45)">
-                    <span>Process while loading</span>
-                    <MethodGrid>
-                      {streamingProcessingBlocks.map((block) => (
-                        <CompactNode key={block}>{block}</CompactNode>
-                      ))}
-                    </MethodGrid>
-                  </DataSourceNode>
-                </ConceptColumn>
-                <Connector />
-                <ConceptColumn>
-                  <StageLabel>Batches</StageLabel>
-                  <Stack>
-                    {streamingOutputs.map((output) => (
-                      <CategoryNode
-                        key={output}
-                        $background="rgba(53, 173, 107, 0.12)"
-                        $border="rgba(53, 173, 107, 0.55)"
-                      >
-                        {output}
-                      </CategoryNode>
-                    ))}
-                  </Stack>
-                </ConceptColumn>
-              </StreamingFlow>
-            </Diagram>
-          </WidePanel>
+          <StreamingConcept />
         </PanelGrid>
       </Content>
     </ConceptsSection>

--- a/website/src/components/home/features.jsx
+++ b/website/src/components/home/features.jsx
@@ -2,7 +2,8 @@ import React from 'react';
 import Link from '@docusaurus/Link';
 import styled from 'styled-components';
 
-const featureCards = [
+/** Homepage capability metadata shared with the corresponding documentation heroes. */
+export const FEATURE_CARDS = [
   {
     id: 'scan',
     eyebrow: 'Query architecture',
@@ -587,7 +588,7 @@ const CategoryNode = styled.span`
  * @param {{type: string, wide?: boolean}} props Component properties.
  * @returns {React.ReactElement} The selected feature visualization.
  */
-function RenderFeatureVisual({type, wide}) {
+export function RenderFeatureVisual({type, wide}) {
   if (type === 'scan') {
     return (
       <ScanVisual $wide={wide} aria-hidden="true">
@@ -733,7 +734,7 @@ export default function Features() {
         </FeatureIntro>
 
         <FeatureGrid>
-          {featureCards.map((feature) => (
+          {FEATURE_CARDS.map((feature) => (
             <FeatureCard key={feature.id} $tone={feature.tone} $wide={feature.wide}>
               <CardBody $wide={feature.wide}>
                 <CardEyebrow>

--- a/website/src/components/home/index.jsx
+++ b/website/src/components/home/index.jsx
@@ -20,8 +20,9 @@ export default function renderPage({HeroExample, children}) {
         <BannerContainer>
           <ProjectName>{siteConfig.title}</ProjectName>
           <TagLine>{siteConfig.tagline}</TagLine>
-          <GetStartedLink href="./docs/developer-guide/get-started" >
-            GET STARTED
+          <GetStartedLink href="./docs/developer-guide/get-started">
+            <span>Get started</span>
+            <span aria-hidden="true">→</span>
           </GetStartedLink>
         </BannerContainer>
       </Banner>

--- a/website/src/components/home/styled.js
+++ b/website/src/components/home/styled.js
@@ -89,36 +89,54 @@ export const TagLine = styled.p`
 `;
 
 export const GetStartedLink = styled.a`
-  pointer-events: all;
+  align-items: center;
   background: var(--ifm-color-primary);
   border: 1px solid var(--ifm-color-primary);
   border-radius: 999px;
-  color: var(--ifm-color-white);
-  font-size: 12px;
-  line-height: 1;
-  letter-spacing: 0.12em;
+  color: #ffffff;
+  display: inline-flex;
+  font-size: 13px;
   font-weight: bold;
-  margin: 24px 0;
-  padding: 15px 22px;
+  gap: 10px;
+  justify-content: center;
+  letter-spacing: 0.04em;
+  line-height: 1;
+  margin: 24px 0 0;
+  min-height: 44px;
+  padding: 0 20px;
   pointer-events: all;
-  display: inline-block;
+  position: relative;
   text-decoration: none;
+  text-shadow: none;
+  width: fit-content;
+  z-index: 1;
   transition:
     background-color 180ms ease-in,
     border-color 180ms ease-in,
     color 180ms ease-in,
     transform 180ms ease-in;
+
+  && {
+    color: #ffffff;
+  }
+
   &:visited {
-    color: var(--ifm-color-white);
+    color: #ffffff;
   }
   &:active {
-    color: var(--ifm-color-white);
+    color: #ffffff;
   }
   &:hover {
-    color: var(--ifm-color-white);
+    color: #ffffff;
     background-color: transparent;
     border-color: rgba(255, 255, 255, 0.7);
     text-decoration: none;
     transform: translateY(-2px);
+  }
+
+  > span {
+    color: #ffffff;
+    display: block;
+    position: relative;
   }
 `;


### PR DESCRIPTION
## Goals

- Make each homepage tentpole link lead to a welcoming, visually consistent destination.
- Put interactive explanations and plain-language orientation before detailed reference material.
- Repair the homepage CTA styling and ensure the promoted scan demo succeeds by default.

## Changes

- Added a reusable capability hero that shares homepage card metadata and illustrations.
- Added capability heroes to format coverage, Scan, streaming, workers, Apache Arrow, loader categories, and CRS pages.
- Reused the format gallery, category explorer, streaming flow, Arrow/category explorer, and federated scan panel ahead of each page's introductory prose.
- Extracted the category and streaming concept panels so the homepage and documentation pages use the same interactive components.
- Changed the federated scan example's declared output fields to nullable so its heterogeneous default sources produce results instead of opening in a failed state.
- Restyled the homepage Get started CTA with an explicit label, arrow, dimensions, and foreground specificity.

## Verification

- `yarn lint fix`
- `cd website && yarn build`
- Browser-verified the homepage CTA and the Loader Categories and Common Scan Architecture pages.
- Browser-verified the Loader Categories page at 480 px with no horizontal overflow.
- Confirmed the default federated scan example produces three rows.

The website build still reports the two pre-existing relative-link warnings on the I3S profile-gallery page.
