### PR TITLE
feat(arrow): support compressed Feather IPC

### DIFF
--- a/docs/modules/arrow/api-reference/arrow-writer.md
+++ b/docs/modules/arrow/api-reference/arrow-writer.md
@@ -43,7 +43,8 @@ import {WriterPipelineGraphic} from '@site/src/components/docs/writer-pipeline-g
   <img src="https://img.shields.io/badge/From-v3.0-blue.svg?style=flat-square" alt="From-v3.0" />
 </p>
 
-The `ArrowWriter` encodes a set of arrays into an ArrayBuffer of Apache Arrow columnar format.
+The `ArrowWriter` encodes a set of arrays into an Apache Arrow IPC stream or file. The file
+container is Feather V2 and can optionally use LZ4-frame or Zstandard embedded buffer compression.
 
 <ReferenceBoundary
   title="ArrowWriter options and shapes"
@@ -76,11 +77,38 @@ const arraysData = [
 const arrayBuffer = encodeSync(arraysData, ArrowWriter);
 ```
 
+To write a compressed Feather V2 file:
+
+```typescript
+import {encode} from '@loaders.gl/core';
+import {ZstdCodec} from 'zstd-codec';
+
+const featherBuffer = await encode(arraysData, ArrowWriter, {
+  modules: {'zstd-codec': ZstdCodec},
+  arrow: {
+    container: 'file',
+    compression: 'zstd'
+  }
+});
+```
+
+LZ4 compression supports `encodeSync` without an injected module. Zstandard compression uses
+asynchronous `encode` and an injected `zstd-codec` module so its codec can be initialized without
+adding the large optional encoder to every Arrow browser bundle.
+
 ## Options
 
-`ArrowWriter` does not currently define format-specific options. The input arrays determine the
-Arrow field names and types; use the exported `VECTOR_TYPES` constants when constructing the input.
+| Option | Type | Default | Description |
+| ------ | ---- | ------- | ----------- |
+| `arrow.container` | `'stream'` \| `'file'` | `'stream'` | Selects the Arrow IPC stream or file container. Feather V2 uses `'file'`. |
+| `arrow.compression` | `null` \| `'lz4'` \| `'zstd'` | `null` | Selects embedded record-batch buffer compression. Compression requires Apache Arrow JS 21.2 or later. |
+
+The input arrays determine the Arrow field names and types; use the exported `VECTOR_TYPES`
+constants when constructing the input.
 
 ## Dependencies
 
 [Apache Arrow JS](https://arrow.apache.org/docs/js/) library is included into the bundle.
+
+Install [`zstd-codec`](https://www.npmjs.com/package/zstd-codec) when writing Zstandard-compressed
+IPC data. Decoding Zstandard data and reading or writing LZ4 data require no additional package.

--- a/docs/modules/arrow/format.md
+++ b/docs/modules/arrow/format.md
@@ -57,7 +57,7 @@ import {DocOrientation, ReferenceBoundary} from '@site/src/components/docs/desig
 | Loader APIs          | `load`, `parse`, `parseSync`, `parseInBatches`                                             |
 | Loader Worker Thread | Yes                                                                                        |
 | Loader Streaming     | Yes                                                                                        |
-| Writer APIs          | `encodeSync`                                                                               |
+| Writer APIs          | `encode`, `encodeSync`                                                                     |
 
 ## Loaders and Writers
 
@@ -81,13 +81,49 @@ import {DocOrientation, ReferenceBoundary} from '@site/src/components/docs/desig
     <strong>ArrowWriter</strong>
     <span>Writes arrays as Apache Arrow IPC data.</span>
     <span className="docs-api-card__meta">Input: arrays</span>
-    <span className="docs-api-card__meta">APIs: encodeSync</span>
+    <span className="docs-api-card__meta">APIs: encode, encodeSync</span>
   </a>
 </div>
 
 ## IPC
 
 `ArrowLoader` reads Apache Arrow IPC file and stream data. IPC streams can be parsed in batches with `parseInBatches`.
+
+Feather V2 is the Arrow IPC file format with a `.feather` extension. Feather V1 is a different
+legacy format and is not supported.
+
+### Format capabilities
+
+| Capability | Arrow IPC stream | Arrow IPC file | Feather V2 | Feather V1 |
+| --- | :---: | :---: | :---: | :---: |
+| Decode complete table | ✅ | ✅ | ✅ | ❌ |
+| Decode record batches | ✅ | ✅ | ✅ | ❌ |
+| Decode in a worker | ✅ | ✅ | ✅ | ❌ |
+| Decode uncompressed data with Apache Arrow JS 17+ | ✅ | ✅ | ✅ | ❌ |
+| Decode LZ4-frame buffer compression with Apache Arrow JS 21.2+ | ✅ | ✅ | ✅ | ❌ |
+| Decode Zstandard buffer compression with Apache Arrow JS 21.2+ | ✅ | ✅ | ✅ | ❌ |
+| Encode with `ArrowWriter` | ✅ | ✅ | ✅ | ❌ |
+| Encode LZ4-frame buffer compression with Apache Arrow JS 21.2+ | ✅ | ✅ | ✅ | ❌ |
+| Encode Zstandard buffer compression with Apache Arrow JS 21.2+ | ✅¹ | ✅¹ | ✅¹ | ❌ |
+
+¹ Zstandard encoding uses asynchronous `encode()` so its codec can be initialized. LZ4 and
+uncompressed output support both `encode()` and `encodeSync()`.
+
+### Embedded compression
+
+Arrow IPC defines exactly two embedded record-batch buffer compression codecs. `ArrowLoader`
+supports both:
+
+| Codec | Decode | Encode | Notes |
+| --- | :---: | :---: | --- |
+| LZ4 Frame (`LZ4_FRAME`) | ✅ | ✅ | Each compressed buffer contains one LZ4 frame. |
+| Zstandard (`ZSTD`) | ✅ | ✅¹ | Standard Zstandard frame compression. |
+
+Individual buffers that a Feather writer leaves uncompressed because compression would not reduce
+their size are also supported. The codecs are registered only when the installed Apache Arrow JS
+runtime exposes IPC compression support (version 21.2.0 or later). Apache Arrow JS 17 through 21.1
+remain supported for uncompressed IPC data and report a targeted version requirement when a
+compressed record batch is encountered.
 
 ## GeoArrow
 

--- a/modules/arrow/package.json
+++ b/modules/arrow/package.json
@@ -77,6 +77,7 @@
     "build-worker2": "esbuild src/workers/arrow-worker.ts --bundle --outfile=dist/arrow-worker.js --platform=browser --external:{stream}"
   },
   "dependencies": {
+    "@loaders.gl/compression": "5.0.0-alpha.2",
     "@loaders.gl/gis": "5.0.0-alpha.2",
     "@loaders.gl/loader-utils": "5.0.0-alpha.2",
     "@loaders.gl/schema": "5.0.0-alpha.2",
@@ -84,7 +85,8 @@
     "@loaders.gl/wkt": "5.0.0-alpha.2",
     "@loaders.gl/worker-utils": "5.0.0-alpha.2",
     "@math.gl/polygon": "4.2.0-alpha.6",
-    "apache-arrow": ">= 17.0.0"
+    "apache-arrow": ">= 17.0.0",
+    "lz4js": "^0.2.0"
   },
   "peerDependencies": {
     "@loaders.gl/core": "~5.0.0-alpha.0"

--- a/modules/arrow/src/arrow-writer.ts
+++ b/modules/arrow/src/arrow-writer.ts
@@ -6,25 +6,44 @@
 
 import type {WriterWithEncoder, WriterOptions} from '@loaders.gl/loader-utils';
 import {ColumnarTable, encodeArrowSync} from './lib/encoders/encode-arrow';
+import {
+  preloadArrowCompressionEncoder,
+  type ArrowIPCCompression
+} from './lib/parsers/arrow-compression';
 import {ArrowFormat} from './exports/arrow-format';
 
 // __VERSION__ is injected by babel-plugin-version-inline
 // @ts-ignore TS2304: Cannot find name '__VERSION__'.
 const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
 
-type ArrowWriterOptions = WriterOptions & {
-  arrow?: {};
+/** Options for Arrow IPC stream and file encoding. */
+export type ArrowWriterOptions = WriterOptions & {
+  arrow?: {
+    /** Arrow IPC container. Feather V2 uses the `file` container. */
+    container?: 'stream' | 'file';
+    /** Optional embedded record-batch buffer compression. */
+    compression?: ArrowIPCCompression | null;
+  };
 };
 
 /** Apache Arrow writer */
 export const ArrowWriter = {
   ...ArrowFormat,
   version: VERSION,
-  options: {},
+  options: {
+    arrow: {
+      container: 'stream',
+      compression: null
+    }
+  },
   encode: async function encodeArrow(data, options?): Promise<ArrayBuffer> {
-    return encodeArrowSync(data);
+    const arrowOptions = options?.arrow;
+    if (arrowOptions?.compression) {
+      await preloadArrowCompressionEncoder(arrowOptions.compression, options?.modules);
+    }
+    return encodeArrowSync(data, arrowOptions);
   },
   encodeSync(data, options?) {
-    return encodeArrowSync(data);
+    return encodeArrowSync(data, options?.arrow);
   }
 } as const satisfies WriterWithEncoder<ColumnarTable, never, ArrowWriterOptions>;

--- a/modules/arrow/src/index.ts
+++ b/modules/arrow/src/index.ts
@@ -14,7 +14,7 @@ export type {ArrowLoaderOptions} from './exports/arrow-loader';
 export {ArrowLoader} from './arrow-loader';
 export {ArrowSourceLoader, ArrowTableSource} from './arrow-source';
 
-export {ArrowWriter} from './arrow-writer';
+export {ArrowWriter, type ArrowWriterOptions} from './arrow-writer';
 export type {
   ArrowConvertFromOptions,
   ArrowConvertToOptions

--- a/modules/arrow/src/lib/encoders/encode-arrow.ts
+++ b/modules/arrow/src/lib/encoders/encode-arrow.ts
@@ -5,6 +5,16 @@
 import * as arrow from 'apache-arrow';
 import {AnyArrayType, VECTOR_TYPES} from '../types';
 import {ensureArrayBuffer} from '@loaders.gl/loader-utils';
+import {
+  registerArrowCompressionEncoderSync,
+  type ArrowIPCCompression
+} from '../parsers/arrow-compression';
+
+/** Options controlling the Arrow IPC container and embedded buffer compression. */
+export type EncodeArrowOptions = {
+  container?: 'stream' | 'file';
+  compression?: ArrowIPCCompression | null;
+};
 
 export type ColumnarTable = {
   name: string;
@@ -19,14 +29,29 @@ export type ColumnarTable = {
  * @param options - the writer options
  * @returns - encoded ArrayBuffer
  */
-export function encodeArrowSync(data: ColumnarTable): ArrayBuffer {
+export function encodeArrowSync(
+  data: ColumnarTable,
+  options: EncodeArrowOptions = {}
+): ArrayBuffer {
   const vectors: Record<string, arrow.Vector> = {};
   for (const arrayData of data) {
     const arrayVector = createVector(arrayData.array, arrayData.type);
     vectors[arrayData.name] = arrayVector;
   }
   const table = new arrow.Table(vectors);
-  const arrowBuffer = arrow.tableToIPC(table);
+  const container = options.container || 'stream';
+  const compressionType = options.compression
+    ? registerArrowCompressionEncoderSync(options.compression)
+    : null;
+  const tableToIPC = arrow.tableToIPC as unknown as (
+    table: arrow.Table,
+    container: 'stream' | 'file',
+    compressionType?: number | null
+  ) => Uint8Array;
+  const arrowBuffer =
+    compressionType === null
+      ? tableToIPC(table, container)
+      : tableToIPC(table, container, compressionType);
   return ensureArrayBuffer(arrowBuffer);
 }
 

--- a/modules/arrow/src/lib/parsers/arrow-compression.ts
+++ b/modules/arrow/src/lib/parsers/arrow-compression.ts
@@ -1,0 +1,159 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import * as arrow from 'apache-arrow';
+import lz4js from 'lz4js';
+import {LZ4JSCompressor} from '@loaders.gl/compression/lz4-compressor-lz4js';
+import {LZ4JSDecompressor} from '@loaders.gl/compression/lz4-decompressor-lz4js';
+import {ZstdFzstdDecompressor} from '@loaders.gl/compression/zstd-decompressor-fzstd';
+import {ZstdCompression} from '@loaders.gl/compression/zstd-compression';
+
+/** Arrow IPC embedded buffer compression codecs. */
+export type ArrowIPCCompression = 'lz4' | 'zstd';
+
+type ArrowCompressionCodec = {
+  encode?: (data: Uint8Array) => Uint8Array;
+  decode?: (data: Uint8Array) => Uint8Array;
+};
+
+type ArrowCompressionRegistry = {
+  get: (compressionType: number) => ArrowCompressionCodec | null;
+  set: (compressionType: number, codec: ArrowCompressionCodec) => void;
+};
+
+type OptionalArrowCompressionAPI = {
+  CompressionType?: {
+    LZ4_FRAME?: number;
+    ZSTD?: number;
+  };
+  compressionRegistry?: ArrowCompressionRegistry;
+};
+
+type SynchronousCompression = {
+  compressSync?: (data: ArrayBuffer) => ArrayBuffer;
+  decompressSync: (data: ArrayBuffer) => ArrayBuffer;
+};
+
+const lz4Compressor = new LZ4JSCompressor({modules: {lz4js}});
+const lz4Decompressor = new LZ4JSDecompressor({modules: {lz4js}});
+const zstdDecompressor = new ZstdFzstdDecompressor();
+const zstdCompressor = new ZstdCompression();
+let zstdCompressorReady = false;
+
+/**
+ * Registers loaders.gl codecs with Apache Arrow runtimes that support IPC body compression.
+ *
+ * Apache Arrow JS 21.2 added the optional compression registry. The feature check keeps this
+ * module compatible with Apache Arrow JS 17, which remains supported for uncompressed IPC data.
+ */
+export function registerArrowCompressionCodecs(
+  compressionAPI: OptionalArrowCompressionAPI = arrow as unknown as OptionalArrowCompressionAPI
+): boolean {
+  const registry = compressionAPI.compressionRegistry;
+  const compressionTypes = compressionAPI.CompressionType;
+
+  if (
+    !registry ||
+    typeof registry.get !== 'function' ||
+    typeof registry.set !== 'function' ||
+    typeof compressionTypes?.LZ4_FRAME !== 'number' ||
+    typeof compressionTypes.ZSTD !== 'number'
+  ) {
+    return false;
+  }
+
+  registerArrowCompressionCodec(registry, compressionTypes.LZ4_FRAME, lz4Decompressor);
+  registerArrowCompressionCodec(registry, compressionTypes.ZSTD, zstdDecompressor);
+  return true;
+}
+
+/** Prepares an Arrow IPC compression encoder for use by the asynchronous writer. */
+export async function preloadArrowCompressionEncoder(
+  compression: ArrowIPCCompression,
+  modules: Record<string, any> = {}
+): Promise<void> {
+  const registration = getArrowCompressionRegistration(compression);
+  if (registration.registry.get(registration.compressionType)?.encode) {
+    return;
+  }
+
+  if (compression === 'zstd') {
+    await zstdCompressor.preload(modules);
+    zstdCompressorReady = true;
+  }
+  try {
+    registerArrowCompressionEncoderSync(compression);
+  } catch (error) {
+    zstdCompressorReady = false;
+    if (compression === 'zstd' && !modules['zstd-codec']) {
+      throw new Error(
+        "Arrow Zstandard encoding requires a 'zstd-codec' module in writer options.modules",
+        {cause: error}
+      );
+    }
+    throw error;
+  }
+}
+
+/** Registers a synchronous Arrow IPC compression encoder and returns its Arrow enum value. */
+export function registerArrowCompressionEncoderSync(compression: ArrowIPCCompression): number {
+  const registration = getArrowCompressionRegistration(compression);
+  const codec = registration.registry.get(registration.compressionType);
+  if (codec?.encode) {
+    return registration.compressionType;
+  }
+  if (compression === 'zstd' && !zstdCompressorReady) {
+    throw new Error(
+      'Synchronous Arrow Zstandard compression is not initialized; use encode() instead of encodeSync()'
+    );
+  }
+
+  const compressor = compression === 'lz4' ? lz4Compressor : zstdCompressor;
+  registration.registry.set(registration.compressionType, {
+    ...(codec || {}),
+    encode: data => new Uint8Array(compressor.compressSync!(data.slice().buffer as ArrayBuffer))
+  });
+  return registration.compressionType;
+}
+
+/** Resolves the optional Arrow JS compression registry and enum for a requested codec. */
+function getArrowCompressionRegistration(compression: ArrowIPCCompression): {
+  registry: ArrowCompressionRegistry;
+  compressionType: number;
+} {
+  const compressionAPI = arrow as unknown as OptionalArrowCompressionAPI;
+  const registry = compressionAPI.compressionRegistry;
+  const compressionTypes = compressionAPI.CompressionType;
+  const compressionType =
+    compression === 'lz4' ? compressionTypes?.LZ4_FRAME : compressionTypes?.ZSTD;
+
+  if (
+    !registry ||
+    typeof registry.get !== 'function' ||
+    typeof registry.set !== 'function' ||
+    typeof compressionType !== 'number'
+  ) {
+    throw new Error(
+      'Arrow IPC buffer compression requires apache-arrow 21.2.0 or later; the installed runtime only supports uncompressed IPC data'
+    );
+  }
+  return {registry, compressionType};
+}
+
+/** Adds a decoder without replacing an application-provided codec or encoder. */
+function registerArrowCompressionCodec(
+  registry: ArrowCompressionRegistry,
+  compressionType: number,
+  decompressor: SynchronousCompression
+): void {
+  const codec = registry.get(compressionType);
+  if (codec?.decode) {
+    return;
+  }
+
+  registry.set(compressionType, {
+    ...(codec || {}),
+    decode: data => new Uint8Array(decompressor.decompressSync(data.slice().buffer as ArrayBuffer))
+  });
+}

--- a/modules/arrow/src/lib/parsers/arrow-compression.ts
+++ b/modules/arrow/src/lib/parsers/arrow-compression.ts
@@ -41,6 +41,11 @@ const zstdDecompressor = new ZstdFzstdDecompressor();
 const zstdCompressor = new ZstdCompression();
 let zstdCompressorReady = false;
 
+const lz4Encoder = (data: Uint8Array): Uint8Array =>
+  new Uint8Array(lz4Compressor.compressSync(data.slice().buffer as ArrayBuffer));
+const zstdEncoder = (data: Uint8Array): Uint8Array =>
+  new Uint8Array(zstdCompressor.compressSync(data.slice().buffer as ArrayBuffer));
+
 /**
  * Registers loaders.gl codecs with Apache Arrow runtimes that support IPC body compression.
  *
@@ -74,7 +79,12 @@ export async function preloadArrowCompressionEncoder(
   modules: Record<string, any> = {}
 ): Promise<void> {
   const registration = getArrowCompressionRegistration(compression);
-  if (registration.registry.get(registration.compressionType)?.encode) {
+  const registeredEncoder = registration.registry.get(registration.compressionType)?.encode;
+  const encoder = compression === 'lz4' ? lz4Encoder : zstdEncoder;
+  if (
+    registeredEncoder &&
+    (compression !== 'zstd' || registeredEncoder !== encoder || zstdCompressorReady)
+  ) {
     return;
   }
 
@@ -100,7 +110,11 @@ export async function preloadArrowCompressionEncoder(
 export function registerArrowCompressionEncoderSync(compression: ArrowIPCCompression): number {
   const registration = getArrowCompressionRegistration(compression);
   const codec = registration.registry.get(registration.compressionType);
-  if (codec?.encode) {
+  const encoder = compression === 'lz4' ? lz4Encoder : zstdEncoder;
+  if (
+    codec?.encode &&
+    (compression !== 'zstd' || codec.encode !== encoder || zstdCompressorReady)
+  ) {
     return registration.compressionType;
   }
   if (compression === 'zstd' && !zstdCompressorReady) {
@@ -109,10 +123,9 @@ export function registerArrowCompressionEncoderSync(compression: ArrowIPCCompres
     );
   }
 
-  const compressor = compression === 'lz4' ? lz4Compressor : zstdCompressor;
   registration.registry.set(registration.compressionType, {
     ...(codec || {}),
-    encode: data => new Uint8Array(compressor.compressSync!(data.slice().buffer as ArrayBuffer))
+    encode: encoder
   });
   return registration.compressionType;
 }

--- a/modules/arrow/src/lib/parsers/arrow-compression.ts
+++ b/modules/arrow/src/lib/parsers/arrow-compression.ts
@@ -88,20 +88,19 @@ export async function preloadArrowCompressionEncoder(
     return;
   }
 
-  if (compression === 'zstd') {
-    await zstdCompressor.preload(modules);
-    zstdCompressorReady = true;
+  if (compression === 'zstd' && !modules['zstd-codec']) {
+    throw new Error(
+      "Arrow Zstandard encoding requires a 'zstd-codec' module in writer options.modules"
+    );
   }
   try {
+    if (compression === 'zstd') {
+      await zstdCompressor.preload(modules);
+      zstdCompressorReady = true;
+    }
     registerArrowCompressionEncoderSync(compression);
   } catch (error) {
     zstdCompressorReady = false;
-    if (compression === 'zstd' && !modules['zstd-codec']) {
-      throw new Error(
-        "Arrow Zstandard encoding requires a 'zstd-codec' module in writer options.modules",
-        {cause: error}
-      );
-    }
     throw error;
   }
 }

--- a/modules/arrow/src/lib/parsers/parse-arrow.ts
+++ b/modules/arrow/src/lib/parsers/parse-arrow.ts
@@ -7,8 +7,10 @@ import type {Table, ArrowTableBatch} from '@loaders.gl/schema';
 import {ArrowLoaderOptions} from '../../exports/arrow-loader';
 import {convertArrowToTable} from '@loaders.gl/schema-utils';
 import {makeTableScanBatch, toArrayBufferIterator} from '@loaders.gl/loader-utils';
+import {registerArrowCompressionCodecs} from './arrow-compression';
 
 const UNSAFE_BIGINT_ERROR_REGEXP = /^(-?\d+) is not safe to convert to a number\.$/;
+const UNSUPPORTED_COMPRESSION_ERROR_REGEXP = /Record batch compression not implemented/i;
 
 /** Parses arrow to a loaders.gl table. Defaults to `arrow-table` */
 export function parseArrowSync(
@@ -22,6 +24,7 @@ export function parseArrowSync(
 
 /** Parses an Arrow IPC table, normalizing dictionary ids unsupported by Arrow JS. */
 function parseArrowTable(arrayBuffer: ArrayBuffer): arrow.Table {
+  const compressionSupported = registerArrowCompressionCodecs();
   try {
     return arrow.tableFromIPC([new Uint8Array(arrayBuffer)]);
   } catch (error) {
@@ -33,8 +36,20 @@ function parseArrowTable(arrayBuffer: ArrayBuffer): arrow.Table {
     if (normalizedArrayBuffer) {
       return arrow.tableFromIPC([new Uint8Array(normalizedArrayBuffer)]);
     }
+    if (!compressionSupported && isUnsupportedCompressionError(error)) {
+      throw new Error(
+        'Arrow IPC buffer compression requires apache-arrow 21.2.0 or later; the installed runtime only supports uncompressed IPC data',
+        {cause: error}
+      );
+    }
     throw error;
   }
+}
+
+/** Checks for the error emitted by Apache Arrow JS releases without IPC compression support. */
+function isUnsupportedCompressionError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return UNSUPPORTED_COMPRESSION_ERROR_REGEXP.test(message);
 }
 
 /** Rewrites unsafe int64 dictionary ids to small ids that Arrow JS can represent. */
@@ -95,6 +110,7 @@ export function parseArrowInBatches(
     | Iterable<ArrayBufferLike | ArrayBufferView>,
   options?: ArrowLoaderOptions
 ): AsyncIterable<ArrowTableBatch> {
+  registerArrowCompressionCodecs();
   // Creates the appropriate arrow.RecordBatchReader subclasses from the input
   // This will also close the underlying source in case of early termination or errors
 

--- a/modules/arrow/test/arrow-loader.spec.ts
+++ b/modules/arrow/test/arrow-loader.spec.ts
@@ -5,7 +5,11 @@
 import {expect, test} from 'vitest';
 import {validateLoader} from 'test/common/conformance';
 import * as fs from 'fs';
+import * as arrow from 'apache-arrow';
+import lz4js from 'lz4js';
+import {ZstdCodec} from 'zstd-codec';
 import {ArrowLoader} from '@loaders.gl/arrow';
+import {registerArrowCompressionCodecs} from '../src/lib/parsers/arrow-compression';
 import {
   isBrowser,
   makeIterator,
@@ -78,6 +82,64 @@ test('ArrowLoader#parseSync(dictionary.arrow)', async () => {
   if (columnarTable.shape === 'columnar-table') {
     expect(columnarTable.data['example-csv'], 'example-csv loaded').toBeTruthy();
   }
+});
+test('ArrowLoader#parseSync supports compressed Feather V2 files', async () => {
+  const compressionAPI = arrow as unknown as {
+    CompressionType?: {LZ4_FRAME?: number; ZSTD?: number};
+    compressionRegistry?: {
+      set: (compressionType: number, codec: {encode: (data: Uint8Array) => Uint8Array}) => void;
+    };
+    tableToIPC: (table: arrow.Table, type: 'file', compressionType: number) => Uint8Array;
+  };
+  const compressionRegistry = compressionAPI.compressionRegistry;
+  const compressionTypes = compressionAPI.CompressionType;
+  if (
+    !compressionRegistry ||
+    typeof compressionTypes?.LZ4_FRAME !== 'number' ||
+    typeof compressionTypes.ZSTD !== 'number'
+  ) {
+    return;
+  }
+  const sourceTable = arrow.tableFromArrays({
+    id: Int32Array.from({length: 2048}, (_, index) => index),
+    category: Array.from({length: 2048}, (_, index) => `category-${index % 4}`)
+  });
+  const zstd = await new Promise<any>(resolve => ZstdCodec.run(resolve));
+  const compressionCases = [
+    {
+      name: 'LZ4_FRAME',
+      type: compressionTypes.LZ4_FRAME,
+      encode: (data: Uint8Array): Uint8Array => lz4js.compress(data)
+    },
+    {
+      name: 'ZSTD',
+      type: compressionTypes.ZSTD,
+      encode: (data: Uint8Array): Uint8Array => new zstd.Simple().compress(data)
+    }
+  ];
+
+  for (const compressionCase of compressionCases) {
+    // Remove the decoder so this test verifies that ArrowLoader installs it while preserving the
+    // encoder used to construct a representative compressed Feather V2 file.
+    compressionRegistry.set(compressionCase.type, {encode: compressionCase.encode});
+    const compressedData = compressionAPI.tableToIPC(sourceTable, 'file', compressionCase.type);
+    expect(() => arrow.tableFromIPC(compressedData), compressionCase.name).toThrow(
+      /codec not found/
+    );
+
+    const table = await parse(compressedData.slice().buffer, ArrowLoader, {
+      core: {worker: false},
+      arrow: {shape: 'object-row-table'}
+    });
+    expect(table.shape, compressionCase.name).toBe('object-row-table');
+    if (table.shape === 'object-row-table') {
+      expect(table.data.length, compressionCase.name).toBe(2048);
+      expect(table.data[1025], compressionCase.name).toEqual({id: 1025, category: 'category-1'});
+    }
+  }
+});
+test('ArrowLoader compression registration tolerates Apache Arrow JS 17', () => {
+  expect(registerArrowCompressionCodecs({})).toBe(false);
 });
 test('ArrowLoader#parse(fetchFile(struct).arrow)', async () => {
   const columns = await parse(fetchFile(ARROW_STRUCT), ArrowLoader);

--- a/modules/arrow/test/arrow-writer.spec.ts
+++ b/modules/arrow/test/arrow-writer.spec.ts
@@ -4,7 +4,9 @@
 
 import {expect, test} from 'vitest';
 import {validateWriter} from 'test/common/conformance';
-import {parseSync, encodeSync} from '@loaders.gl/core';
+import * as arrow from 'apache-arrow';
+import {ZstdCodec} from 'zstd-codec';
+import {parseSync, encode, encodeSync} from '@loaders.gl/core';
 import {ArrowWriter} from '@loaders.gl/arrow';
 import {ArrowLoader} from '@loaders.gl/arrow/bundled';
 test('ArrowWriter#writer conformance', () => {
@@ -32,4 +34,59 @@ test('ArrowWriter#encode', async () => {
     expect(table.data.precipitation).toBeTruthy();
     expect(table.data.precipitation.length).toBe(LENGTH);
   }
+});
+test('ArrowWriter#encodeSync writes an Arrow IPC file / Feather V2 container', () => {
+  const arraysData = [
+    {array: Int32Array.from([1, 2, 3]), name: 'id', type: 0},
+    {array: ['alpha', 'beta', 'gamma'], name: 'name', type: 1}
+  ];
+  const arrayBuffer = encodeSync(arraysData, ArrowWriter, {
+    arrow: {container: 'file'}
+  });
+  const bytes = new Uint8Array(arrayBuffer);
+  const magic = new TextEncoder().encode('ARROW1');
+
+  expect(bytes.subarray(0, magic.length)).toEqual(magic);
+  expect(bytes.subarray(bytes.length - magic.length)).toEqual(magic);
+  expect(parseSync(arrayBuffer, ArrowLoader).shape).toBe('columnar-table');
+});
+test('ArrowWriter writes LZ4 and Zstandard compressed Feather V2 files', async () => {
+  const compressionAPI = arrow as unknown as {
+    CompressionType?: {LZ4_FRAME?: number; ZSTD?: number};
+    compressionRegistry?: unknown;
+  };
+  if (
+    !compressionAPI.compressionRegistry ||
+    typeof compressionAPI.CompressionType?.LZ4_FRAME !== 'number' ||
+    typeof compressionAPI.CompressionType.ZSTD !== 'number'
+  ) {
+    return;
+  }
+
+  const arraysData = [
+    {array: Int32Array.from({length: 4096}, (_, index) => index % 8), name: 'id', type: 0},
+    {
+      array: Array.from({length: 4096}, (_, index) => `category-${index % 4}`),
+      name: 'category',
+      type: 1
+    }
+  ];
+  const uncompressed = encodeSync(arraysData, ArrowWriter, {arrow: {container: 'file'}});
+  const lz4 = encodeSync(arraysData, ArrowWriter, {
+    arrow: {container: 'file', compression: 'lz4'}
+  });
+  expect(() =>
+    encodeSync(arraysData, ArrowWriter, {
+      arrow: {container: 'file', compression: 'zstd'}
+    })
+  ).toThrow(/use encode\(\) instead of encodeSync\(\)/);
+  const zstd = await encode(arraysData, ArrowWriter, {
+    modules: {'zstd-codec': ZstdCodec},
+    arrow: {container: 'file', compression: 'zstd'}
+  });
+
+  expect(lz4.byteLength).toBeLessThan(uncompressed.byteLength);
+  expect(zstd.byteLength).toBeLessThan(uncompressed.byteLength);
+  expect(parseSync(lz4, ArrowLoader).shape).toBe('columnar-table');
+  expect(parseSync(zstd, ArrowLoader).shape).toBe('columnar-table');
 });

--- a/modules/arrow/test/arrow-writer.spec.ts
+++ b/modules/arrow/test/arrow-writer.spec.ts
@@ -94,27 +94,47 @@ test('ArrowWriter writes LZ4 and Zstandard compressed Feather V2 files', async (
   const lz4Sync = encodeSync(arraysData, ArrowWriter, {
     arrow: {container: 'file', compression: 'lz4'}
   });
-  compressionAPI.compressionRegistry.set(compressionAPI.CompressionType.ZSTD, {});
-  expect(() =>
-    encodeSync(arraysData, ArrowWriter, {
+  const originalModules = globalThis.loaders?.modules;
+  if (globalThis.loaders) {
+    globalThis.loaders.modules = {...originalModules};
+    delete globalThis.loaders.modules['zstd-codec'];
+  }
+  let zstd: ArrayBuffer | null = null;
+  try {
+    compressionAPI.compressionRegistry.set(compressionAPI.CompressionType.ZSTD, {});
+    expect(() =>
+      encodeSync(arraysData, ArrowWriter, {
+        arrow: {container: 'file', compression: 'zstd'}
+      })
+    ).toThrow(/use encode\(\) instead of encodeSync\(\)/);
+    await expect(
+      encode(arraysData, ArrowWriter, {
+        arrow: {container: 'file', compression: 'zstd'}
+      })
+    ).rejects.toThrow(/requires a 'zstd-codec' module/);
+    zstd = await encode(arraysData, ArrowWriter, {
+      modules: {'zstd-codec': ZstdCodec},
       arrow: {container: 'file', compression: 'zstd'}
-    })
-  ).toThrow(/use encode\(\) instead of encodeSync\(\)/);
-  await expect(
-    encode(arraysData, ArrowWriter, {
+    });
+    const zstdWithRegisteredEncoder = await encode(arraysData, ArrowWriter, {
       arrow: {container: 'file', compression: 'zstd'}
-    })
-  ).rejects.toThrow(/requires a 'zstd-codec' module/);
-  const zstd = await encode(arraysData, ArrowWriter, {
-    modules: {'zstd-codec': ZstdCodec},
-    arrow: {container: 'file', compression: 'zstd'}
-  });
+    });
+    expect(zstdWithRegisteredEncoder.byteLength).toBe(zstd.byteLength);
+    expect(parseSync(zstd, ArrowLoader).shape).toBe('columnar-table');
+  } finally {
+    if (globalThis.loaders) {
+      globalThis.loaders.modules = originalModules;
+    }
+  }
 
   expect(lz4.byteLength).toBeLessThan(uncompressed.byteLength);
   expect(lz4WithRegisteredEncoder.byteLength).toBe(lz4.byteLength);
   expect(lz4Sync.byteLength).toBeLessThan(uncompressed.byteLength);
+  expect(zstd).not.toBeNull();
+  if (!zstd) {
+    throw new Error('Zstandard encoding did not produce an Arrow IPC buffer');
+  }
   expect(zstd.byteLength).toBeLessThan(uncompressed.byteLength);
   expect(parseSync(lz4, ArrowLoader).shape).toBe('columnar-table');
   expect(parseSync(lz4Sync, ArrowLoader).shape).toBe('columnar-table');
-  expect(parseSync(zstd, ArrowLoader).shape).toBe('columnar-table');
 });

--- a/modules/arrow/test/arrow-writer.spec.ts
+++ b/modules/arrow/test/arrow-writer.spec.ts
@@ -25,7 +25,7 @@ test('ArrowWriter#encode', async () => {
     {array: rainAmounts, name: 'precipitation', type: 0},
     {array: rainDates, name: 'date', type: 1}
   ];
-  const arrayBuffer = encodeSync(arraysData, ArrowWriter);
+  const arrayBuffer = await encode(arraysData, ArrowWriter);
   expect(arrayBuffer).toBeTruthy();
   const table = parseSync(arrayBuffer, ArrowLoader);
   expect(table).toBeTruthy();
@@ -53,7 +53,19 @@ test('ArrowWriter#encodeSync writes an Arrow IPC file / Feather V2 container', (
 test('ArrowWriter writes LZ4 and Zstandard compressed Feather V2 files', async () => {
   const compressionAPI = arrow as unknown as {
     CompressionType?: {LZ4_FRAME?: number; ZSTD?: number};
-    compressionRegistry?: unknown;
+    compressionRegistry?: {
+      get: (compressionType: number) => {
+        encode?: (data: Uint8Array) => Uint8Array;
+        decode?: (data: Uint8Array) => Uint8Array;
+      } | null;
+      set: (
+        compressionType: number,
+        codec: {
+          encode?: (data: Uint8Array) => Uint8Array;
+          decode?: (data: Uint8Array) => Uint8Array;
+        }
+      ) => void;
+    };
   };
   if (
     !compressionAPI.compressionRegistry ||
@@ -72,21 +84,37 @@ test('ArrowWriter writes LZ4 and Zstandard compressed Feather V2 files', async (
     }
   ];
   const uncompressed = encodeSync(arraysData, ArrowWriter, {arrow: {container: 'file'}});
-  const lz4 = encodeSync(arraysData, ArrowWriter, {
+  compressionAPI.compressionRegistry.set(compressionAPI.CompressionType.LZ4_FRAME, {});
+  const lz4 = await encode(arraysData, ArrowWriter, {
     arrow: {container: 'file', compression: 'lz4'}
   });
+  const lz4WithRegisteredEncoder = await encode(arraysData, ArrowWriter, {
+    arrow: {container: 'file', compression: 'lz4'}
+  });
+  const lz4Sync = encodeSync(arraysData, ArrowWriter, {
+    arrow: {container: 'file', compression: 'lz4'}
+  });
+  compressionAPI.compressionRegistry.set(compressionAPI.CompressionType.ZSTD, {});
   expect(() =>
     encodeSync(arraysData, ArrowWriter, {
       arrow: {container: 'file', compression: 'zstd'}
     })
   ).toThrow(/use encode\(\) instead of encodeSync\(\)/);
+  await expect(
+    encode(arraysData, ArrowWriter, {
+      arrow: {container: 'file', compression: 'zstd'}
+    })
+  ).rejects.toThrow(/requires a 'zstd-codec' module/);
   const zstd = await encode(arraysData, ArrowWriter, {
     modules: {'zstd-codec': ZstdCodec},
     arrow: {container: 'file', compression: 'zstd'}
   });
 
   expect(lz4.byteLength).toBeLessThan(uncompressed.byteLength);
+  expect(lz4WithRegisteredEncoder.byteLength).toBe(lz4.byteLength);
+  expect(lz4Sync.byteLength).toBeLessThan(uncompressed.byteLength);
   expect(zstd.byteLength).toBeLessThan(uncompressed.byteLength);
   expect(parseSync(lz4, ArrowLoader).shape).toBe('columnar-table');
+  expect(parseSync(lz4Sync, ArrowLoader).shape).toBe('columnar-table');
   expect(parseSync(zstd, ArrowLoader).shape).toBe('columnar-table');
 });

--- a/modules/arrow/tsconfig.json
+++ b/modules/arrow/tsconfig.json
@@ -8,6 +8,7 @@
     "outDir": "dist"
   },
   "references": [
+    {"path": "../compression"},
     {"path": "../core"},
     {"path": "../gis"},
     {"path": "../geoarrow"},

--- a/yarn.lock
+++ b/yarn.lock
@@ -5163,6 +5163,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@loaders.gl/arrow@workspace:modules/arrow"
   dependencies:
+    "@loaders.gl/compression": "npm:5.0.0-alpha.2"
     "@loaders.gl/gis": "npm:5.0.0-alpha.2"
     "@loaders.gl/loader-utils": "npm:5.0.0-alpha.2"
     "@loaders.gl/schema": "npm:5.0.0-alpha.2"
@@ -5171,6 +5172,7 @@ __metadata:
     "@loaders.gl/worker-utils": "npm:5.0.0-alpha.2"
     "@math.gl/polygon": "npm:4.2.0-alpha.6"
     apache-arrow: "npm:>= 17.0.0"
+    lz4js: "npm:^0.2.0"
   peerDependencies:
     "@loaders.gl/core": ~5.0.0-alpha.0
   languageName: unknown


### PR DESCRIPTION
## Goals

- Support Feather V2 / Arrow IPC embedded compression without dropping Apache Arrow JS v17 compatibility required by DuckDB.
- Decode every compression codec allowed by the Arrow IPC specification and expose matching writer capabilities.
- Document Arrow and Feather read/write support in a capability matrix.

## Changes

- Dynamically detects the Apache Arrow JS compression registry introduced in v21.2, while retaining uncompressed IPC behavior on v17 through v21.1.
- Registers LZ4 Frame and Zstandard decoders for complete and batched Arrow reads.
- Adds Arrow IPC stream/file selection to `ArrowWriter`; the file container produces Feather V2 output.
- Adds LZ4 compression to sync and async writes, and Zstandard compression to async writes using an injected optional `zstd-codec` module.
- Adds targeted errors for compressed input on older Arrow runtimes and for unsupported synchronous Zstandard initialization.
- Adds browser tests covering real LZ4/ZSTD Feather files, file magic, compression size, round trips, and the v17 feature-detection path.
- Adds Arrow/Feather and embedded-codec capability tables plus writer examples.

## Validation

- `yarn install`
- `yarn lint fix`
- `yarn build`
- `yarn build-workers`
- `yarn test-audit`
- `yarn test-node` — 60 files, 391 passed, 6 skipped
- `yarn test-headless` — 557 passed files, 1 skipped; 3,668 passed tests, 39 skipped
