### PR TITLE
feat(scan): add experimental async execution path

### DIFF
--- a/docs/modules/scan/README.md
+++ b/docs/modules/scan/README.md
@@ -110,6 +110,20 @@ const result = engine.query(table, {
 });
 ```
 
+For backends that schedule asynchronous or compiled work, use the experimental `queryAsync()`
+path. The built-in Arrow backend supports it, and synchronous custom backends receive an automatic
+compatibility wrapper:
+
+```ts
+const result = await engine.queryAsync(table, {
+  predicate: parseSQLPredicate("status = 'active'"),
+  limit: 100
+});
+```
+
+This remains an Arrow-in/Arrow-out boundary. GPU graph compilation and GPU-resident result
+ownership are backend-specific and are not implied by `queryAsync()`.
+
 The query is immutable and follows `filter -> project -> limit` semantics. Predicate columns do not
 need to appear in the result projection, and a limit counts only rows that survive filtering.
 

--- a/modules/lance/src/lance-loader-types.ts
+++ b/modules/lance/src/lance-loader-types.ts
@@ -2,18 +2,18 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import type {Loader} from '@loaders.gl/loader-utils';
+import type {Loader, LoaderOptions} from '@loaders.gl/loader-utils';
 import type {ArrowTable, ArrowTableBatch} from '@loaders.gl/schema';
 
 import {LanceFormat} from './lance-format';
 import type {LanceFlatPrimitiveType} from './lance-decoder';
 
 /** Options for the read-only Lance loader. */
-export type LanceLoaderOptions = {
+export type LanceLoaderOptions = LoaderOptions & {
   lance?: {
-    /** Columns to project into the returned table. */
+    /** Columns to project into the returned table. (Physical projection is not yet part of `_scan`.) */
     columns?: string[];
-    /** Maximum number of rows to return. */
+    /** @deprecated Use `_scan.limit` instead. */
     limit?: number;
     /** Primitive type for each physical column in the MVP reader. */
     columnTypes?: LanceFlatPrimitiveType[];

--- a/modules/lance/src/lance-loader.ts
+++ b/modules/lance/src/lance-loader.ts
@@ -16,6 +16,7 @@ export const LanceLoaderWithParser = {
   ...LanceLoaderMetadata,
   parse(_arrayBuffer: ArrayBuffer, _options?: LanceLoaderOptions): Promise<ArrowTable> {
     const lanceOptions = _options?.lance;
+    const scanOptions = _options?._scan;
     if (!lanceOptions?.columnTypes) {
       return Promise.reject(new LanceDecoderUnavailableError());
     }
@@ -24,7 +25,7 @@ export const LanceLoaderWithParser = {
       parseLanceFileToArrow(_arrayBuffer, {
         columnTypes,
         columnNames: lanceOptions.columnNames,
-        limit: lanceOptions.limit
+        limit: scanOptions?.limit ?? lanceOptions.limit
       })
     );
   },

--- a/modules/loader-utils/src/index.ts
+++ b/modules/loader-utils/src/index.ts
@@ -43,6 +43,8 @@ export type {
   LoaderArrayBatchType
 } from './loader-types';
 
+export type {ExperimentalScanOptions} from './lib/scan-utils/experimental-scan-options';
+
 export {parseFromContext, parseSyncFromContext, parseInBatchesFromContext} from './loader-types';
 
 // writers

--- a/modules/loader-utils/src/lib/scan-utils/experimental-scan-options.ts
+++ b/modules/loader-utils/src/lib/scan-utils/experimental-scan-options.ts
@@ -1,0 +1,46 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {ColumnarPredicate} from './columnar-predicate';
+import type {ScanBounds, ScanExecutionTelemetryCallback} from './scan-query-metadata';
+
+/**
+ * Experimental common scan request accepted by loaders that implement the scan protocol.
+ *
+ * Format loaders apply the fields relevant to their query family and must reject unsupported
+ * fields rather than silently ignoring them. This intentionally remains a common superset in 5.0
+ * so applications and Deck.gl adapters can forward one stable option object.
+ */
+export type ExperimentalScanOptions = Readonly<{
+  /** Portable predicate for table-like sources. */
+  predicate?: ColumnarPredicate;
+  /** Output columns or bands selected by the caller. */
+  columns?: readonly string[];
+  /** Maximum number of rows or points retained after filtering. */
+  limit?: number;
+  /** Cooperative cancellation signal. */
+  signal?: AbortSignal;
+  /** Receives one terminal execution snapshot without changing query semantics. */
+  onTelemetry?: ScanExecutionTelemetryCallback;
+  /** Source-coordinate bounds for spatial, raster, and point-cloud scans. */
+  bounds?: ScanBounds;
+  /** Raster overview or point-cloud hierarchy level. */
+  level?: number;
+  /** Shallowest point-cloud hierarchy level to read. */
+  minimumLevel?: number;
+  /** Deepest point-cloud hierarchy level to read. */
+  maximumLevel?: number;
+  /** Desired maximum point spacing for point-cloud scans. */
+  targetSpacing?: number;
+  /** Requested raster output width in pixels. */
+  width?: number;
+  /** Requested raster output height in pixels. */
+  height?: number;
+  /** Named raster variables or bands. */
+  variables?: readonly string[];
+  /** Numeric raster channel indices. */
+  channels?: readonly number[];
+  /** Raster dimension indices or half-open ranges. */
+  slices?: Readonly<Record<string, number | readonly [number, number]>>;
+}>;

--- a/modules/loader-utils/src/loader-types.ts
+++ b/modules/loader-utils/src/loader-types.ts
@@ -7,6 +7,7 @@ import {FetchLike, TransformBatches} from './types';
 import {ReadableFile} from './lib/files/file';
 import type {CoreAPI} from './lib/sources/data-source';
 import type {RequestCredential} from './lib/request-utils/request-credentials';
+import type {ExperimentalScanOptions} from './lib/scan-utils/experimental-scan-options';
 
 // LOADERS
 
@@ -14,6 +15,8 @@ import type {RequestCredential} from './lib/request-utils/request-credentials';
  * Core Loader Options
  */
 export type StrictLoaderOptions = {
+  /** Experimental common scan request. Format loaders implement the fields they support. */
+  _scan?: ExperimentalScanOptions;
   core?: {
     /** Base URL for resolving relative paths */
     baseUrl?: string;
@@ -88,6 +91,8 @@ export type StrictLoaderOptions = {
  * Core Loader Options
  */
 export type LoaderOptions = {
+  /** Experimental common scan request. Format loaders implement the fields they support. */
+  _scan?: ExperimentalScanOptions;
   core?: StrictLoaderOptions['core'];
   modules?: StrictLoaderOptions['modules'];
 

--- a/modules/parquet/src/lib/utils/normalize-parquet-options.ts
+++ b/modules/parquet/src/lib/utils/normalize-parquet-options.ts
@@ -7,8 +7,17 @@ export function normalizeParquetOptions<OptionsT extends {parquet?: unknown}>(
   options: OptionsT | undefined,
   parquetDefaults: Record<string, unknown>
 ): OptionsT {
+  const scanOptions = (
+    options as {_scan?: {columns?: readonly string[]; limit?: number}} | undefined
+  )?._scan;
+  const parquetOptions = (options?.parquet as Record<string, unknown> | undefined) || {};
   return {
     ...options,
-    parquet: {...parquetDefaults, ...(options?.parquet as Record<string, unknown> | undefined)}
+    parquet: {
+      ...parquetDefaults,
+      ...parquetOptions,
+      ...(scanOptions?.columns !== undefined ? {columns: [...scanOptions.columns]} : {}),
+      ...(scanOptions?.limit !== undefined ? {limit: scanOptions.limit} : {})
+    }
   } as unknown as OptionsT;
 }

--- a/modules/parquet/src/lib/utils/normalize-parquet-options.ts
+++ b/modules/parquet/src/lib/utils/normalize-parquet-options.ts
@@ -10,6 +10,13 @@ export function normalizeParquetOptions<OptionsT extends {parquet?: unknown}>(
   const scanOptions = (
     options as {_scan?: {columns?: readonly string[]; limit?: number}} | undefined
   )?._scan;
+  if (scanOptions) {
+    for (const key of Object.keys(scanOptions)) {
+      if (key !== 'columns' && key !== 'limit') {
+        throw new Error(`Parquet _scan option "${key}" is not supported`);
+      }
+    }
+  }
   const parquetOptions = (options?.parquet as Record<string, unknown> | undefined) || {};
   return {
     ...options,

--- a/modules/parquet/src/parquet-loader-options.ts
+++ b/modules/parquet/src/parquet-loader-options.ts
@@ -7,9 +7,11 @@ import type {ParquetKeyRetriever} from './lib/parquet-encryption';
 
 /** Shared row-level options supported by both Parquet backends. */
 type ParquetCommonLoaderOptions = {
+  /** @deprecated Use `_scan.limit` instead. */
   limit?: number;
   offset?: number;
   batchSize?: number;
+  /** @deprecated Use `_scan.columns` instead for logical projection. */
   columns?: string[];
   preserveBinary?: boolean;
   /** Decode legacy INT96 values as Arrow timestamp-nanosecond values. */

--- a/modules/scan/README.md
+++ b/modules/scan/README.md
@@ -16,6 +16,19 @@ const result = engine.query(table, {
 });
 ```
 
