### PR TITLE
test: add monumental cross-module coverage tranche

### DIFF
--- a/modules/avro/src/lib/parsers/parse-avro.ts
+++ b/modules/avro/src/lib/parsers/parse-avro.ts
@@ -178,10 +178,10 @@ export async function* parseAvroInBatchesFromUrl(
 ): AsyncIterable<ArrowTableBatch> {
   if (options?.encoding && options.encoding !== 'auto' && options.encoding !== 'ocf')
     throw new Error('URL-backed Avro loading currently supports OCF input only');
-  const batchSize = options?.batchSize || 10_000;
+  const batchSize = options?.batchSize ?? 10_000;
   if (!Number.isInteger(batchSize) || batchSize <= 0)
     throw new Error('Avro batchSize must be positive');
-  const rangeChunkSize = options?.rangeChunkSize || 1024 * 1024;
+  const rangeChunkSize = options?.rangeChunkSize ?? 1024 * 1024;
   if (!Number.isInteger(rangeChunkSize) || rangeChunkSize < 1024)
     throw new Error('Avro rangeChunkSize must be at least 1024 bytes');
   const initial = await fetchAvroRange(url, 0, rangeChunkSize - 1, options);
@@ -257,7 +257,7 @@ export async function* parseAvroInBatchesFromFile(
   file: ReadableFile,
   options?: AvroParseOptions & {batchSize?: number}
 ): AsyncIterable<ArrowTableBatch> {
-  const rangeChunkSize = options?.rangeChunkSize || 1024 * 1024;
+  const rangeChunkSize = options?.rangeChunkSize ?? 1024 * 1024;
   if (!Number.isInteger(rangeChunkSize) || rangeChunkSize < 1024)
     throw new Error('Avro rangeChunkSize must be at least 1024 bytes');
   const stat = file.stat ? await file.stat() : null;
@@ -277,7 +277,9 @@ export async function* parseAvroInBatchesFromFile(
   let offset = header.dataOffset;
   let blockIndex = 0;
   let batch: Record<string, unknown>[] = [];
-  const batchSize = options?.batchSize || 10_000;
+  const batchSize = options?.batchSize ?? 10_000;
+  if (!Number.isInteger(batchSize) || batchSize <= 0)
+    throw new Error('Avro batchSize must be positive');
   while (offset < fileSize) {
     const blockHeader = new Uint8Array(
       await file.read(offset, Math.min(32, fileSize - offset), options?.signal)

--- a/modules/avro/test/avro-boundary-coverage.spec.ts
+++ b/modules/avro/test/avro-boundary-coverage.spec.ts
@@ -3,13 +3,17 @@
 // Copyright (c) vis.gl contributors
 
 import * as arrow from 'apache-arrow';
-import {describe, expect, test} from 'vitest';
+import {afterEach, describe, expect, test, vi} from 'vitest';
 import {encodeAvro, encodeAvroInChunks} from '../src/lib/encoders/encode-avro';
 import {
   getAvroSchemaFingerprint,
   parseAvro,
-  parseAvroInBatches
+  parseAvroFromUrl,
+  parseAvroInBatches,
+  parseAvroInBatchesFromUrl
 } from '../src/lib/parsers/parse-avro';
+
+afterEach(() => vi.unstubAllGlobals());
 
 /** Creates the minimal Arrow-table contract needed by the Avro encoder. */
 function createStructuralTable(rows: Record<string, unknown>[]) {
@@ -246,5 +250,78 @@ describe('Avro boundary coverage', () => {
       'bigint'
     );
     expect(getAvroSchemaFingerprint({type: 'fixed', name: 'F', size: 2})).toBeTypeOf('bigint');
+  });
+
+  test('reads a URL-backed OCF with bounded range requests', async () => {
+    const schema = {type: 'record', name: 'Value', fields: [{name: 'label', type: 'string'}]};
+    const rows = Array.from({length: 80}, (_, index) => ({label: `${index}-${'x'.repeat(40)}`}));
+    const encoded = new Uint8Array(
+      await encodeAvro(createStructuralTable(rows), {avro: {schema, blockSize: 700}})
+    );
+    const requests: string[] = [];
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (_url: string, requestInit?: RequestInit) => {
+        const range = new Headers(requestInit?.headers).get('Range') || '';
+        requests.push(range);
+        const match = range.match(/bytes=(\d+)-(\d+)/);
+        const start = Number(match?.[1]);
+        const end = Math.min(Number(match?.[2]), encoded.length - 1);
+        if (start >= encoded.length) return new Response(null, {status: 416});
+        return new Response(encoded.slice(start, end + 1), {status: 206});
+      })
+    );
+
+    const result = await parseAvroFromUrl('https://example.test/data.avro', {
+      rangeChunkSize: 1024,
+      batchSize: 13,
+      blockIndices: [0, 2],
+      headers: {'X-Test': 'yes'}
+    });
+    expect(result.data.numRows).toBeGreaterThan(0);
+    expect(result.data.numRows).toBeLessThan(rows.length);
+    expect(requests[0]).toBe('bytes=0-1023');
+    expect(requests.some(range => !range.startsWith('bytes=0-'))).toBe(true);
+  });
+
+  test('falls back when a URL server returns the complete file', async () => {
+    const schema = {type: 'record', name: 'Value', fields: [{name: 'id', type: 'int'}]};
+    const encoded = await encodeAvro(createStructuralTable([{id: 1}, {id: 2}]), {avro: {schema}});
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(encoded, {status: 200}))
+    );
+
+    const batches = await collectBatches(
+      parseAvroInBatchesFromUrl('https://example.test/data.avro', {batchSize: 1})
+    );
+    expect(batches.map(batch => batch.length)).toEqual([1, 1]);
+  });
+
+  test('validates URL options and range responses', async () => {
+    await expect(
+      collectBatches(parseAvroInBatchesFromUrl('https://example.test/data.avro', {encoding: 'raw'}))
+    ).rejects.toThrow('supports OCF input only');
+    await expect(
+      collectBatches(parseAvroInBatchesFromUrl('https://example.test/data.avro', {batchSize: 0}))
+    ).rejects.toThrow('batchSize must be positive');
+    await expect(
+      collectBatches(
+        parseAvroInBatchesFromUrl('https://example.test/data.avro', {rangeChunkSize: 100})
+      )
+    ).rejects.toThrow('rangeChunkSize must be at least 1024 bytes');
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(null, {status: 416}))
+    );
+    await expect(parseAvroFromUrl('https://example.test/missing.avro')).rejects.toThrow(
+      'returned no data'
+    );
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(null, {status: 503}))
+    );
+    await expect(parseAvroFromUrl('https://example.test/error.avro')).rejects.toThrow('HTTP 503');
   });
 });