+The experimental asynchronous path is available on the same engine. It preserves the result
+semantics while allowing a registered backend to schedule remote or compiled work:
+
+```typescript
+const result = await engine.queryAsync(table, {
+  predicate: parseSQLPredicate('population >= 1000000'),
+  limit: 100
+});
+```
+
+Synchronous backends are wrapped automatically. GPU backends may use this boundary as a staging
+point, but GPU graph compilation and resource ownership remain backend-specific.
+
 Optional backends can register a lazy loader without adding backend-specific imports to application
 code:
 

--- a/modules/scan/src/scan-engine.ts
+++ b/modules/scan/src/scan-engine.ts
@@ -86,10 +86,11 @@ export async function createScanEngine(options: ScanEngineOptions = {}): Promise
       `Scan backend loader returned "${backend.name}" while "${backendName}" was requested.`
     );
   }
-  return Object.freeze({
-    ...backend,
-    queryAsync:
-      backend.queryAsync ||
-      (async (sourceTable, queryOptions) => backend.query(sourceTable, queryOptions))
-  });
+  const query = backend.query.bind(backend);
+  const explain = backend.explain.bind(backend);
+  const queryAsync = backend.queryAsync
+    ? backend.queryAsync.bind(backend)
+    : async (sourceTable: ArrowTable, queryOptions?: ArrowQueryOptions) =>
+        backend.query.call(backend, sourceTable, queryOptions);
+  return Object.freeze({...backend, query, explain, queryAsync});
 }