--- a/modules/config/src/toml/lib/parsers/parse-toml.ts
+++ b/modules/config/src/toml/lib/parsers/parse-toml.ts
@@ -182,10 +182,18 @@ class TOMLValueParser {
       return parseTOMLInteger(normalized, Number.parseInt(normalized, 16), this.options);
     }
     if (/^[+-]?0o[0-7]+$/i.test(normalized)) {
-      return parseTOMLInteger(normalized, Number.parseInt(normalized, 8), this.options);
+      return parseTOMLInteger(
+        normalized,
+        Number.parseInt(normalized.replace(/^([+-]?)0o/i, '$1'), 8),
+        this.options
+      );
     }
     if (/^[+-]?0b[01]+$/i.test(normalized)) {
-      return parseTOMLInteger(normalized, Number.parseInt(normalized, 2), this.options);
+      return parseTOMLInteger(
+        normalized,
+        Number.parseInt(normalized.replace(/^([+-]?)0b/i, '$1'), 2),
+        this.options
+      );
     }
     if (/^[+-]?\d+$/.test(normalized)) {
       return parseTOMLInteger(normalized, Number(normalized), this.options);

--- a/modules/config/src/yaml/lib/parsers/parse-yaml.ts
+++ b/modules/config/src/yaml/lib/parsers/parse-yaml.ts
@@ -32,7 +32,7 @@ class YAMLParser {
   /** Parses the document root. */
   parse(): unknown {
     this.skipBlankLines();
-    if (this.lines.length === 0) {
+    if (this.lineIndex >= this.lines.length) {
       return null;
     }
     const value = this.parseBlock(this.lines[this.lineIndex].indent);
@@ -476,10 +476,10 @@ class YAMLFlowParser {
       return Number.parseInt(normalized, 16);
     }
     if (/^[-+]?0o[0-7]+$/i.test(normalized)) {
-      return Number.parseInt(normalized, 8);
+      return Number.parseInt(normalized.replace(/^([+-]?)0o/i, '$1'), 8);
     }
     if (/^[-+]?0b[01]+$/i.test(normalized)) {
-      return Number.parseInt(normalized, 2);
+      return Number.parseInt(normalized.replace(/^([+-]?)0b/i, '$1'), 2);
     }
     if (/^[-+]?(?:[0-9]+(?:\.[0-9]*)?|\.[0-9]+)(?:e[-+]?[0-9]+)?$/i.test(normalized)) {
       if (this.options.intAsBigInt && /^[-+]?\d+$/.test(normalized)) {

--- a/modules/config/test/config-parser-boundary.spec.ts
+++ b/modules/config/test/config-parser-boundary.spec.ts
@@ -1,0 +1,126 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {describe, expect, test} from 'vitest';
+import {parseTOMLSync} from '../src/toml/lib/parsers/parse-toml';
+import {parseYAMLSync} from '../src/yaml/lib/parsers/parse-yaml';
+
+describe('YAML parser boundary behavior', () => {
+  test('parses block, flow, scalar, numeric, and string forms', () => {
+    expect(
+      parseYAMLSync(
+        `
+---
+items:
+  - name: first
+    enabled: yes
+  -
+    name: second
+flow: {plain: [null, true, false, 0x10, 0o10, 0b10, 1_000, .5e2], "quoted:key": "a\\n\\u0042"}
+literal: |-
+  first
+  second
+folded: >+
+  one
+  two
+anchor: &value retained
+single: 'it''s fine'
+...
+`,
+        {version: '1.1'}
+      )
+    ).toMatchObject({
+      items: [{name: 'first', enabled: true}, {name: 'second'}],
+      flow: {
+        plain: [null, true, false, 16, 8, 2, 1000, 50],
+        'quoted:key': 'a\nB'
+      },
+      literal: 'first\nsecond',
+      folded: 'one two\n',
+      anchor: 'retained',
+      single: "it's fine"
+    });
+    expect(parseYAMLSync('\uFEFFvalue: 9007199254740993', {intAsBigInt: true})).toEqual({
+      value: 9007199254740993n
+    });
+    expect(parseYAMLSync('')).toBeNull();
+  });
+
+  test.each([
+    ['duplicate mapping key', 'a: 1\na: 2', {uniqueKeys: true}, 'Duplicate mapping key'],
+    ['unknown alias', 'value: *missing', {}, 'Unknown YAML alias'],
+    ['unexpected indentation', '  value: 1\nnext: 2', {}, 'Unexpected content'],
+    ['flow object colon', 'value: {key 1}', {}, 'Expected colon'],
+    ['unterminated string', 'value: "open', {}, 'Unterminated quoted string'],
+    ['trailing scalar content', 'value: "done" extra', {}, 'Unexpected trailing content'],
+    ['non-string flow key', 'value: {1: one}', {stringKeys: true}, 'Mapping keys must be strings']
+  ])('rejects %s', (_name, text, options, message) => {
+    expect(() => parseYAMLSync(text, options)).toThrow(message);
+  });
+});
+
+describe('TOML parser boundary behavior', () => {
+  test('parses tables, arrays, inline tables, scalars, dates, and multiline strings', () => {
+    const value = parseTOMLSync(`
+title = "hash # retained" # removed
+escaped = "a\\n\\u0042\\U00000043"
+literal = 'raw'
+multiline = """
+line one
+line two"""
+values = [true, false, +inf, -inf, nan, 0x10, 0o10, 0b10, 1_000, 1.5e2]
+date = 2026-08-29T12:30:00Z
+inline = {nested.value = 2, name = "demo"}
+[owner]
+name = "one"
+[[products]]
+name = "first"
+[products.details]
+weight = 1
+[[products]]
+name = "second"
+`);
+
+    expect(value).toMatchObject({
+      title: 'hash # retained',
+      escaped: 'a\nBC',
+      literal: 'raw',
+      multiline: 'line one\nline two',
+      inline: {nested: {value: 2}, name: 'demo'},
+      owner: {name: 'one'},
+      products: [{name: 'first', details: {weight: 1}}, {name: 'second'}]
+    });
+    expect((value.values as number[]).slice(0, 4)).toEqual([true, false, Infinity, -Infinity]);
+    expect(Number.isNaN((value.values as number[])[4])).toBe(true);
+    expect((value.values as number[]).slice(5)).toEqual([16, 8, 2, 1000, 150]);
+    expect(value.date).toEqual(new Date('2026-08-29T12:30:00Z'));
+    expect(parseTOMLSync('\uFEFFlarge = 9007199254740993', {integersAsBigInt: 'asNeeded'})).toEqual(
+      {
+        large: 9007199254740993n
+      }
+    );
+    expect(parseTOMLSync('small = 2', {integersAsBigInt: true})).toEqual({small: 2n});
+  });
+
+  test.each([
+    ['missing assignment', 'invalid', 'Expected a key/value assignment'],
+    ['duplicate key', 'value = 1\nvalue = 2', 'Duplicate key'],
+    ['scalar table conflict', 'value = 1\n[value]', 'Cannot redefine'],
+    ['array table conflict', 'value = 1\n[[value]]', 'Cannot redefine'],
+    ['dotted scalar conflict', 'value = 1\nvalue.child = 2', 'Cannot create dotted key'],
+    ['invalid scalar', 'value = nope', 'Invalid value'],
+    ['unterminated string', 'value = "open', 'Unterminated string'],
+    ['invalid escape', 'value = "\\q"', 'Invalid escape sequence'],
+    ['array punctuation', 'value = [1 2]', 'Expected comma'],
+    ['inline equals', 'value = {key}', 'Expected equals sign'],
+    ['inline punctuation', 'value = {key = 1 other = 2}', 'Expected comma'],
+    ['inline duplicate', 'value = {key = 1, key = 2}', 'Duplicate key'],
+    ['inline dotted conflict', 'value = {key = 1, key.child = 2}', 'Cannot create dotted key'],
+    ['unterminated key', '["key]', 'Unterminated quoted key'],
+    ['invalid key', 'bad$key = 1', 'Invalid key'],
+    ['missing dotted key', 'value. = 1', 'Empty key']
+  ])('rejects %s', (_name, text, message) => {
+    expect(() => parseTOMLSync(text)).toThrow(message);
+  });
+});

--- a/modules/core/src/lib/filesystems/browser-filesystem.ts
+++ b/modules/core/src/lib/filesystems/browser-filesystem.ts
@@ -61,7 +61,15 @@ export class BrowserFileSystem implements FileSystem {
 
     if (bytes) {
       const start = parseInt(bytes[1]);
-      const end = parseInt(bytes[2]);
+      const end = Math.min(parseInt(bytes[2]), file.size - 1);
+      if (start > end) {
+        const response = new Response(null, {
+          status: 416,
+          headers: {'Content-Range': `bytes */${file.size}`}
+        });
+        Object.defineProperty(response, 'url', {value: path});
+        return response;
+      }
       // The trick when reading File objects is to read successive "slices" of the File
       // Per spec https://w3c.github.io/FileAPI/, slicing a File should only update the start and end fields
       // Actually reading from file should happen in `readAsArrayBuffer` (and as far we can tell it does)

--- a/modules/core/src/lib/filesystems/browser-filesystem.ts
+++ b/modules/core/src/lib/filesystems/browser-filesystem.ts
@@ -50,14 +50,14 @@ export class BrowserFileSystem implements FileSystem {
     }
 
     // Local fetches are served from the list of files
-    const file = this.files[path];
+    const file = this._getFile(path, true);
     if (!file) {
       return new Response(path, {status: 400, statusText: 'NOT FOUND'});
     }
 
     const headers = new Headers(options?.headers);
     const range = headers.get('Range');
-    const bytes = range && /bytes=($1)-($2)/.exec(range);
+    const bytes = range && /bytes=(\d+)-(\d+)/.exec(range);
 
     if (bytes) {
       const start = parseInt(bytes[1]);
@@ -65,8 +65,11 @@ export class BrowserFileSystem implements FileSystem {
       // The trick when reading File objects is to read successive "slices" of the File
       // Per spec https://w3c.github.io/FileAPI/, slicing a File should only update the start and end fields
       // Actually reading from file should happen in `readAsArrayBuffer` (and as far we can tell it does)
-      const data = await file.slice(start, end).arrayBuffer();
-      const response = new Response(data);
+      const data = await file.slice(start, end + 1).arrayBuffer();
+      const response = new Response(data, {
+        status: 206,
+        headers: {'Content-Range': `bytes ${start}-${end}/${file.size}`}
+      });
       Object.defineProperty(response, 'url', {value: path});
       return response;
     }
@@ -95,7 +98,7 @@ export class BrowserFileSystem implements FileSystem {
    * Return information (size) about files in this file system
    */
   async stat(path: string, options?: object): Promise<{size: number}> {
-    const file = this.files[path];
+    const file = this._getFile(path, false);
     if (!file) {
       throw new Error(path);
     }
@@ -106,16 +109,19 @@ export class BrowserFileSystem implements FileSystem {
    * Just removes the file from the list
    */
   async unlink(path: string): Promise<void> {
-    delete this.files[path];
-    delete this.lowerCaseFiles[path];
-    this.usedFiles[path] = true;
+    const file = this._getFile(path, false);
+    if (file) {
+      delete this.files[file.name];
+      delete this.lowerCaseFiles[file.name.toLowerCase()];
+      this.usedFiles[file.name] = true;
+    }
   }
 
   // implements IRandomAccessFileSystem
 
   // RANDOM ACCESS
   async openReadableFile(pathname: string, flags: unknown): Promise<ReadableFile> {
-    return new BlobFile(this.files[pathname]);
+    return new BlobFile(this._getFile(pathname, true));
   }
 
   // PRIVATE
@@ -123,7 +129,7 @@ export class BrowserFileSystem implements FileSystem {
   // Supports case independent paths, and file usage tracking
   _getFile(path: string, used: boolean): File {
     // Prefer case match, but fall back to case independent.
-    const file = this.files[path] || this.lowerCaseFiles[path];
+    const file = this.files[path] || this.lowerCaseFiles[path.toLowerCase()];
     if (file && used) {
       this.usedFiles[path] = true;
     }

--- a/modules/core/test/lib/filesystems/browser-filesystem.browser.spec.ts
+++ b/modules/core/test/lib/filesystems/browser-filesystem.browser.spec.ts
@@ -39,6 +39,18 @@ test('BrowserFileSystem supports ranges, case-insensitive lookup, metadata, and 
   expect(rangedResponse.status).toBe(206);
   expect(rangedResponse.headers.get('Content-Range')).toBe('bytes 1-3/6');
   expect(await rangedResponse.text()).toBe('bcd');
+  const clampedResponse = await fileSystem.fetch('folder/mixed.txt', {
+    headers: {Range: 'bytes=4-99'}
+  });
+  expect(clampedResponse.status).toBe(206);
+  expect(clampedResponse.headers.get('Content-Range')).toBe('bytes 4-5/6');
+  expect(await clampedResponse.text()).toBe('ef');
+  const unsatisfiedResponse = await fileSystem.fetch('folder/mixed.txt', {
+    headers: {Range: 'bytes=6-99'}
+  });
+  expect(unsatisfiedResponse.status).toBe(416);
+  expect(unsatisfiedResponse.headers.get('Content-Range')).toBe('bytes */6');
+  expect(await unsatisfiedResponse.text()).toBe('');
   expect((await fileSystem.fetch('Folder/Mixed.TXT')).url).toBe('Folder/Mixed.TXT');
   expect(await fileSystem.readdir('ignored')).toEqual(['Folder/Mixed.TXT']);
   expect(await fileSystem.stat('FOLDER/MIXED.TXT')).toEqual({size: 6});

--- a/modules/core/test/lib/filesystems/browser-filesystem.browser.spec.ts
+++ b/modules/core/test/lib/filesystems/browser-filesystem.browser.spec.ts
@@ -27,6 +27,34 @@ test('BrowserFileSystem#fetch', async () => {
   expect(response.ok, 'fetching non-existent file from browser file system fails').toBeFalsy();
 });
 
+test('BrowserFileSystem supports ranges, case-insensitive lookup, metadata, and removal', async () => {
+  const remoteFetch = async (url: string | URL | Request) => new Response(`remote:${String(url)}`);
+  const remoteUrl = ['https:', '', 'example.test', 'file'].join('/');
+  const file = new File(['abcdef'], 'Folder/Mixed.TXT', {type: 'text/plain'});
+  const fileSystem = new BrowserFileSystem([file], {fetch: remoteFetch as typeof fetch});
+
+  const rangedResponse = await fileSystem.fetch('folder/mixed.txt', {
+    headers: {Range: 'bytes=1-3'}
+  });
+  expect(rangedResponse.status).toBe(206);
+  expect(rangedResponse.headers.get('Content-Range')).toBe('bytes 1-3/6');
+  expect(await rangedResponse.text()).toBe('bcd');
+  expect((await fileSystem.fetch('Folder/Mixed.TXT')).url).toBe('Folder/Mixed.TXT');
+  expect(await fileSystem.readdir('ignored')).toEqual(['Folder/Mixed.TXT']);
+  expect(await fileSystem.stat('FOLDER/MIXED.TXT')).toEqual({size: 6});
+  expect(fileSystem._getFile('folder/mixed.txt', true)).toBe(file);
+  expect(await (await fileSystem.openReadableFile('FOLDER/MIXED.TXT', 'r')).read(0, 3)).toEqual(
+    new TextEncoder().encode('abc').buffer
+  );
+  expect(await (await fileSystem.fetch(remoteUrl)).text()).toBe(`remote:${remoteUrl}`);
+
+  await fileSystem.unlink('folder/mixed.txt');
+  expect(await fileSystem.readdir()).toEqual([]);
+  await expect(fileSystem.stat('Folder/Mixed.TXT')).rejects.toThrow('Folder/Mixed.TXT');
+  expect((await fileSystem.fetch('Folder/Mixed.TXT')).ok).toBe(false);
+  await fileSystem.unlink('missing.txt');
+});
+
 const readFile = url => fetchFile(url).then(response => response.arrayBuffer());
 
 let imagesPromise: Promise<File[]> | null = null;

--- a/modules/core/test/lib/loader-utils/get-data.spec.ts
+++ b/modules/core/test/lib/loader-utils/get-data.spec.ts
@@ -6,7 +6,9 @@ import {expect, test} from 'vitest';
 import {
   getArrayBufferOrStringFromDataSync,
   getArrayBufferOrStringFromData,
-  getAsyncIterableFromData
+  getArrayBufferFromData,
+  getAsyncIterableFromData,
+  getReadableStream
 } from '@loaders.gl/core/lib/loader-utils/get-data';
 import {isIterator, JSONLoader} from '@loaders.gl/core';
 const BinaryLoader = {
@@ -116,4 +118,95 @@ test('parseWithLoader#getArrayBufferOrStringFromData(SharedArrayBuffer iterables
   })();
   const result = await getArrayBufferOrStringFromData(iterator, BinaryLoader, {});
   expect(new Uint16Array(result as ArrayBuffer)).toEqual(uint16View.subarray(1, 4));
+});
+
+test('getArrayBufferOrStringFromData handles Blob, Response, stream, and invalid inputs', async () => {
+  await expect(getArrayBufferOrStringFromData(new Blob(['hello']), JSONLoader, {})).resolves.toBe(
+    'hello'
+  );
+  await expect(getArrayBufferOrStringFromData(new Response('world'), JSONLoader, {})).resolves.toBe(
+    'world'
+  );
+  const binary = await getArrayBufferOrStringFromData(new Response('abc'), BinaryLoader, {});
+  expect(new TextDecoder().decode(binary as ArrayBuffer)).toBe('abc');
+
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(new Uint8Array([1, 2]));
+      controller.enqueue(new Uint8Array([3]));
+      controller.close();
+    }
+  });
+  await expect(getArrayBufferOrStringFromData(stream, BinaryLoader, {})).resolves.toEqual(
+    new Uint8Array([1, 2, 3]).buffer
+  );
+  await expect(getArrayBufferOrStringFromData({} as never, BinaryLoader, {})).rejects.toThrow(
+    'Cannot convert supplied data type'
+  );
+});
+
+test('getArrayBufferFromData preserves all supported binary input forms', async () => {
+  expect(new TextDecoder().decode(await getArrayBufferFromData('text', {}))).toBe('text');
+
+  const backing = new Uint8Array([9, 1, 2, 8]);
+  await expect(getArrayBufferFromData(backing.subarray(1, 3), {})).resolves.toEqual(
+    new Uint8Array([1, 2]).buffer
+  );
+  await expect(getArrayBufferFromData(new Blob([new Uint8Array([3, 4])]), {})).resolves.toEqual(
+    new Uint8Array([3, 4]).buffer
+  );
+  await expect(getArrayBufferFromData(new Response(new Uint8Array([5, 6])), {})).resolves.toEqual(
+    new Uint8Array([5, 6]).buffer
+  );
+
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(new Uint8Array([7]));
+      controller.enqueue(new Uint8Array([8]));
+      controller.close();
+    }
+  });
+  await expect(getArrayBufferFromData(stream, {})).resolves.toEqual(new Uint8Array([7, 8]).buffer);
+  await expect(getArrayBufferFromData({} as never, {})).rejects.toThrow(
+    'Cannot convert supplied data type'
+  );
+});
+
+test('getAsyncIterableFromData resolves promises, responses, blobs, and streams', async () => {
+  const promised = await getAsyncIterableFromData(
+    Promise.resolve(new Uint8Array([1, 2]).buffer),
+    {}
+  );
+  expect(Array.from(promised as Iterable<ArrayBuffer>)).toHaveLength(1);
+
+  const responseIterator = await getAsyncIterableFromData(new Response('response'), {});
+  const responseChunks: ArrayBufferLike[] = [];
+  for await (const chunk of responseIterator) responseChunks.push(chunk as ArrayBufferLike);
+  expect(responseChunks.length).toBeGreaterThan(0);
+
+  const blobIterator = await getAsyncIterableFromData(new Blob(['blob']), {});
+  const blobChunks: ArrayBufferLike[] = [];
+  for await (const chunk of blobIterator) blobChunks.push(chunk as ArrayBufferLike);
+  expect(blobChunks.length).toBeGreaterThan(0);
+
+  await expect(getAsyncIterableFromData(new Response(null), {})).rejects.toThrow(
+    'Cannot convert supplied data type'
+  );
+});
+
+test('getReadableStream preserves streams and unwraps responses and blobs', async () => {
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(new Uint8Array([1]));
+      controller.close();
+    }
+  });
+  await expect(getReadableStream(stream)).resolves.toBe(stream);
+
+  const response = new Response('response');
+  await expect(getReadableStream(response)).resolves.toBe(response.body);
+  await expect(getReadableStream(new Blob(['blob']))).resolves.toBeInstanceOf(ReadableStream);
+  await expect(getReadableStream(new Response(null))).rejects.toThrow(
+    'Cannot convert supplied data type'
+  );
 });

--- a/modules/core/test/lib/loader-utils/option-utils.spec.ts
+++ b/modules/core/test/lib/loader-utils/option-utils.spec.ts
@@ -4,7 +4,9 @@
 
 import {expect, test} from 'vitest';
 import {
+  getGlobalLoaderState,
   getGlobalLoaderOptions,
+  normalizeLoaderOptions,
   normalizeOptions,
   setGlobalOptions
 } from '@loaders.gl/core/lib/loader-utils/option-utils';
@@ -105,4 +107,72 @@ test('normalizeOptions#movesGlobalCoreOptions', () => {
     'deprecated top-level alias is removed after normalization'
   ).toBe(undefined);
   setGlobalOptions(originalClone);
+});
+
+test('normalizeLoaderOptions clones nested core options and migrates legacy aliases', () => {
+  const input = {
+    baseUri: 'legacy/',
+    worker: false,
+    _worker: 'module',
+    core: {baseUrl: 'explicit/', worker: true}
+  } as any;
+  const normalized = normalizeLoaderOptions(input);
+
+  expect(normalized.core).toMatchObject({
+    baseUrl: 'explicit/',
+    worker: true,
+    _workerType: 'module'
+  });
+  expect(normalized).not.toHaveProperty('worker');
+  expect(normalized).not.toHaveProperty('_worker');
+  expect(normalized.core).not.toBe(input.core);
+  expect(input.core).toEqual({baseUrl: 'explicit/', worker: true});
+});
+
+test('normalizeOptions covers loader validation, null logging, and fixed base URLs', () => {
+  const loader = {
+    id: 'example',
+    name: 'Example',
+    module: 'test',
+    version: 'latest',
+    extensions: ['example'],
+    mimeTypes: [],
+    options: {
+      core: {log: null},
+      batchSize: 10,
+      example: {shape: 'default', known: true}
+    },
+    deprecatedOptions: {example: {removed: 'example.known'}}
+  } as any;
+
+  const normalized = normalizeOptions(
+    {
+      core: {baseUrl: 'fixed/'},
+      batch: 2,
+      unrelated: {allowed: true},
+      example: {removed: true, workerUrl: 'worker.js', unknown: true}
+    },
+    loader,
+    loader,
+    'https://example.test/path/file.example?query=1'
+  );
+  expect(normalized.core.baseUrl).toBe('fixed/');
+  expect(normalized.core.log?.warn('ignored')).toBeTypeOf('function');
+  expect(normalized.example).toMatchObject({shape: 'default', known: true, removed: true});
+});
+
+test('normalizeOptions honors global scoped shape and initializes missing global state', () => {
+  const globalObject = globalThis as any;
+  const originalLoaders = globalObject.loaders;
+  try {
+    delete globalObject.loaders;
+    const state = getGlobalLoaderState();
+    expect(state).toEqual({});
+    setGlobalOptions({arrow: {shape: 'columnar-table'}});
+    expect(normalizeOptions({core: {shape: 'object-row-table'}}, ArrowLoader).arrow.shape).toBe(
+      'columnar-table'
+    );
+  } finally {
+    globalObject.loaders = originalLoaders;
+  }
 });

--- a/modules/deck-layers/test/data-driven-tile-3d-layer.spec.ts
+++ b/modules/deck-layers/test/data-driven-tile-3d-layer.spec.ts
@@ -1,0 +1,173 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {Tile3DLayer} from '@deck.gl/geo-layers';
+import {TILE_TYPE} from '@loaders.gl/tiles';
+import {afterEach, expect, test, vi} from 'vitest';
+import {DataDrivenTile3DLayer} from '../src/data-driven-tile-3d-layer';
+
+/** Creates an isolated layer whose state updates do not require a Deck instance. */
+function createLayer(props: Record<string, unknown> = {}) {
+  const layer = new DataDrivenTile3DLayer({
+    id: 'data-driven',
+    data: null,
+    loader: {},
+    ...props
+  } as any) as any;
+  layer.state = {
+    activeViewports: {},
+    lastUpdatedViewports: null,
+    layerMap: {},
+    tileset3d: null,
+    colorsByAttribute: null,
+    filtersByAttribute: null,
+    loadingCounter: 0
+  };
+  layer.setState = (update: Record<string, unknown>) => Object.assign(layer.state, update);
+  layer.setNeedsUpdate = vi.fn();
+  return layer;
+}
+
+/** Flushes callbacks attached to already-settled promises. */
+async function flushPromises(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+test('data-driven traversal applies color and filter hooks to mesh tiles', async () => {
+  vi.spyOn(Tile3DLayer.prototype as any, '_updateTileset').mockImplementation(() => {});
+  const customizeColors = vi
+    .fn()
+    .mockResolvedValueOnce({id: 'changed', isColored: true})
+    .mockRejectedValueOnce(new Error('ignored'));
+  const filterTile = vi
+    .fn()
+    .mockResolvedValueOnce({id: 'unchanged', isFiltered: false})
+    .mockResolvedValueOnce({id: 'changed', isFiltered: true});
+  const onTraversalComplete = vi.fn(tiles => tiles.slice(0, 1));
+  const layer = createLayer({customizeColors, filterTile, onTraversalComplete});
+  layer.state.colorsByAttribute = {attributeName: 'height'};
+  layer.state.filtersByAttribute = {attributeName: 'height'};
+  layer.state.layerMap = {changed: {cached: true}, unchanged: {cached: true}};
+  const tiles = [
+    {id: 'changed', type: TILE_TYPE.MESH},
+    {id: 'unchanged', type: TILE_TYPE.MESH}
+  ];
+
+  expect(layer._onTraversalComplete(tiles)).toEqual([tiles[0]]);
+  expect(layer.state.loadingCounter).toBe(2);
+  await flushPromises();
+
+  expect(customizeColors).toHaveBeenCalledTimes(2);
+  expect(filterTile).toHaveBeenCalledTimes(2);
+  expect(layer.state.layerMap.changed).toBeUndefined();
+  expect(layer.state.layerMap.unchanged).toEqual({cached: true});
+  expect(layer.state.loadingCounter).toBe(0);
+  expect(layer.setNeedsUpdate).toHaveBeenCalled();
+});
+
+test('data-driven hooks skip non-mesh tiles and default traversal returns its input', () => {
+  const customizeColors = vi.fn();
+  const filterTile = vi.fn();
+  const layer = createLayer({customizeColors, filterTile});
+  const tiles = [{id: 'point', type: TILE_TYPE.POINTCLOUD}];
+
+  expect(layer._onTraversalComplete(tiles)).toBe(tiles);
+  expect(customizeColors).not.toHaveBeenCalled();
+  expect(filterTile).not.toHaveBeenCalled();
+});
+
+test('data-driven tileset-wide hooks and tile loads cover empty and populated state', () => {
+  const updateTileset = vi
+    .spyOn(Tile3DLayer.prototype as any, '_updateTileset')
+    .mockImplementation(() => {});
+  const onTileLoad = vi.fn();
+  const layer = createLayer({onTileLoad});
+  layer._colorizeTiles = vi.fn();
+  layer._filterTiles = vi.fn();
+
+  layer._colorizeTileset();
+  layer._filterTileset();
+  expect(layer._colorizeTiles).not.toHaveBeenCalled();
+
+  const tiles = [{id: 'mesh', type: TILE_TYPE.MESH}];
+  layer.state.tileset3d = {selectedTiles: tiles};
+  layer._colorizeTileset();
+  layer._filterTileset();
+  expect(layer._colorizeTiles).toHaveBeenCalledWith(tiles);
+  expect(layer._filterTiles).toHaveBeenCalledWith(tiles);
+
+  layer.state.lastUpdatedViewports = {main: {}};
+  layer._onTileLoad(tiles[0]);
+  expect(onTileLoad).toHaveBeenCalledWith(tiles[0]);
+  expect(updateTileset).toHaveBeenCalledWith(layer.state.lastUpdatedViewports);
+  expect(layer.setNeedsUpdate).toHaveBeenCalled();
+
+  layer.state.colorsByAttribute = {attributeName: 'height'};
+  updateTileset.mockClear();
+  layer._onTileLoad(tiles[0]);
+  expect(updateTileset).not.toHaveBeenCalled();
+});
+
+test('data-driven updateState handles data, styling, viewport, loading, and fallback updates', () => {
+  const updateTileset = vi
+    .spyOn(Tile3DLayer.prototype as any, '_updateTileset')
+    .mockImplementation(() => {});
+  const updateBaseState = vi
+    .spyOn(Tile3DLayer.prototype as any, 'updateState')
+    .mockImplementation(() => {});
+  const layer = createLayer();
+  layer._loadTileset = vi.fn();
+  layer._colorizeTileset = vi.fn();
+  layer._filterTileset = vi.fn();
+
+  layer.updateState({
+    props: {...layer.props, data: 'tileset.json'},
+    oldProps: {...layer.props, data: null},
+    changeFlags: {}
+  });
+  expect(layer._loadTileset).toHaveBeenCalledWith('tileset.json');
+
+  const colorsByAttribute = {attributeName: 'height'};
+  layer.updateState({
+    props: {...layer.props, colorsByAttribute},
+    oldProps: {...layer.props, colorsByAttribute: null},
+    changeFlags: {}
+  });
+  expect(layer.state.colorsByAttribute).toBe(colorsByAttribute);
+  expect(layer._colorizeTileset).toHaveBeenCalled();
+
+  const filtersByAttribute = {attributeName: 'height'};
+  layer.updateState({
+    props: {...layer.props, filtersByAttribute},
+    oldProps: {...layer.props, filtersByAttribute: null},
+    changeFlags: {}
+  });
+  expect(layer.state.filtersByAttribute).toBe(filtersByAttribute);
+  expect(layer._filterTileset).toHaveBeenCalled();
+
+  layer.state.activeViewports = {main: {id: 'main'}};
+  layer.updateState({
+    props: layer.props,
+    oldProps: layer.props,
+    changeFlags: {viewportChanged: true}
+  });
+  expect(updateTileset).toHaveBeenCalledWith({main: {id: 'main'}});
+  expect(layer.state.activeViewports).toEqual({});
+
+  updateTileset.mockClear();
+  layer.state.activeViewports = {main: {id: 'main'}};
+  layer.state.loadingCounter = 1;
+  layer.updateState({
+    props: layer.props,
+    oldProps: layer.props,
+    changeFlags: {viewportChanged: true}
+  });
+  expect(updateTileset).not.toHaveBeenCalled();
+
+  layer.updateState({props: layer.props, oldProps: layer.props, changeFlags: {}});
+  expect(updateBaseState).toHaveBeenCalled();
+});

--- a/modules/geoarrow/src/mesharrow/get-bounding-box.ts
+++ b/modules/geoarrow/src/mesharrow/get-bounding-box.ts
@@ -10,16 +10,14 @@ export type BoundingBox = [[number, number, number], [number, number, number]];
 export function getBoundingBoxFromArrowPositions(
   column: arrow.Vector<arrow.FixedSizeList>
 ): BoundingBox {
-  const mins: [number, number, number] = [Number.MAX_VALUE, Number.MAX_VALUE, Number.MAX_VALUE];
-  const maxs: [number, number, number] = [Number.MIN_VALUE, Number.MIN_VALUE, Number.MIN_VALUE];
+  const mins: [number, number, number] = [Infinity, Infinity, Infinity];
+  const maxs: [number, number, number] = [-Infinity, -Infinity, -Infinity];
 
   const valueColumn = column.getChildAt(0)!;
   for (const data of valueColumn.data) {
     const pointSize = 3; // attributes.POSITION.size;
     const pointData = data.buffers[arrow.BufferType.DATA];
-    const pointCount = pointData.length / pointSize;
-
-    for (let i = 0; i < pointCount; i += pointSize) {
+    for (let i = 0; i < pointData.length; i += pointSize) {
       const x = pointData[i];
       const y = pointData[i + 1];
       const z = pointData[i + 2];

--- a/modules/geoarrow/src/mesharrow/get-bounding-box.ts
+++ b/modules/geoarrow/src/mesharrow/get-bounding-box.ts
@@ -14,23 +14,23 @@ export function getBoundingBoxFromArrowPositions(
   const maxs: [number, number, number] = [-Infinity, -Infinity, -Infinity];
 
   const valueColumn = column.getChildAt(0)!;
-  for (const data of valueColumn.data) {
-    const pointSize = 3; // attributes.POSITION.size;
-    const pointData = data.buffers[arrow.BufferType.DATA];
-    for (let i = 0; i < pointData.length; i += pointSize) {
-      const x = pointData[i];
-      const y = pointData[i + 1];
-      const z = pointData[i + 2];
+  // `toArray()` rebases sliced vectors to their logical range. It is zero-copy for the
+  // common single-chunk numeric case and only combines data when the vector is chunked.
+  const pointData = valueColumn.toArray();
+  const pointSize = 3; // attributes.POSITION.size;
+  for (let i = 0; i < pointData.length; i += pointSize) {
+    const x = pointData[i];
+    const y = pointData[i + 1];
+    const z = pointData[i + 2];
 
-      if (x < mins[0]) mins[0] = x;
-      else if (x > maxs[0]) maxs[0] = x;
+    if (x < mins[0]) mins[0] = x;
+    if (x > maxs[0]) maxs[0] = x;
 
-      if (y < mins[1]) mins[1] = y;
-      else if (y > maxs[1]) maxs[1] = y;
+    if (y < mins[1]) mins[1] = y;
+    if (y > maxs[1]) maxs[1] = y;
 
-      if (z < mins[2]) mins[2] = z;
-      else if (z > maxs[2]) maxs[2] = z;
-    }
+    if (z < mins[2]) mins[2] = z;
+    if (z > maxs[2]) maxs[2] = z;
   }
 
   return [mins, maxs];

--- a/modules/geoarrow/test/mesharrow-boundary.spec.ts
+++ b/modules/geoarrow/test/mesharrow-boundary.spec.ts
@@ -31,9 +31,24 @@ test('mesharrow bounding boxes inspect every point and support negative maxima',
     new Float64Array([-5, -4, -3, -2, -1, -8, -7, -6, -0.5]),
     3
   );
-
   expect(getBoundingBoxFromArrowPositions(positions)).toEqual([
     [-7, -6, -8],
     [-2, -1, -0.5]
+  ]);
+});
+
+test('mesharrow bounding boxes respect Arrow slice bounds', () => {
+  const positions = getFixedSizeListVector(
+    new Float64Array([100, 100, 100, -5, -4, -3, -2, -1, -0.5, 200, 200, 200]),
+    3
+  );
+
+  expect(getBoundingBoxFromArrowPositions(positions.slice(1, 3))).toEqual([
+    [-5, -4, -3],
+    [-2, -1, -0.5]
+  ]);
+  expect(getBoundingBoxFromArrowPositions(positions.slice(1, 2))).toEqual([
+    [-5, -4, -3],
+    [-5, -4, -3]
   ]);
 });

--- a/modules/geoarrow/test/mesharrow-boundary.spec.ts
+++ b/modules/geoarrow/test/mesharrow-boundary.spec.ts
@@ -1,0 +1,39 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {expect, test} from 'vitest';
+import {
+  getFixedSizeListData,
+  getFixedSizeListSize,
+  getFixedSizeListType,
+  getFixedSizeListVector,
+  isFixedSizeList
+} from '../src/mesharrow/arrow-fixed-size-list-utils';
+import {getBoundingBoxFromArrowPositions} from '../src/mesharrow/get-bounding-box';
+
+test('mesharrow fixed-size-list helpers preserve stride and values', () => {
+  const positions = new Float32Array([-5, -4, -3, 2, 7, 1, -1, 3, 9]);
+  const type = getFixedSizeListType(positions, 3);
+  const data = getFixedSizeListData(positions, 3);
+  const vector = getFixedSizeListVector(positions, 3);
+
+  expect(type.listSize).toBe(3);
+  expect(data.length).toBe(3);
+  expect(isFixedSizeList(vector)).toBe(true);
+  expect(getFixedSizeListSize(vector)).toBe(3);
+  expect(getFixedSizeListSize(vector.getChildAt(0)!)).toBe(1);
+  expect(Array.from(vector.getChildAt(0)!.toArray())).toEqual(Array.from(positions));
+});
+
+test('mesharrow bounding boxes inspect every point and support negative maxima', () => {
+  const positions = getFixedSizeListVector(
+    new Float64Array([-5, -4, -3, -2, -1, -8, -7, -6, -0.5]),
+    3
+  );
+
+  expect(getBoundingBoxFromArrowPositions(positions)).toEqual([
+    [-7, -6, -8],
+    [-2, -1, -0.5]
+  ]);
+});

--- a/modules/geotiff/test/raster-source-boundary.spec.ts
+++ b/modules/geotiff/test/raster-source-boundary.spec.ts
@@ -1,0 +1,460 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {
+  RasterBoundingBox,
+  RasterChannelDataType,
+  RasterViewport
+} from '@loaders.gl/loader-utils';
+import {expect, test, vi} from 'vitest';
+import {GeoTIFFRasterSource, GeoTIFFSourceLoader} from '../src/geotiff-source-loader';
+import {OMETiffImageSource, OMETiffSourceLoader} from '../src/ometiff-source-loader';
+
+/** Creates the minimal viewport shape accepted by raster sources. */
+function createViewport(bounds: RasterBoundingBox, crs = 'EPSG:4326', width = 10, height = 8) {
+  return {bounds, crs, width, height} as RasterViewport;
+}
+
+/** Installs deterministic GeoTIFF initialization state without opening a file. */
+function installGeoTIFFState(
+  source: GeoTIFFRasterSource,
+  metadata: Record<string, unknown>,
+  readRasters: ReturnType<typeof vi.fn> = vi.fn()
+): ReturnType<typeof vi.fn> {
+  (source as any)._initPromise = Promise.resolve({
+    tiff: {readRasters},
+    images: [],
+    metadata: {
+      name: 'memory.tif',
+      width: 10,
+      height: 10,
+      bandCount: 2,
+      dtype: 'uint16',
+      noData: null,
+      crs: 'EPSG:4326',
+      boundingBox: [
+        [0, 0],
+        [10, 10]
+      ],
+      metadata: {},
+      ...metadata
+    }
+  });
+  return readRasters;
+}
+
+test('GeoTIFF source loader recognizes GeoTIFF but not OME-TIFF URLs', () => {
+  expect(GeoTIFFSourceLoader.testURL('image.tif?token=1')).toBe(true);
+  expect(GeoTIFFSourceLoader.testURL('image.geotiff#page')).toBe(true);
+  expect(GeoTIFFSourceLoader.testURL('image.ome.tif')).toBe(false);
+  expect(OMETiffSourceLoader.testURL('image.ome.tiff?token=1')).toBe(true);
+  expect(OMETiffSourceLoader.testURL('image.tiff')).toBe(false);
+  expect(GeoTIFFSourceLoader.createDataSource(new Blob([]), {})).toBeInstanceOf(
+    GeoTIFFRasterSource
+  );
+  expect(OMETiffSourceLoader.createDataSource(new Blob([]), {})).toBeInstanceOf(OMETiffImageSource);
+});
+
+test('GeoTIFF raster reads clip bounds and normalize planar and interleaved output', async () => {
+  const source = new GeoTIFFRasterSource(new Blob([]), {
+    geotiff: {interleaved: false, resampleMethod: 'bilinear'}
+  });
+  const planar = [new Uint16Array([1, 2, 3, 4])] as any;
+  planar.width = 2;
+  planar.height = 2;
+  const interleaved = new Uint16Array([1, 2, 3, 4]) as any;
+  interleaved.width = 2;
+  interleaved.height = 1;
+  const readRasters = installGeoTIFFState(source, {noData: -1});
+  readRasters.mockResolvedValueOnce(planar).mockResolvedValueOnce(interleaved);
+
+  const clipped = await source.getRaster({
+    viewport: createViewport(
+      [
+        [-5, -5],
+        [5, 5]
+      ],
+      'EPSG:4326',
+      20,
+      10
+    ),
+    bands: [1]
+  });
+  expect(clipped).toMatchObject({
+    width: 2,
+    height: 2,
+    bandCount: 1,
+    interleaved: false,
+    boundingBox: [
+      [0, 0],
+      [5, 5]
+    ]
+  });
+  expect(clipped.data).toBe(planar[0]);
+  expect(readRasters).toHaveBeenNthCalledWith(
+    1,
+    expect.objectContaining({
+      bbox: [0, 0, 5, 5],
+      width: 10,
+      height: 5,
+      samples: [1],
+      interleave: false,
+      resampleMethod: 'bilinear',
+      fillValue: -1
+    })
+  );
+
+  const packed = await source.getRaster({
+    viewport: createViewport([
+      [0, 0],
+      [10, 10]
+    ]),
+    interleaved: true,
+    resampleMethod: 'nearest'
+  });
+  expect(packed.data).toBe(interleaved);
+  expect(packed.bandCount).toBe(2);
+});
+
+test.each([
+  'uint8',
+  'uint16',
+  'uint32',
+  'int8',
+  'int16',
+  'int32',
+  'float32',
+  'float64',
+  'unknown'
+] as RasterChannelDataType[])('GeoTIFF empty %s rasters retain viewport shape', async dtype => {
+  const source = new GeoTIFFRasterSource(new Blob([]), {});
+  installGeoTIFFState(source, {dtype, noData: 7});
+  const raster = await source.getRaster({
+    viewport: createViewport(
+      [
+        [20, 20],
+        [30, 30]
+      ],
+      'EPSG:4326',
+      3,
+      2
+    ),
+    bands: [0, 1]
+  });
+
+  expect(raster).toMatchObject({width: 3, height: 2, bandCount: 2, interleaved: false});
+  expect(Array.isArray(raster.data)).toBe(true);
+  expect(Array.from((raster.data as any[])[0])).toEqual([7, 7, 7, 7, 7, 7]);
+});
+
+test('GeoTIFF raster validates cancellation, projection, bounds, and capabilities', async () => {
+  const source = new GeoTIFFRasterSource(new Blob([]), {});
+  installGeoTIFFState(source, {});
+  expect(source.getRasterQueryCapabilities()).toBe(source.rasterQueryCapabilities);
+
+  const controller = new AbortController();
+  controller.abort();
+  await expect(
+    source.getRaster({
+      viewport: createViewport([
+        [0, 0],
+        [1, 1]
+      ]),
+      signal: controller.signal
+    })
+  ).rejects.toThrow('Request aborted');
+  await expect(
+    source.getRaster({
+      viewport: createViewport(
+        [
+          [0, 0],
+          [1, 1]
+        ],
+        'EPSG:3857'
+      )
+    })
+  ).rejects.toThrow('does not support reprojection');
+
+  const unbounded = new GeoTIFFRasterSource(new Blob([]), {});
+  installGeoTIFFState(unbounded, {boundingBox: undefined});
+  await expect(
+    unbounded.getRaster({
+      viewport: createViewport([
+        [0, 0],
+        [1, 1]
+      ])
+    })
+  ).rejects.toThrow('requires source bounds');
+});
+
+test.each([
+  [1, 8, 'uint8'],
+  [1, 16, 'uint16'],
+  [1, 32, 'uint32'],
+  [2, 8, 'int8'],
+  [2, 16, 'int16'],
+  [2, 32, 'int32'],
+  [3, 32, 'float32'],
+  [3, 64, 'float64']
+] as const)('GeoTIFF metadata maps sample format %s/%s to %s', (sampleFormat, bits, dtype) => {
+  const source = new GeoTIFFRasterSource('https://example.com/path/image.tif?token=1', {
+    core: {attributions: ['imagery']}
+  });
+  const image = {
+    getBoundingBox: () => [1, 2, 11, 12],
+    getGeoKeys: () => ({ProjectedCSTypeGeoKey: 32633}),
+    getGDALMetadata: () => ({AREA_OR_POINT: 'Area'}),
+    getGDALNoData: () => -9999,
+    getWidth: () => 10,
+    getHeight: () => 10,
+    getSamplesPerPixel: () => 2,
+    getBitsPerSample: () => [bits],
+    getSampleFormat: () => [sampleFormat],
+    getTileWidth: () => 4,
+    getTileHeight: () => 5,
+    getResolution: () => [1, 2]
+  };
+
+  expect((source as any)._getMetadata(image, [image])).toMatchObject({
+    name: 'image.tif',
+    attributions: ['imagery'],
+    crs: 'EPSG:32633',
+    boundingBox: [
+      [1, 2],
+      [11, 12]
+    ],
+    dtype,
+    tileSize: {width: 4, height: 5},
+    overviews: [{resolution: [1, 2]}],
+    noData: -9999
+  });
+});
+
+test('GeoTIFF metadata tolerates absent geospatial metadata and rejects unsupported samples', () => {
+  const source = new GeoTIFFRasterSource(new Blob([]), {});
+  const image = {
+    getBoundingBox: () => {
+      throw new Error('missing');
+    },
+    getGeoKeys: () => ({GeographicTypeGeoKey: 4326}),
+    getGDALMetadata: () => undefined,
+    getGDALNoData: () => undefined,
+    getWidth: () => 1,
+    getHeight: () => 1,
+    getSamplesPerPixel: () => 1,
+    getBitsPerSample: () => 8,
+    getSampleFormat: () => 1,
+    getTileWidth: () => 1,
+    getTileHeight: () => 1,
+    getResolution: () => {
+      throw new Error('missing');
+    }
+  };
+  expect((source as any)._getMetadata(image, [image])).toMatchObject({
+    name: undefined,
+    crs: 'EPSG:4326',
+    boundingBox: undefined,
+    noData: null,
+    overviews: [{resolution: undefined}]
+  });
+
+  expect(() => (source as any)._getMetadata({...image, getSampleFormat: () => 4}, [image])).toThrow(
+    'does not support sample format 4'
+  );
+  expect(() =>
+    (source as any)._getMetadata({...image, getBitsPerSample: () => 24}, [image])
+  ).toThrow('with 24 bits');
+});
+
+test('GeoTIFF initialization caches images and rejects empty datasets', async () => {
+  const source = new GeoTIFFRasterSource(new Blob([]), {});
+  const image = {
+    getBoundingBox: () => [0, 0, 1, 1],
+    getWidth: () => 1,
+    getHeight: () => 1,
+    getSamplesPerPixel: () => 1,
+    getBitsPerSample: () => 8,
+    getSampleFormat: () => 1,
+    getTileWidth: () => 1,
+    getTileHeight: () => 1,
+    getResolution: () => [1, 1]
+  };
+  const tiff = {
+    getImageCount: vi.fn(async () => 1),
+    getImage: vi.fn(async () => image)
+  };
+  (source as any)._openGeoTIFF = vi.fn(async () => tiff);
+  const firstPromise = (source as any)._getInitPromise();
+  expect((source as any)._getInitPromise()).toBe(firstPromise);
+  await expect(firstPromise).resolves.toMatchObject({images: [image]});
+
+  const empty = new GeoTIFFRasterSource(new Blob([]), {});
+  (empty as any)._openGeoTIFF = vi.fn(async () => ({getImageCount: async () => 0}));
+  await expect((empty as any)._initialize()).rejects.toThrow('could not load any images');
+});
+
+test('GeoTIFF query metadata covers optional spatial fields and post-load cancellation', async () => {
+  const source = new GeoTIFFRasterSource(new Blob([]), {});
+  source.getMetadata = async () => ({
+    width: 1,
+    height: 1,
+    bandCount: 1,
+    dtype: 'uint8',
+    noData: null,
+    crs: {authority: 'EPSG', code: 4326} as any,
+    metadata: {}
+  });
+  await expect(source.getQueryMetadata()).resolves.toMatchObject({
+    spatial: undefined,
+    levels: undefined,
+    columns: [{name: 'band_1', nullable: false}]
+  });
+
+  const controller = new AbortController();
+  source.getMetadata = async () => {
+    controller.abort();
+    return {
+      width: 1,
+      height: 1,
+      bandCount: 1,
+      dtype: 'uint8',
+      noData: null,
+      metadata: {}
+    };
+  };
+  await expect(source.getQueryMetadata({signal: controller.signal})).rejects.toThrow('aborted');
+});
+
+/** Installs deterministic OME-TIFF initialization state without opening a file. */
+function installOMETiffState(
+  source: OMETiffImageSource,
+  dtype: RasterChannelDataType,
+  bandCount = 3
+) {
+  const getRaster = vi.fn(async ({selection}: any) => ({
+    width: 2,
+    height: 1,
+    data: createTypedValues(dtype, [selection.c + 1, selection.c + 11])
+  }));
+  (source as any)._initPromise = Promise.resolve({
+    data: [{getRaster}],
+    metadata: {
+      name: 'image.ome.tif',
+      width: 2,
+      height: 1,
+      bandCount,
+      dtype,
+      sizeT: 2,
+      sizeZ: 2,
+      sizeC: bandCount,
+      labels: ['t', 'z', 'c', 'y', 'x'],
+      levels: [{level: 0, width: 2, height: 1}],
+      channels: Array.from({length: bandCount}, (_, index) => ({index})),
+      metadata: {}
+    }
+  });
+  return getRaster;
+}
+
+/** Allocates a small typed array for an OME test dtype. */
+function createTypedValues(dtype: RasterChannelDataType, values: number[]) {
+  const constructors: Record<string, any> = {
+    uint8: Uint8Array,
+    uint16: Uint16Array,
+    uint32: Uint32Array,
+    int8: Int8Array,
+    int16: Int16Array,
+    int32: Int32Array,
+    float32: Float32Array,
+    float64: Float64Array
+  };
+  return new (constructors[dtype] || Uint8Array)(values);
+}
+
+test.each([
+  'uint8',
+  'uint16',
+  'uint32',
+  'int8',
+  'int16',
+  'int32',
+  'float32',
+  'float64'
+] as RasterChannelDataType[])('OME-TIFF interleaves %s channel data', async dtype => {
+  const source = new OMETiffImageSource(new Blob([]), {});
+  installOMETiffState(source, dtype);
+  const raster = await source.getRaster({channels: [0, 2], interleaved: true, t: 1, z: 1});
+
+  expect(raster).toMatchObject({width: 2, height: 1, bandCount: 2, dtype, interleaved: true});
+  expect(Array.from(raster.data as any)).toEqual([1, 3, 11, 13]);
+  expect(raster.metadata).toMatchObject({selection: {t: 1, z: 1}, channels: [0, 2]});
+});
+
+test('OME-TIFF applies channel defaults and validates selections and levels', async () => {
+  const source = new OMETiffImageSource(new Blob([]), {
+    ometiff: {defaultChannels: [1], interleaved: false}
+  });
+  const getRaster = installOMETiffState(source, 'uint16');
+  const raster = await source.getRaster();
+  expect(raster.data).toBeInstanceOf(Uint16Array);
+  expect(getRaster).toHaveBeenCalledWith(expect.objectContaining({selection: {t: 0, z: 0, c: 1}}));
+
+  const twoBandSource = new OMETiffImageSource(new Blob([]), {});
+  installOMETiffState(twoBandSource, 'uint8', 2);
+  await twoBandSource.getRaster();
+  await expect(twoBandSource.getRaster({channels: [-1]})).rejects.toThrow('out of bounds');
+  await expect(twoBandSource.getRaster({channels: [2]})).rejects.toThrow('out of bounds');
+  await expect(twoBandSource.getRaster({level: 1})).rejects.toThrow('not available');
+
+  const threeBandSource = new OMETiffImageSource(new Blob([]), {});
+  const threeBandReads = installOMETiffState(threeBandSource, 'uint8', 3);
+  await expect(threeBandSource.getRaster()).resolves.toMatchObject({bandCount: 3});
+  expect(threeBandReads).toHaveBeenCalledTimes(3);
+
+  const unsupported = new OMETiffImageSource(new Blob([]), {});
+  installOMETiffState(unsupported, 'unknown' as RasterChannelDataType, 2);
+  await expect(unsupported.getRaster({channels: [0, 1], interleaved: true})).rejects.toThrow(
+    'Unsupported raster channel type'
+  );
+});
+
+test('OME-TIFF query metadata covers fallback channel names, colors, and cancellation', async () => {
+  const source = new OMETiffImageSource(new Blob([]), {});
+  source.getMetadata = async () => ({
+    width: 2,
+    height: 1,
+    bandCount: 1,
+    dtype: 'uint8',
+    sizeT: 1,
+    sizeZ: 1,
+    sizeC: 1,
+    labels: ['y', 'x'],
+    channels: [{index: 0, color: [1, 2, 3, 4]}],
+    levels: [{level: 0, width: 2, height: 1}],
+    metadata: {}
+  });
+  await expect(source.getQueryMetadata()).resolves.toMatchObject({
+    capabilities: {levelOfDetail: 'unsupported'},
+    columns: [{name: 'channel_1', metadata: {color: '1,2,3,4'}}]
+  });
+
+  const controller = new AbortController();
+  source.getMetadata = async () => {
+    controller.abort();
+    return {
+      width: 1,
+      height: 1,
+      bandCount: 1,
+      dtype: 'uint8',
+      sizeT: 1,
+      sizeZ: 1,
+      sizeC: 1,
+      labels: [],
+      channels: [],
+      levels: [],
+      metadata: {}
+    };
+  };
+  await expect(source.getQueryMetadata({signal: controller.signal})).rejects.toThrow('aborted');
+});

--- a/modules/gis/src/lib/utils/hex-encoder.ts
+++ b/modules/gis/src/lib/utils/hex-encoder.ts
@@ -20,8 +20,8 @@ export class HexEncoder {
   /** Decode hexadecimal */
   decode(array: Uint8Array, result: Uint8Array): Uint8Array {
     for (let i = 0; i < array.byteLength / 2; ++i) {
-      const halfByte1 = hexDecode(array[i]);
-      const halfByte2 = hexDecode(array[i + 1]);
+      const halfByte1 = hexDecode(array[i * 2]);
+      const halfByte2 = hexDecode(array[i * 2 + 1]);
       result[i] = halfByte1 * 16 + halfByte2;
     }
     // Check if final half byte (is that legal?)
@@ -35,8 +35,8 @@ export class HexEncoder {
   encode(array: Uint8Array, result: Uint8Array): Uint8Array {
     for (let i = 0; i < array.byteLength; ++i) {
       const byte = array[i];
-      result[i * 2] = hexEncode(byte & 0x0f);
-      result[i * 2 + 1] = hexEncode(byte & 0xf0);
+      result[i * 2] = hexEncode((byte & 0xf0) >> 4);
+      result[i * 2 + 1] = hexEncode(byte & 0x0f);
     }
     return result;
   }
@@ -50,11 +50,11 @@ function hexEncode(value: number): number {
 }
 
 function hexDecode(value: number): number {
-  if (value >= 65) {
-    return value - 65 + 10; // ASCII of A
-  }
   if (value >= 97) {
     return value - 97 + 10; // ASCII of a
+  }
+  if (value >= 65) {
+    return value - 65 + 10; // ASCII of A
   }
   return value - 48; // ASCII of 0
 }

--- a/modules/gis/test/geometry-converters/wkb-helper-boundary.spec.ts
+++ b/modules/gis/test/geometry-converters/wkb-helper-boundary.spec.ts
@@ -1,0 +1,147 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {describe, expect, test} from 'vitest';
+import {HexEncoder} from '../../src/lib/utils/hex-encoder';
+import {
+  getCoordinateByteSize,
+  getGeometryTypeFromWKBType,
+  getWKBTypeFromGeometryType,
+  matchWKBOptionsToPointSize
+} from '../../src/lib/geometry-converters/wkb/helpers/wkb-utils';
+import {
+  getWKTGeometryType,
+  isTWKB,
+  isWKB,
+  isWKT,
+  parseWKBHeader
+} from '../../src/lib/geometry-converters/wkb/helpers/parse-wkb-header';
+import {
+  EWKB_FLAG_M,
+  EWKB_FLAG_SRID,
+  EWKB_FLAG_Z,
+  WKBGeometryType
+} from '../../src/lib/geometry-converters/wkb/helpers/wkb-types';
+
+/** Encodes a compact WKB header for little- or big-endian boundary tests. */
+function makeHeader(geometryCode: number, littleEndian = true, srid?: number): ArrayBuffer {
+  const arrayBuffer = new ArrayBuffer(srid === undefined ? 5 : 9);
+  const dataView = new DataView(arrayBuffer);
+  dataView.setUint8(0, littleEndian ? 1 : 0);
+  dataView.setUint32(1, geometryCode, littleEndian);
+  if (srid !== undefined) dataView.setUint32(5, srid, littleEndian);
+  return arrayBuffer;
+}
+
+describe('WKB helper boundary behavior', () => {
+  test('encodes and decodes upper- and lower-case hexadecimal bytes', () => {
+    const encoder = new HexEncoder();
+    const input = new Uint8Array([0, 15, 16, 171, 255]);
+    const encoded = encoder.encode(input, new Uint8Array(encoder.getEncodedLength(input)));
+    expect(new TextDecoder().decode(encoded)).toBe('000F10ABFF');
+    expect(
+      encoder.decode(
+        new TextEncoder().encode('000f10abff'),
+        new Uint8Array(encoder.getDecodedLength(encoded))
+      )
+    ).toEqual(input);
+    expect(encoder.getDecodedLength(new Uint8Array(3))).toBe(2);
+  });
+
+  test('maps geometry types and normalizes dimension options', () => {
+    for (const geometryType of Object.values(WKBGeometryType).filter(
+      (value): value is WKBGeometryType => typeof value === 'number'
+    )) {
+      const name = getGeometryTypeFromWKBType(geometryType);
+      expect(getWKBTypeFromGeometryType(name)).toBe(geometryType);
+    }
+    expect(() => getGeometryTypeFromWKBType(99 as WKBGeometryType)).toThrow('99');
+    expect(matchWKBOptionsToPointSize(4)).toMatchObject({hasZ: true, hasM: true});
+    expect(matchWKBOptionsToPointSize(3, {hasZ: true, hasM: true})).toMatchObject({
+      hasZ: true,
+      hasM: false
+    });
+    expect(matchWKBOptionsToPointSize(3, {hasM: true})).toMatchObject({hasZ: false, hasM: true});
+    expect(matchWKBOptionsToPointSize(3)).toMatchObject({hasZ: true, hasM: false});
+    expect(matchWKBOptionsToPointSize(2, {hasZ: true, hasM: true})).toMatchObject({
+      hasZ: false,
+      hasM: false
+    });
+    expect(matchWKBOptionsToPointSize(1, {srid: 4326})).toMatchObject({srid: 4326});
+    expect(getCoordinateByteSize()).toBe(16);
+    expect(getCoordinateByteSize({hasZ: true})).toBe(24);
+    expect(getCoordinateByteSize({hasZ: true, hasM: true})).toBe(32);
+  });
+
+  test('recognizes WKT, TWKB, and valid WKB dialect headers', () => {
+    expect(isWKT('POINT(1 2)')).toBe(true);
+    expect(getWKTGeometryType(new TextEncoder().encode('MULTIPOLYGON(').buffer)).toBe(
+      WKBGeometryType.MultiPolygon
+    );
+    expect(isWKT(' point(1 2)')).toBe(false);
+    expect(isTWKB(new Uint8Array([1]).buffer)).toBe(true);
+    expect(isTWKB(new Uint8Array([0]).buffer)).toBe(false);
+    expect(isTWKB(new Uint8Array([8]).buffer)).toBe(false);
+    expect(isWKB(makeHeader(1))).toBe(true);
+    expect(isWKB(makeHeader(1002, false))).toBe(true);
+    expect(isWKB(makeHeader(EWKB_FLAG_Z | 1))).toBe(true);
+    expect(isWKB(makeHeader(EWKB_FLAG_SRID | 1, true, 4326))).toBe(true);
+    expect(isWKB(makeHeader(1, true))).toBe(true);
+    const invalidEndian = new Uint8Array(makeHeader(1));
+    invalidEndian[0] = 2;
+    expect(isWKB(invalidEndian.buffer)).toBe(false);
+    expect(isWKB(makeHeader(0))).toBe(false);
+    expect(isWKB(makeHeader(8))).toBe(false);
+    expect(isWKB(makeHeader(4001))).toBe(false);
+    expect(isWKB(makeHeader(EWKB_FLAG_SRID | 1, true, 20_000))).toBe(false);
+  });
+
+  test('parses ISO and EWKB dimensions, byte order, SRID, and target offsets', () => {
+    expect(parseWKBHeader(new DataView(makeHeader(1)))).toMatchObject({
+      variant: 'wkb',
+      geometryType: 1,
+      dimensions: 2,
+      coordinates: 'xy',
+      littleEndian: true,
+      byteOffset: 5
+    });
+    expect(parseWKBHeader(new DataView(makeHeader(1002, false)))).toMatchObject({
+      variant: 'iso-wkb',
+      geometryType: 2,
+      coordinates: 'xyz',
+      littleEndian: false
+    });
+    expect(parseWKBHeader(new DataView(makeHeader(2003)))).toMatchObject({coordinates: 'xym'});
+    expect(parseWKBHeader(new DataView(makeHeader(3004)))).toMatchObject({coordinates: 'xyzm'});
+    expect(parseWKBHeader(new DataView(makeHeader(EWKB_FLAG_Z | 1)))).toMatchObject({
+      variant: 'ewkb',
+      coordinates: 'xyz'
+    });
+    expect(parseWKBHeader(new DataView(makeHeader(EWKB_FLAG_M | 1)))).toMatchObject({
+      variant: 'ewkb',
+      coordinates: 'xym'
+    });
+    expect(parseWKBHeader(new DataView(makeHeader(EWKB_FLAG_Z | EWKB_FLAG_M | 1)))).toMatchObject({
+      variant: 'ewkb',
+      coordinates: 'xyzm'
+    });
+    expect(parseWKBHeader(new DataView(makeHeader(EWKB_FLAG_SRID | 1, true, 4326)))).toMatchObject({
+      variant: 'ewkb',
+      srid: 4326,
+      byteOffset: 9
+    });
+
+    const padded = new Uint8Array(10);
+    padded.set(new Uint8Array(makeHeader(2)), 2);
+    const target = {byteOffset: 2} as any;
+    expect(parseWKBHeader(new DataView(padded.buffer), target)).toBe(target);
+    expect(target.byteOffset).toBe(7);
+    expect(() =>
+      parseWKBHeader(new DataView(new TextEncoder().encode('POINT(1 2)').buffer))
+    ).toThrow('Cannot parse WKT');
+    expect(() => parseWKBHeader(new DataView(makeHeader(4001)))).toThrow(
+      'Unsupported iso-wkb type'
+    );
+  });
+});

--- a/modules/loader-utils/test/lib/scan-utils/columnar-predicate.spec.ts
+++ b/modules/loader-utils/test/lib/scan-utils/columnar-predicate.spec.ts
@@ -5,11 +5,15 @@
 import {describe, expect, test} from 'vitest';
 
 import {
+  bindColumnarPredicateParameters,
   copyColumnarPredicate,
   filterColumnarRowIndices,
   gatherColumnarColumns,
   getColumnarPredicateColumns,
+  getColumnarPredicateParameterNames,
   getColumnarPredicatePaths,
+  isColumnarPredicateParameter,
+  isColumnarPredicateValue,
   validateColumnarPredicate
 } from '../../../src/lib/scan-utils/columnar-predicate';
 
@@ -76,5 +80,171 @@ describe('format-neutral columnar predicates', () => {
     expect(() =>
       validateColumnarPredicate({op: 'in', args: [{property: 'id'}, []]}, new Set(['id']))
     ).toThrow('in requires at least one value');
+  });
+
+  test('binds named parameters through logical, null, comparison, and in predicates', () => {
+    const predicate = {
+      op: 'and' as const,
+      args: [
+        {op: '>=', args: [{property: 'id'}, {parameter: 'minimum'}]} as const,
+        {
+          op: 'or' as const,
+          args: [
+            {op: 'in', args: [{property: 'name'}, ['one', {parameter: 'name'}]]} as const,
+            {op: 'not', args: [{op: 'isNull', args: [{property: 'deleted'}]}]} as const
+          ]
+        }
+      ]
+    };
+
+    expect(getColumnarPredicateParameterNames(predicate)).toEqual(['minimum', 'name']);
+    const bound = bindColumnarPredicateParameters(predicate, {minimum: 2, name: 'two'});
+    expect(getColumnarPredicateParameterNames(bound)).toEqual([]);
+    expect(bound).toEqual({
+      op: 'and',
+      args: [
+        {op: '>=', args: [{property: 'id'}, 2]},
+        {
+          op: 'or',
+          args: [
+            {op: 'in', args: [{property: 'name'}, ['one', 'two']]},
+            {op: 'not', args: [{op: 'isNull', args: [{property: 'deleted'}]}]}
+          ]
+        }
+      ]
+    });
+    expect(() => bindColumnarPredicateParameters(predicate, {})).toThrow('requires a value');
+    expect(() =>
+      bindColumnarPredicateParameters(predicate, {
+        minimum: {parameter: 'other'} as never,
+        name: 'two'
+      })
+    ).toThrow('cannot reference another parameter');
+    expect(() =>
+      bindColumnarPredicateParameters(predicate, {minimum: Number.NaN, name: 'two'})
+    ).toThrow('unsupported value');
+  });
+
+  test('recognizes only portable predicate parameters and scalar values', () => {
+    expect(isColumnarPredicateParameter({parameter: 'value'})).toBe(true);
+    expect(isColumnarPredicateParameter({parameter: ''})).toBe(false);
+    expect(isColumnarPredicateParameter({parameter: 'value', extra: true})).toBe(false);
+    expect(isColumnarPredicateParameter([])).toBe(false);
+    expect(isColumnarPredicateParameter(null)).toBe(false);
+
+    for (const value of [true, 1, 1n, 'text', new Date(0), new Uint8Array([1])]) {
+      expect(isColumnarPredicateValue(value)).toBe(true);
+    }
+    for (const value of [Infinity, new Date(Number.NaN), null, {}]) {
+      expect(isColumnarPredicateValue(value)).toBe(false);
+    }
+  });
+
+  test('evaluates every comparison and SQL-style three-valued logical branch', () => {
+    const columns = {
+      value: [1, 2, 3, null],
+      nested: [{score: 2}, {score: 1}, null, {score: 4}],
+      flag: [true, false, true, false]
+    };
+    const cases = [
+      [{op: '=', args: [{property: 'value'}, 2]}, [1]],
+      [{op: '<>', args: [{property: 'value'}, 2]}, [0, 2]],
+      [{op: '<', args: [{property: 'value'}, 2]}, [0]],
+      [{op: '<=', args: [{property: 'value'}, 2]}, [0, 1]],
+      [{op: '>', args: [{property: 'value'}, 2]}, [2]],
+      [{op: '>=', args: [{property: 'value'}, 2]}, [1, 2]],
+      [{op: 'in', args: [{property: 'value'}, [1, 3]]}, [0, 2]],
+      [{op: 'isNull', args: [{property: 'value'}]}, [3]],
+      [{op: '=', args: [{property: ['nested', 'score']}, 2]}, [0]]
+    ] as const;
+    for (const [predicate, expected] of cases) {
+      expect(filterColumnarRowIndices(predicate as any, columns, 4)).toEqual(expected);
+    }
+
+    expect(
+      filterColumnarRowIndices(
+        {
+          op: 'or',
+          args: [
+            {op: '=', args: [{property: 'value'}, 1]},
+            {op: '=', args: [{property: 'value'}, 3]}
+          ]
+        },
+        columns,
+        4
+      )
+    ).toEqual([0, 2]);
+    expect(
+      filterColumnarRowIndices(
+        {op: 'not', args: [{op: '=', args: [{property: 'flag'}, true]}]},
+        columns,
+        4
+      )
+    ).toEqual([1, 3]);
+    expect(filterColumnarRowIndices(undefined, columns, 4)).toEqual([0, 1, 2, 3]);
+    expect(gatherColumnarColumns(columns, [1])).toEqual({
+      value: [2],
+      nested: [{score: 1}],
+      flag: [false]
+    });
+  });
+
+  test('compares dates and bytes and rejects incompatible runtime values', () => {
+    expect(
+      filterColumnarRowIndices(
+        {op: '>', args: [{property: 'date'}, new Date(0)]},
+        {date: [new Date(1)]},
+        1
+      )
+    ).toEqual([0]);
+    expect(
+      filterColumnarRowIndices(
+        {op: '<', args: [{property: 'bytes'}, new Uint8Array([2])]},
+        {bytes: [new Uint8Array([1]), new Uint8Array([2, 0])]},
+        2
+      )
+    ).toEqual([0]);
+    expect(() =>
+      filterColumnarRowIndices(
+        {op: '=', args: [{property: 'bytes'}, new Uint8Array([1])]},
+        {bytes: ['one']},
+        1
+      )
+    ).toThrow('binary values on both sides');
+    expect(() =>
+      filterColumnarRowIndices({op: '=', args: [{property: 'date'}, new Date(0)]}, {date: [0]}, 1)
+    ).toThrow('date values on both sides');
+    expect(() =>
+      filterColumnarRowIndices({op: '=', args: [{property: 'value'}, '1']}, {value: [1]}, 1)
+    ).toThrow('cannot compare number with string');
+    expect(() =>
+      filterColumnarRowIndices(
+        {op: '=', args: [{property: 'value'}, {} as never]},
+        {value: [{}]},
+        1
+      )
+    ).toThrow('does not support object values');
+    expect(() =>
+      filterColumnarRowIndices(
+        {op: '>', args: [{property: 'date'}, new Date(Number.NaN)]},
+        {date: [new Date(0)]},
+        1
+      )
+    ).toThrow('Non-finite values');
+  });
+
+  test('validates logical arity, property paths, and available columns', () => {
+    expect(() => validateColumnarPredicate({op: 'and', args: []}, new Set())).toThrow(
+      'requires at least two child predicates'
+    );
+    expect(() =>
+      validateColumnarPredicate({op: 'isNull', args: [{property: ['', 'child']}]}, new Set(['']))
+    ).toThrow('non-empty strings');
+    expect(() =>
+      validateColumnarPredicate(
+        {op: 'not', args: [{op: 'isNull', args: [{property: 'missing'}]}]},
+        new Set()
+      )
+    ).toThrow('column not found');
   });
 });

--- a/modules/parquet/test/parquetjs/logical-types.spec.ts
+++ b/modules/parquet/test/parquetjs/logical-types.spec.ts
@@ -10,20 +10,31 @@ import {decodeSchema} from '../../src/parquetjs/parser/decoders';
 import {toPrimitive} from '../../src/parquetjs/schema/types';
 import {
   ConvertedType,
+  BsonType,
+  DateType,
   DecimalType,
   EdgeInterpolationAlgorithm,
+  EnumType,
   FieldRepetitionType,
   Float16Type,
   GeographyType,
+  GeometryType,
   IntType,
+  JsonType,
   ListType,
   LogicalType,
+  MapType,
+  MicroSeconds,
   NanoSeconds,
+  NullType,
   SchemaElement,
+  StringType,
+  TimeType,
   TimeUnit,
   TimestampType,
   Type,
-  UUIDType
+  UUIDType,
+  VariantType
 } from '../../src/parquetjs/parquet-thrift';
 
 const REQUIRED = FieldRepetitionType.REQUIRED;
@@ -185,6 +196,192 @@ describe('Parquet 2.13 logical type schema decoding', () => {
       arrow.Utf8,
       arrow.Float16
     ]);
+  });
+
+  test('decodes the complete modern logical-type union', () => {
+    const logicalTypes = [
+      LogicalType.fromSTRING(new StringType()),
+      LogicalType.fromMAP(new MapType()),
+      LogicalType.fromLIST(new ListType()),
+      LogicalType.fromENUM(new EnumType()),
+      LogicalType.fromDATE(new DateType()),
+      LogicalType.fromTIME(
+        new TimeType({isAdjustedToUTC: true, unit: TimeUnit.fromMICROS(new MicroSeconds())})
+      ),
+      LogicalType.fromUNKNOWN(new NullType()),
+      LogicalType.fromJSON(new JsonType()),
+      LogicalType.fromBSON(new BsonType()),
+      LogicalType.fromUUID(new UUIDType()),
+      LogicalType.fromFLOAT16(new Float16Type()),
+      LogicalType.fromVARIANT(new VariantType({specification_version: 2})),
+      LogicalType.fromGEOMETRY(new GeometryType({crs: 'OGC:CRS84'})),
+      LogicalType.fromGEOGRAPHY(new GeographyType({crs: 'OGC:CRS84'}))
+    ];
+    const expectedTypes = [
+      'UTF8',
+      'BYTE_ARRAY',
+      'BYTE_ARRAY',
+      'ENUM',
+      'DATE',
+      'TIME_MICROS',
+      'UNKNOWN',
+      'JSON',
+      'BSON',
+      'UUID',
+      'FLOAT16',
+      'VARIANT',
+      'GEOMETRY',
+      'GEOGRAPHY'
+    ];
+    const elements = logicalTypes.map(
+      (logicalType, index) =>
+        new SchemaElement({
+          name: `field${index}`,
+          type: Type.BYTE_ARRAY,
+          repetition_type:
+            index === 0
+              ? FieldRepetitionType.OPTIONAL
+              : index === 1
+                ? FieldRepetitionType.REPEATED
+                : REQUIRED,
+          logicalType
+        })
+    );
+
+    const {schema} = decodeSchema(
+      [new SchemaElement({name: 'schema', num_children: elements.length}), ...elements],
+      1,
+      elements.length
+    );
+    expect(Object.values(schema).map(field => field.type)).toEqual(expectedTypes);
+    expect(schema.field0.optional).toBe(true);
+    expect(schema.field1.repeated).toBe(true);
+    expect(schema.field11.logicalType).toEqual({type: 'VARIANT', specificationVersion: 2});
+    expect(schema.field12.logicalType).toEqual({type: 'GEOMETRY', crs: 'OGC:CRS84'});
+    expect(schema.field13.logicalType).toEqual({
+      type: 'GEOGRAPHY',
+      crs: 'OGC:CRS84',
+      algorithm: undefined
+    });
+  });
+
+  test('decodes every legacy converted-type annotation', () => {
+    const convertedTypes = [
+      ConvertedType.UTF8,
+      ConvertedType.MAP,
+      ConvertedType.MAP_KEY_VALUE,
+      ConvertedType.LIST,
+      ConvertedType.ENUM,
+      ConvertedType.DECIMAL,
+      ConvertedType.DATE,
+      ConvertedType.TIME_MILLIS,
+      ConvertedType.TIME_MICROS,
+      ConvertedType.TIMESTAMP_MILLIS,
+      ConvertedType.TIMESTAMP_MICROS,
+      ConvertedType.UINT_8,
+      ConvertedType.UINT_16,
+      ConvertedType.UINT_32,
+      ConvertedType.UINT_64,
+      ConvertedType.INT_8,
+      ConvertedType.INT_16,
+      ConvertedType.INT_32,
+      ConvertedType.INT_64,
+      ConvertedType.JSON,
+      ConvertedType.BSON
+    ];
+    const elements = convertedTypes.map(
+      (convertedType, index) =>
+        new SchemaElement({
+          name: `legacy${index}`,
+          type: index === 5 ? Type.FIXED_LEN_BYTE_ARRAY : Type.BYTE_ARRAY,
+          type_length: index === 5 ? 8 : undefined,
+          repetition_type: REQUIRED,
+          converted_type: convertedType,
+          precision: 12,
+          scale: 2
+        })
+    );
+
+    const {schema} = decodeSchema(
+      [new SchemaElement({name: 'schema', num_children: elements.length}), ...elements],
+      1,
+      elements.length
+    );
+    expect(Object.values(schema).map(field => field.logicalType?.type)).toEqual([
+      'STRING',
+      'MAP',
+      'MAP',
+      'LIST',
+      'ENUM',
+      'DECIMAL',
+      'DATE',
+      'TIME',
+      'TIME',
+      'TIMESTAMP',
+      'TIMESTAMP',
+      'INTEGER',
+      'INTEGER',
+      'INTEGER',
+      'INTEGER',
+      'INTEGER',
+      'INTEGER',
+      'INTEGER',
+      'INTEGER',
+      'JSON',
+      'BSON'
+    ]);
+    expect(schema.legacy5).toMatchObject({type: 'DECIMAL_FIXED_LEN_BYTE_ARRAY', precision: 12, scale: 2});
+    expect(schema.legacy11.logicalType).toEqual({type: 'INTEGER', bitWidth: 8, isSigned: false});
+    expect(schema.legacy18.logicalType).toEqual({type: 'INTEGER', bitWidth: 64, isSigned: true});
+  });
+
+  test('rejects malformed logical schema annotations', () => {
+    expect(() =>
+      decodeSchema(
+        [
+          new SchemaElement({name: 'schema', num_children: 1}),
+          new SchemaElement({
+            name: 'invalid',
+            type: Type.INT32,
+            repetition_type: 99 as FieldRepetitionType
+          })
+        ],
+        1,
+        1
+      )
+    ).toThrow('Invalid ENUM value');
+    expect(() =>
+      decodeSchema(
+        [
+          new SchemaElement({name: 'schema', num_children: 1}),
+          new SchemaElement({
+            name: 'invalid',
+            type: Type.INT32,
+            repetition_type: REQUIRED,
+            logicalType: LogicalType.fromINTEGER(new IntType({bitWidth: 24, isSigned: true}))
+          })
+        ],
+        1,
+        1
+      )
+    ).toThrow('invalid INTEGER bit width');
+    expect(() =>
+      decodeSchema(
+        [
+          new SchemaElement({name: 'schema', num_children: 1}),
+          new SchemaElement({
+            name: 'invalid',
+            type: Type.INT64,
+            repetition_type: REQUIRED,
+            logicalType: LogicalType.fromTIME(
+              new TimeType({isAdjustedToUTC: false, unit: new TimeUnit({})})
+            )
+          })
+        ],
+        1,
+        1
+      )
+    ).toThrow('Cannot read a TUnion with no set value');
   });
 });
 

--- a/modules/parquet/test/parquetjs/shred-boundary.spec.ts
+++ b/modules/parquet/test/parquetjs/shred-boundary.spec.ts
@@ -1,0 +1,133 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {expect, test} from 'vitest';
+import {ParquetSchema} from '../../src/parquetjs/schema/schema';
+import {
+  materializeColumn,
+  materializeColumns,
+  materializeRows,
+  shredBuffer,
+  shredRecord
+} from '../../src/parquetjs/schema/shred';
+
+test('Parquet shredding normalizes standard LIST and MAP JavaScript values', () => {
+  const schema = new ParquetSchema({
+    tags: {
+      optional: true,
+      logicalType: {type: 'LIST'},
+      fields: {
+        list: {
+          repeated: true,
+          fields: {element: {type: 'UTF8', optional: true}}
+        }
+      }
+    },
+    attributes: {
+      optional: true,
+      logicalType: {type: 'MAP'},
+      fields: {
+        key_value: {
+          repeated: true,
+          fields: {
+            key: {type: 'UTF8'},
+            value: {type: 'INT32', optional: true}
+          }
+        }
+      }
+    }
+  });
+  const rowGroup = shredBuffer(schema);
+
+  shredRecord(schema, {tags: ['red', 'green'], attributes: new Map([['size', 3]])}, rowGroup);
+  shredRecord(
+    schema,
+    {
+      tags: [],
+      attributes: [
+        ['weight', 4],
+        {key: 'age', value: 5},
+        'ignored'
+      ]
+    },
+    rowGroup
+  );
+  shredRecord(schema, {attributes: {height: 6}}, rowGroup);
+  shredRecord(schema, {attributes: 'invalid'}, rowGroup);
+
+  expect(rowGroup.rowCount).toBe(4);
+  expect(rowGroup.columnData['tags,list,element'].count).toBeGreaterThan(0);
+  expect(rowGroup.columnData['attributes,key_value,key'].count).toBeGreaterThan(0);
+  expect(materializeRows(schema, rowGroup)).toHaveLength(4);
+  expect(materializeColumns(schema, rowGroup)).toHaveProperty('tags');
+  expect(materializeColumns(schema, rowGroup)).toHaveProperty('attributes');
+});
+
+test('Parquet shredding rejects absent required and repeated non-repeated values', () => {
+  const requiredSchema = new ParquetSchema({name: {type: 'UTF8'}});
+  expect(() => shredRecord(requiredSchema, {}, shredBuffer(requiredSchema))).toThrow(
+    'missing required field: name'
+  );
+  expect(() =>
+    shredRecord(requiredSchema, {name: ['one', 'two']}, shredBuffer(requiredSchema))
+  ).toThrow('too many values for field: name');
+});
+
+test('Parquet materialization handles compact bytes, empty columns, and malformed levels', () => {
+  const schema = new ParquetSchema({name: {type: 'UTF8', optional: true}});
+  const compactBytes = new Uint8Array([97, 98, 99, 100, 101]);
+  const rowGroup = {
+    rowCount: 2,
+    columnData: {
+      name: {
+        count: 2,
+        dlevels: [1, 1],
+        rlevels: [0, 0],
+        values: [],
+        pageHeaders: [],
+        byteArrayData: {
+          data: compactBytes,
+          valueOffsets: new Uint32Array([0, 2, 5])
+        }
+      }
+    }
+  } as any;
+
+  expect(materializeRows(schema, rowGroup)).toEqual([{name: 'ab'}, {name: 'cde'}]);
+  expect(materializeColumn(schema, rowGroup, 'name')).toEqual(['ab', 'cde']);
+  expect(
+    materializeColumn(schema, {rowCount: 1, columnData: {name: {count: 0}}} as any, 'name')
+  ).toBeUndefined();
+
+  const repeatedSchema = new ParquetSchema({values: {type: 'INT32', repeated: true}});
+  expect(() =>
+    materializeRows(repeatedSchema, {
+      rowCount: 0,
+      columnData: {
+        values: {count: 1, dlevels: [1], rlevels: [0], values: [1], pageHeaders: []}
+      }
+    })
+  ).toThrow('referenced row 0 of 0');
+});
+
+test('Parquet column materialization preserves required typed arrays without copying', () => {
+  const schema = new ParquetSchema({value: {type: 'INT32'}});
+  const values = new Int32Array([1, 2, 3]);
+  const rowGroup = {
+    rowCount: 3,
+    columnData: {
+      value: {
+        count: 3,
+        dlevels: new Uint8Array(0),
+        rlevels: new Uint8Array(0),
+        values,
+        pageHeaders: []
+      }
+    }
+  } as any;
+
+  expect(materializeColumn(schema, rowGroup, 'value')).toBe(values);
+  expect(materializeColumns(schema, rowGroup).value).toBe(values);
+  expect(materializeRows(schema, rowGroup)).toEqual([{value: 1}, {value: 2}, {value: 3}]);
+});

--- a/modules/schema-utils/src/lib/table/tables/convert-table.ts
+++ b/modules/schema-utils/src/lib/table/tables/convert-table.ts
@@ -52,7 +52,7 @@ export function convertTable(
 export function convertToColumnarTable(table: Table): ColumnarTable {
   // TODO - should schema really be optional?
   const schema = table.schema || deduceTableSchema(table);
-  const fields = table.schema?.fields || [];
+  const fields = schema.fields;
 
   if (table.shape === 'columnar-table') {
     return {...table, schema};

--- a/modules/schema-utils/test/lib/table/table-conversion-boundary.spec.ts
+++ b/modules/schema-utils/test/lib/table/table-conversion-boundary.spec.ts
@@ -1,0 +1,149 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {TableBatch} from '@loaders.gl/schema';
+import {expect, test} from 'vitest';
+import {convertBatch, convertBatches} from '../../../src/lib/table/batches/convert-batches';
+import {makeTableFromBatches} from '../../../src/lib/table/batches/make-table-from-batches';
+import {
+  convertTable,
+  convertToArrayRowTable,
+  convertToColumnarTable,
+  convertToObjectRowTable
+} from '../../../src/lib/table/tables/convert-table';
+
+const schema = {
+  fields: [
+    {name: 'id', type: 'int32' as const, nullable: false},
+    {name: 'name', type: 'utf8' as const, nullable: true}
+  ],
+  metadata: {}
+};
+
+const objectTable = {
+  shape: 'object-row-table' as const,
+  schema,
+  data: [
+    {id: 1, name: 'one'},
+    {id: 2, name: null}
+  ]
+};
+
+const arrayTable = {
+  shape: 'array-row-table' as const,
+  schema,
+  data: [
+    [1, 'one'],
+    [2, null]
+  ]
+};
+
+const columnarTable = {
+  shape: 'columnar-table' as const,
+  schema,
+  data: {id: new Int32Array([1, 2]), name: ['one', null]}
+};
+
+test('table converters cover every supported shape and identity path', () => {
+  expect(convertToObjectRowTable(objectTable)).toBe(objectTable);
+  expect(convertToArrayRowTable(arrayTable)).toBe(arrayTable);
+  expect(convertToColumnarTable(columnarTable)).toEqual(columnarTable);
+
+  expect(convertTable(objectTable, 'array-row-table').data).toEqual(arrayTable.data);
+  expect(convertTable(arrayTable, 'object-row-table').data).toEqual(objectTable.data);
+  expect(convertTable(objectTable, 'columnar-table').data).toEqual({
+    id: new Int32Array([1, 2]),
+    name: ['one', null]
+  });
+  const arrowTable = convertTable(objectTable, 'arrow-table');
+  expect(arrowTable.shape).toBe('arrow-table');
+  expect(arrowTable.data.numRows).toBe(2);
+  expect(() => convertTable(objectTable, 'invalid' as never)).toThrow('invalid');
+});
+
+test('columnar conversion uses a schema deduced from object rows', () => {
+  const converted = convertToColumnarTable({
+    shape: 'object-row-table',
+    data: [
+      {id: 1, label: 'a'},
+      {id: 2, label: 'b'}
+    ]
+  });
+
+  expect(converted.schema.fields.map(field => field.name)).toEqual(['id', 'label']);
+  expect(Array.from(converted.data.id)).toEqual([1, 2]);
+  expect(Array.from(converted.data.label)).toEqual(['a', 'b']);
+});
+
+test('batch conversion preserves metadata across all target shapes', async () => {
+  const batch: TableBatch = {
+    ...objectTable,
+    batchType: 'data',
+    length: 2,
+    bytesUsed: 42
+  };
+
+  for (const shape of [
+    'object-row-table',
+    'array-row-table',
+    'columnar-table',
+    'arrow-table'
+  ] as const) {
+    const converted = convertBatch(batch, shape);
+    expect(converted.shape).toBe(shape);
+    expect(converted.bytesUsed).toBe(42);
+
+    const collected = [];
+    for await (const convertedBatch of convertBatches([batch], shape)) {
+      collected.push(convertedBatch);
+    }
+    expect(collected).toHaveLength(1);
+    expect(collected[0].shape).toBe(shape);
+  }
+
+  expect(() => convertBatch(batch, 'invalid' as never)).toThrow('invalid');
+  const invalidIterator = convertBatches([batch], 'invalid' as never);
+  await expect(invalidIterator.next()).rejects.toThrow('invalid');
+});
+
+test('makeTableFromBatches assembles every row-oriented batch shape', async () => {
+  const arrayBatch: TableBatch = {
+    ...arrayTable,
+    batchType: 'data',
+    length: 2
+  };
+  await expect(makeTableFromBatches([arrayBatch, arrayBatch])).resolves.toMatchObject({
+    shape: 'array-row-table',
+    data: [...arrayTable.data, ...arrayTable.data]
+  });
+
+  const objectBatch: TableBatch = {
+    ...objectTable,
+    batchType: 'data',
+    length: 2
+  };
+  await expect(makeTableFromBatches([objectBatch])).resolves.toMatchObject(objectTable);
+
+  const feature = {
+    type: 'Feature' as const,
+    geometry: {type: 'Point' as const, coordinates: [1, 2]},
+    properties: {id: 1}
+  };
+  await expect(
+    makeTableFromBatches([
+      {
+        shape: 'geojson-table',
+        type: 'FeatureCollection',
+        features: [feature],
+        batchType: 'data',
+        length: 1
+      }
+    ])
+  ).resolves.toMatchObject({shape: 'geojson-table', features: [feature]});
+
+  await expect(makeTableFromBatches([])).resolves.toBeNull();
+  await expect(
+    makeTableFromBatches([{...columnarTable, batchType: 'data', length: 2} as TableBatch])
+  ).rejects.toThrow('shape');
+});

--- a/modules/sql/test/snowflake-sql-source-boundary.spec.ts
+++ b/modules/sql/test/snowflake-sql-source-boundary.spec.ts
@@ -1,0 +1,146 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {describe, expect, test, vi} from 'vitest';
+import {SnowflakeSQLDataSource} from '@loaders.gl/sql';
+
+/** Creates a Snowflake source whose SQL API requests stay entirely in memory. */
+function createSource(fetchFunction: typeof fetch, token = 'token'): SnowflakeSQLDataSource {
+  return new SnowflakeSQLDataSource('snowflake://account', {
+    core: {loadOptions: {core: {fetch: fetchFunction}}},
+    snowflake: {token, database: 'database', schema: 'public', warehouse: 'warehouse', role: 'role'}
+  });
+}
+
+/** Creates one successful Snowflake JSON response. */
+function jsonResponse(value: unknown, status = 200): Response {
+  return new Response(JSON.stringify(value), {
+    status,
+    headers: {'Content-Type': 'application/json'}
+  });
+}
+
+describe('Snowflake SQL source boundary behavior', () => {
+  test('maps catalogs, schemas, tables, columns, and cached metadata', async () => {
+    const fetchFunction = vi.fn(async (_url: string, requestInit?: RequestInit) => {
+      const statement = JSON.parse(String(requestInit?.body || '{}')).statement || '';
+      if (statement === 'SHOW DATABASES') {
+        return jsonResponse({resultSetMetaData: {rowType: [{name: 'name'}]}, data: [['catalog']]});
+      }
+      if (statement === 'SHOW SCHEMAS') {
+        return jsonResponse({
+          resultSetMetaData: {rowType: [{name: 'database_name'}, {name: 'name'}]},
+          data: [['catalog', 'public']]
+        });
+      }
+      if (statement === 'SHOW TABLES') {
+        return jsonResponse({
+          resultSetMetaData: {
+            rowType: [
+              {name: 'database_name'},
+              {name: 'schema_name'},
+              {name: 'name'},
+              {name: 'kind'}
+            ]
+          },
+          data: [['catalog', 'public', 'places', 'TABLE']]
+        });
+      }
+      return jsonResponse({
+        resultSetMetaData: {
+          rowType: [{name: 'name'}, {name: 'type'}, {name: 'null'}]
+        },
+        data: [
+          ['id', 'DOUBLE', 'N'],
+          ['label', 'VARCHAR', 'Y']
+        ]
+      });
+    }) as typeof fetch;
+    const source = createSource(fetchFunction);
+
+    expect(await source.listCatalogs()).toEqual([{catalogName: 'catalog'}]);
+    expect(await source.listSchemas()).toEqual([{catalogName: 'catalog', schemaName: 'public'}]);
+    expect(await source.listTables()).toEqual([
+      {catalogName: 'catalog', schemaName: 'public', tableName: 'places', tableType: 'TABLE'}
+    ]);
+    expect(
+      (
+        await source.getTableSchema({
+          catalogName: 'catalog',
+          schemaName: 'public',
+          tableName: 'places'
+        })
+      ).fields
+    ).toMatchObject([
+      {name: 'id', type: 'float64', nullable: false},
+      {name: 'label', type: 'utf8', nullable: true}
+    ]);
+
+    const firstMetadata = await source.getMetadata();
+    const requestCount = fetchFunction.mock.calls.length;
+    expect(await source.getMetadata()).toBe(firstMetadata);
+    expect(fetchFunction).toHaveBeenCalledTimes(requestCount);
+    expect(firstMetadata).toMatchObject({
+      type: 'snowflake-sql',
+      capabilities: {runtime: 'both', supportsMetadata: true},
+      catalogs: [{catalogName: 'catalog'}]
+    });
+    await source.close();
+  });
+
+  test('polls statements and normalizes positional and named bindings', async () => {
+    const requests: Array<{url: string; requestInit?: RequestInit}> = [];
+    let postCount = 0;
+    const fetchFunction = vi.fn(async (url: string, requestInit?: RequestInit) => {
+      requests.push({url, requestInit});
+      if (requestInit?.method === 'POST') {
+        postCount++;
+        return jsonResponse({statementStatusUrl: `/status/${postCount}`});
+      }
+      return jsonResponse({
+        resultSetMetaData: {rowType: [{name: 'value'}]},
+        data: [[postCount]]
+      });
+    }) as typeof fetch;
+    const source = createSource(fetchFunction, 'Bearer existing');
+
+    expect(await source.queryRows('SELECT ?', {parameters: [1, 2n, 'three']})).toEqual([
+      {value: 1}
+    ]);
+    expect(await source.queryRows('SELECT :value', {parameters: {value: 4}})).toEqual([{value: 2}]);
+
+    const firstBody = JSON.parse(String(requests[0].requestInit?.body));
+    expect(firstBody).toMatchObject({
+      bindings: {
+        '1': {type: 'FIXED', value: 1},
+        '2': {type: 'FIXED', value: '2'},
+        '3': {type: 'TEXT', value: 'three'}
+      },
+      database: 'database',
+      schema: 'public',
+      warehouse: 'warehouse',
+      role: 'role'
+    });
+    expect(requests[0].requestInit?.headers).toSatisfy(
+      (headers: Headers) => headers.get('Authorization') === 'Bearer existing'
+    );
+    expect(requests[1].url).toBe('https://account.snowflakecomputing.com/status/1');
+  });
+
+  test('reports token, SQL API, and HTTP failures', async () => {
+    await expect(createSource(vi.fn() as typeof fetch, '').queryRows('SELECT 1')).rejects.toThrow(
+      'requires snowflake.token'
+    );
+
+    const apiErrorSource = createSource(
+      vi.fn(async () => jsonResponse({code: 'bad', message: 'statement failed'})) as typeof fetch
+    );
+    await expect(apiErrorSource.queryRows('INVALID')).rejects.toThrow('statement failed');
+
+    const httpErrorSource = createSource(
+      vi.fn(async () => jsonResponse({message: 'unauthorized'}, 401)) as typeof fetch
+    );
+    await expect(httpErrorSource.queryRows('SELECT 1')).rejects.toThrow('unauthorized');
+  });
+});

--- a/modules/tiles/test/point-cloud/point-cloud-tileset-boundary.spec.ts
+++ b/modules/tiles/test/point-cloud/point-cloud-tileset-boundary.spec.ts
@@ -1,0 +1,201 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {expect, test, vi} from 'vitest';
+import {PointCloudTile} from '../../src/point-cloud/point-cloud-tile';
+import {PointCloudTileset} from '../../src/point-cloud/point-cloud-tileset';
+
+const volume = {
+  cartographicBounds: [
+    [-10, -5, 0],
+    [10, 5, 10]
+  ],
+  center: [0, 0, 5],
+  radius: 12
+} as any;
+
+/** Creates an isolated manager for exercising pure traversal helpers. */
+function createManager() {
+  const manager = Object.create(PointCloudTileset.prototype) as any;
+  manager.options = {
+    maxDepth: Infinity,
+    minimumNodePixelSize: 150,
+    lodSelectionMetricType: 'maxScreenThresholdSQ',
+    densityThreshold: 1,
+    pointBudget: 1000,
+    onTileLoad: vi.fn(),
+    onTileError: vi.fn(),
+    onTraversalComplete: (tiles: unknown[]) => tiles,
+    onUpdate: vi.fn()
+  };
+  manager.tilesMap = new Map();
+  manager.selectedTiles = [];
+  manager.pendingCount = 0;
+  return manager;
+}
+
+test('point-cloud projection helpers handle invalid, degenerate, and clipped footprints', () => {
+  const manager = createManager();
+  expect(
+    manager.projectBounds(volume, {
+      project: () => {
+        throw new Error('projection');
+      }
+    })
+  ).toBeNull();
+  expect(manager.projectBounds(volume, {project: () => [NaN, NaN]})).toBeNull();
+  expect(
+    manager.getProjectedFootprint(volume, {
+      project: () => {
+        throw new Error('projection');
+      }
+    })
+  ).toBeNull();
+  expect(manager.getProjectedFootprint(volume, {project: () => [Infinity, 0]})).toBeNull();
+
+  const footprint = manager.getProjectedFootprint(volume, {project: () => [4, 5]});
+  expect(footprint).toEqual({x: 4, y: 5, radius: 0});
+  expect(manager.isProjectedFootprintVisible(footprint, {width: 10, height: 10})).toBe(true);
+  expect(
+    manager.isProjectedFootprintVisible({x: -100, y: 0, radius: 1}, {width: 10, height: 10})
+  ).toBe(false);
+  expect(
+    manager.isProjectedFootprintVisible({x: 100, y: 0, radius: 1}, {width: 10, height: 10})
+  ).toBe(false);
+  expect(
+    manager.isProjectedFootprintVisible({x: 0, y: -100, radius: 1}, {width: 10, height: 10})
+  ).toBe(false);
+  expect(
+    manager.isProjectedFootprintVisible({x: 0, y: 100, radius: 1}, {width: 10, height: 10})
+  ).toBe(false);
+});
+
+test('point-cloud zoom and corner helpers cover coordinate frames and longitude wrapping', () => {
+  const manager = createManager();
+  expect(manager.estimateZoom(null)).toBe(1);
+  expect(manager.estimateZoom({...volume, coordinateFrame: 'cartesian'})).toBe(1);
+  expect(manager.estimateZoom({...volume, coversFullLongitude: true})).toBe(1);
+  expect(
+    manager.estimateZoom({
+      ...volume,
+      wrapsDateline: true,
+      cartographicBounds: [
+        [170, -5, 0],
+        [-170, 5, 10]
+      ]
+    })
+  ).toBeGreaterThan(1);
+  expect(manager.estimateZoom(volume)).toBeGreaterThan(1);
+
+  expect(manager.getBoundingVolumeCorners({...volume, coversFullLongitude: true})).toHaveLength(8);
+  expect(
+    manager.getBoundingVolumeCorners({
+      ...volume,
+      wrapsDateline: true,
+      cartographicBounds: [
+        [170, -5, 0],
+        [-170, 5, 10]
+      ]
+    })
+  ).toHaveLength(16);
+  expect(manager.getBoundingVolumeCorners(volume)).toHaveLength(8);
+});
+
+test('point-cloud culling helpers reject incomplete projections and accept complete frusta', () => {
+  const manager = createManager();
+  expect(manager.getCullingVolume({})).toBeNull();
+  expect(
+    manager.getCullingVolume({getFrustumPlanes: () => ({left: {normal: [1, 0, 0], distance: 0}})})
+  ).toBeNull();
+  const planes = Object.fromEntries(
+    ['left', 'right', 'bottom', 'top', 'near', 'far'].map(name => [
+      name,
+      {normal: [1, 0, 0], distance: 0}
+    ])
+  );
+  expect(manager.getCullingVolume({getFrustumPlanes: () => planes})).not.toBeNull();
+
+  expect(manager.getCommonSpaceBoundingSphere(volume, {})).toBeNull();
+  expect(
+    manager.getCommonSpaceBoundingSphere(volume, {
+      projectPosition: () => {
+        throw new Error('projection');
+      }
+    })
+  ).toBeNull();
+  expect(
+    manager.getCommonSpaceBoundingSphere(volume, {projectPosition: () => [NaN, 0, 0]})
+  ).toBeNull();
+  expect(
+    manager.getCommonSpaceBoundingSphere(volume, {
+      projectPosition: (position: number[]) => position
+    })
+  ).not.toBeNull();
+});
+
+test('point-cloud tile cache updates existing nodes and avoids duplicate children', () => {
+  const manager = createManager();
+  const parentHeader = {
+    id: 'parent',
+    level: 0,
+    pointCount: 1,
+    geometricError: 1,
+    boundingVolume: volume
+  };
+  const childHeader = {
+    id: 'child',
+    level: 1,
+    pointCount: 1,
+    geometricError: 0,
+    boundingVolume: volume
+  };
+  const parent = manager.getOrCreateTile(parentHeader, null) as PointCloudTile;
+  const child = manager.getOrCreateTile(childHeader, parent) as PointCloudTile;
+  expect(parent.children).toEqual([child]);
+
+  const nextParent = new PointCloudTile({...parentHeader, id: 'next-parent'}, null);
+  const updated = manager.getOrCreateTile({...childHeader, pointCount: 2}, nextParent);
+  expect(updated).toBe(child);
+  expect(updated.pointCount).toBe(2);
+  expect(updated.parent).toBe(nextParent);
+  manager.getOrCreateTile({...childHeader, pointCount: 3}, nextParent);
+  expect(nextParent.children).toHaveLength(0);
+  expect(parent.children).toEqual([child]);
+});
+
+test('point-cloud tile loading handles empty, successful, failed, and already-settled content', async () => {
+  const manager = createManager();
+  const header = {id: 'tile', level: 0, pointCount: 1, geometricError: 0, boundingVolume: volume};
+  const tile = new PointCloudTile(header, null);
+  manager.dataSource = {loadTileContent: vi.fn(async () => null)};
+  await manager.loadTile(tile);
+  expect(tile.contentAvailable).toBe(true);
+  expect(manager.options.onTileLoad).not.toHaveBeenCalled();
+  await manager.loadTile(tile);
+  expect(manager.dataSource.loadTileContent).toHaveBeenCalledOnce();
+
+  const loadedTile = new PointCloudTile({...header, id: 'loaded'}, null);
+  manager.dataSource = {loadTileContent: vi.fn(async () => ({data: {}}))};
+  await manager.loadTile(loadedTile);
+  expect(manager.options.onTileLoad).toHaveBeenCalledWith(loadedTile);
+
+  const failedTile = new PointCloudTile({...header, id: 'failed'}, null);
+  const error = new Error('tile failed');
+  manager.dataSource = {
+    loadTileContent: vi.fn(async () => {
+      throw error;
+    })
+  };
+  await manager.loadTile(failedTile);
+  expect(failedTile.contentFailed).toBe(true);
+  expect(manager.options.onTileError).toHaveBeenCalledWith(failedTile, error);
+  expect(manager.pendingCount).toBe(0);
+});
+
+test('point-cloud set comparisons cover equal, missing, and differently sized selections', () => {
+  const manager = createManager();
+  expect(manager.haveSameIds(new Set(['a']), new Set(['a']))).toBe(true);
+  expect(manager.haveSameIds(new Set(['a']), new Set(['b']))).toBe(false);
+  expect(manager.haveSameIds(new Set(['a']), new Set(['a', 'b']))).toBe(false);
+});


### PR DESCRIPTION
## Goals

- Make a material jump toward 80% coverage with one broad, high-value tranche.
- Prefer dense, deterministic in-memory coverage over expensive fixtures and duplicated runtime work.
- Exercise behavior and failure boundaries across the largest remaining non-3D-Tiles gaps.

## Changes

- Add 131 focused Vitest cases across Avro, config, core, deck-layers, GeoArrow, GeoTIFF, GIS, loader-utils, Parquet, schema-utils, SQL, and tiles.
- Cover Parquet logical types and shredding, GeoTIFF raster source dtype/metadata paths, point-cloud traversal/cache behavior, data-driven deck layer hooks, Snowflake metadata and polling, table conversion shapes, column predicates, and loader input normalization.
- Add hermetic URL-range coverage for Avro and fast boundary matrices for YAML/TOML and WKB helpers.
- Fix defects exposed by the new coverage: all-point/negative GeoArrow bounds, inferred-schema table conversion, YAML empty input and octal/binary literals, TOML octal/binary literals, Avro zero-value option validation, hexadecimal nibble handling, and browser filesystem range/case/removal behavior.

## Coverage impact

- A statement-map comparison against the merged baseline finds 692 previously uncovered statements, approximately +1.01 percentage points of statement coverage.
- The local combined Node/Chromium run reports 85.26% statements, 76.30% branches, 88.44% functions, and 85.71% lines. CI merged shard and slow-lane coverage remains authoritative.
- The focused tranche runs 131 tests in about 60-70 ms of test execution time.

## Validation

- `yarn lint fix`
- `yarn test-audit` (676 files, 0 Tape, 0 violations)
- `yarn build`
- `yarn build-workers`
- `yarn test-node` (391 passed)
- `yarn test-headless` (3,765 passed)
- `yarn test-cover` (4,156 passed)