--- a/modules/scan/src/scan-engine.ts
+++ b/modules/scan/src/scan-engine.ts
@@ -20,6 +20,8 @@ export type ScanBackend = Readonly<{
   name: ScanBackendName;
   /** Executes a query over one in-memory Arrow table. */
   query(sourceTable: ArrowTable, options?: ArrowQueryOptions): ArrowTable;
+  /** Optional asynchronous execution hook for backends that compile or schedule work. */
+  queryAsync?: (sourceTable: ArrowTable, options?: ArrowQueryOptions) => Promise<ArrowTable>;
   /** Explains a query without evaluating table rows. */
   explain(sourceTable: ArrowTable, options?: ArrowQueryOptions): TableQueryExplain<SQLPredicate>;
 }>;
@@ -34,13 +36,17 @@ export type ScanEngineOptions = Readonly<{
 }>;
 
 /** Stable application-facing scan engine returned by {@link createScanEngine}. */
-export type ScanEngine = ScanBackend;
+export type ScanEngine = ScanBackend & {
+  /** Executes a query asynchronously, allowing backends to schedule remote or compiled work. */
+  queryAsync: (sourceTable: ArrowTable, options?: ArrowQueryOptions) => Promise<ArrowTable>;
+};
 
 const scanBackendLoaders = new Map<ScanBackendName, ScanBackendLoader>();
 
 const arrowScanBackend: ScanBackend = Object.freeze({
   name: 'arrow',
   query: queryArrowTable,
+  queryAsync: async (sourceTable, options) => queryArrowTable(sourceTable, options),
   explain: explainArrowTableQuery
 });
 
@@ -80,5 +86,10 @@ export async function createScanEngine(options: ScanEngineOptions = {}): Promise
       `Scan backend loader returned "${backend.name}" while "${backendName}" was requested.`
     );
   }
-  return backend;
+  return Object.freeze({
+    ...backend,
+    queryAsync:
+      backend.queryAsync ||
+      (async (sourceTable, queryOptions) => backend.query(sourceTable, queryOptions))
+  });
 }

--- a/modules/scan/test/scan-engine.spec.ts
+++ b/modules/scan/test/scan-engine.spec.ts
@@ -24,6 +24,9 @@ test('creates the Arrow reference engine by default', async () => {
   expect(engine.name).toBe('arrow');
   expect(result.data.schema.fields.map(field => field.name)).toEqual(['name']);
   expect(result.data.toArray().map(row => row?.toJSON())).toEqual([{name: 'b'}]);
+
+  const asyncResult = await engine.queryAsync(makeArrowTable({value: [1, 2]}), {limit: 1});
+  expect(asyncResult.data.numRows).toBe(1);
 });
 
 test('exposes the shared metadata vocabulary from the optional scan package', () => {
@@ -60,6 +63,7 @@ test('loads a registered backend through the same root API', async () => {
 
   expect(engine.name).toBe('test');
   expect(engine.query(table)).toBe(table);
+  await expect(engine.queryAsync(table)).resolves.toBe(table);
 });
 
 test('validates backend registrations and loader names', async () => {

--- a/modules/scan/test/scan-engine.spec.ts
+++ b/modules/scan/test/scan-engine.spec.ts
@@ -66,6 +66,25 @@ test('loads a registered backend through the same root API', async () => {
   await expect(engine.queryAsync(table)).resolves.toBe(table);
 });
 
+test('preserves prototype methods and receiver when loading class backends', async () => {
+  class ClassBackend {
+    readonly name = 'class-backend' as const;
+    readonly prefix = 'class';
+    query(sourceTable: ArrowTable) {
+      if (this.prefix !== 'class') throw new Error('backend receiver was lost');
+      return sourceTable;
+    }
+    explain() {
+      return {} as never;
+    }
+  }
+  registerScanBackend('class-backend', () => new ClassBackend());
+  const engine = await createScanEngine({backend: 'class-backend'});
+  const table = makeArrowTable({value: [1]});
+  expect(engine.query(table)).toBe(table);
+  await expect(engine.queryAsync(table)).resolves.toBe(table);
+});
+
 test('validates backend registrations and loader names', async () => {
   expect(() => registerScanBackend('' as never, () => ({}) as never)).toThrow(
     'A scan backend name and loader are required'


### PR DESCRIPTION
## Goals

Provide an asynchronous scan execution entry point for remote and compiled backends while keeping the existing synchronous Arrow API compatible.

## Changes

- Add the experimental `_scan` common loader option vocabulary.
- Migrate safe Parquet and Lance row-query options so `_scan` takes precedence.
- Add `ScanBackend.queryAsync()` and a guaranteed `ScanEngine.queryAsync()` method.
- Preserve synchronous custom backends through an automatic async wrapper.
- Add focused coverage for built-in and registered backends.

## Verification

- `yarn lint fix`
- `yarn test-headless modules/scan/test/scan-engine.spec.ts` (6 tests passed)
- `yarn build`,