### PR TITLE
feat(zarr): add SpatialData container source

### DIFF
--- a/docs/modules/zarr/README.md
+++ b/docs/modules/zarr/README.md
@@ -70,6 +70,9 @@ npm install @loaders.gl/core @loaders.gl/zarr
 - [`GeoZarrSourceLoader`](/docs/modules/zarr/api-reference/geo-zarr-source-loader) opens one
   georeferenced Zarr data variable and reads native spatial windows with named time, vertical, or
   band selections.
+- [`SpatialDataSourceLoader`](/docs/modules/zarr/api-reference/spatial-data-source-loader) discovers named images, labels, points, shapes, and tables from a
+  SpatialData root. It opens Zarr-backed raster and AnnData array elements directly and reports
+  interoperable Parquet-dataset and GeoParquet URLs for points and shapes.
 - `loadZarrConsolidatedMetadata()` probes `.zmetadata`, `zmetadata`, and `zarr.json` documents and
   reports top-level arrays and groups.
 - `loadZarr()` and `ZarrPixelSource` provide the legacy Zarr v2 pixel-pyramid API.
@@ -115,7 +118,7 @@ store directly from S3 and renders monthly solar irradiance on an interactive ma
 | Viewport-driven geospatial windows | — | — | — | Yes | Available |
 | Typed planar or interleaved channel output | Yes | Yes | Yes | Yes | Available |
 | Zarrita-backed v2/v3 implementation | Yes | Yes | Yes | Yes | Available |
-| SpatialData tables, points, and shapes | — | — | Planned | — | Planned |
+| SpatialData images, labels, points, shapes, and tables | — | — | Yes | — | Discovery and typed storage references available |
 | Codec expansion and broader multiscale layouts | Partial | Partial | Planned | Planned | Planned |
 | Common raster query execution | — | — | Levels, channels, and slices | Native spatial windows and named selections | Available |
 
@@ -138,6 +141,28 @@ array output, but their query vocabulary reflects the kind of array being opened
 Query metadata is suitable for populating source-neutral controls before pixel data is requested.
 GeoZarr bounds must use the source CRS; callers should reproject the viewport before requesting a
 window when necessary.
+
+## SpatialData containers
+
+`SpatialDataSourceLoader` normalizes the five standard SpatialData namespaces without loading
+element payloads. Each element retains its axes, coordinate transformations, format version, and
+original attributes. Image and label descriptors use `ome-zarr`; point descriptors use
+`parquet-dataset`; shape descriptors use `geoparquet`; and table descriptors use `anndata-zarr`.
+
+```ts
+import {createDataSource} from '@loaders.gl/core';
+import {SpatialDataSourceLoader} from '@loaders.gl/zarr';
+
+const source = createDataSource(rootUrl, [SpatialDataSourceLoader]);
+const metadata = await source.getMetadata();
+const image = await source.createRasterSource('image', metadata.images[0].name);
+const expression = await source.createTableArraySource('annotations', 'X');
+```
+
+SpatialData points are Dask-style Parquet datasets and shapes are GeoParquet files. Their normalized
+descriptors expose the canonical `points.parquet` and `shapes.parquet` URLs so applications can
+hand them to the corresponding loaders.gl Parquet sources without coupling the lightweight Zarr
+module to the complete Parquet runtime.
 
 ## Attributions
 

--- a/docs/modules/zarr/api-reference/spatial-data-source-loader.md
+++ b/docs/modules/zarr/api-reference/spatial-data-source-loader.md
@@ -1,0 +1,62 @@
+# SpatialDataSourceLoader
+
+<p class="badges">
+  <img src="https://img.shields.io/badge/From-v5.0-blue.svg?style=flat-square" alt="From-v5.0" />
+  &nbsp;
+  <img src="https://img.shields.io/badge/Status-Experimental-orange.svg?style=flat-square" alt="Status: Experimental" />
+</p>
+
+`SpatialDataSourceLoader` opens a SpatialData Zarr root and discovers its named images, labels,
+points, shapes, and tables without reading element payloads.
+
+## Usage
+
+```ts
+import {createDataSource} from '@loaders.gl/core';
+import {SpatialDataSourceLoader} from '@loaders.gl/zarr';
+
+const source = createDataSource('https://example.com/dataset.zarr', [SpatialDataSourceLoader]);
+const metadata = await source.getMetadata();
+
+const imageSource = await source.createRasterSource('image', metadata.images[0].name);
+const raster = await imageSource.getRaster({level: 'auto', width: 1024, height: 768});
+
+const expressionSource = await source.createTableArraySource('annotations', 'X');
+const expression = await expressionSource.getArray({
+  selection: [{start: 0, stop: 100}, {start: 0, stop: 20}]
+});
+```
+
+## `getMetadata(signal?): Promise<SpatialDataSourceMetadata>`
+
+Returns the container version, root attributes, and stable arrays for every element family. Each
+`SpatialDataElementMetadata` contains:
+
+- `kind` and `name`
+- the element's Zarr `path`
+- its canonical payload `url`
+- a normalized `format`: `ome-zarr`, `parquet-dataset`, `geoparquet`, or `anndata-zarr`
+- declared axes, coordinate transformations, encoding version, and original attributes
+
+## `getElement(kind, name, signal?): Promise<SpatialDataElementMetadata>`
+
+Returns one named element or rejects when the element is absent.
+
+## `createRasterSource(kind, name, signal?): Promise<OMEZarrImageSource>`
+
+Opens an image or label element as an OME-Zarr raster source. Raster metadata and pixel chunks are
+still loaded lazily.
+
+## `createTableArraySource(name, arrayPath, options?, signal?): Promise<ZarrArraySource>`
+
+Opens a numeric array below an AnnData-Zarr table element. Common examples include `X`, `layers/...`,
+and multidimensional arrays below `obsm` or `varm`. AnnData dataframe and categorical encodings are
+retained in the element metadata but are not flattened into a single table automatically.
+
+## Point and shape payloads
+
+Current SpatialData encodings store points in a Dask-style Parquet dataset named `points.parquet`
+and shapes in a GeoParquet file named `shapes.parquet`. Element descriptors report those canonical
+URLs and preserve the group-level spatial transformations. Applications can pass the references to
+the loaders.gl Parquet sources they already use. Keeping that integration explicit avoids adding the
+full Parquet and GeoArrow runtime to applications that only need Zarr rasters.

--- a/docs/modules/zarr/formats/zarr.md
+++ b/docs/modules/zarr/formats/zarr.md
@@ -67,6 +67,21 @@ and named scientific dimensions.
 | Multiscale image levels | Format-specific | Format-specific | Supported | Not assumed |
 | Spatial CRS and transform | Not inherent | Not inherent | Not required | Supported |
 | Named time/z/band selection | Array-dependent | Array-dependent | Supported | Supported |
+| SpatialData container discovery | Supported | Supported | Images and labels | Tables and geometries by reference |
+
+## SpatialData support
+
+| Element | On-disk representation | loaders.gl integration |
+| --- | --- | --- |
+| Images | OME-Zarr image group | `OMEZarrImageSource` through `createRasterSource()` |
+| Labels | OME-Zarr label group | `OMEZarrImageSource` through `createRasterSource()` |
+| Points | Partitioned Parquet dataset | Typed `parquet-dataset` descriptor and canonical payload URL |
+| Shapes | GeoParquet file | Typed `geoparquet` descriptor and canonical payload URL |
+| Tables | AnnData-Zarr group | Generic array access through `createTableArraySource()` |
+
+`SpatialDataSourceLoader` discovers these elements from consolidated metadata without materializing
+pixel, geometry, or annotation payloads. It retains element axes, coordinate transformations,
+format versions, and original attributes for downstream interoperability.
 
 ## Scan support
 

--- a/modules/scan/test/scan-engine.cross.spec.ts
+++ b/modules/scan/test/scan-engine.cross.spec.ts
@@ -1,0 +1,22 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import * as arrow from 'apache-arrow';
+import {expect, test} from 'vitest';
+import type {ArrowTable} from '@loaders.gl/schema';
+import {convertArrowToSchema} from '@loaders.gl/schema-utils';
+import {createScanEngine} from '@loaders.gl/scan';
+
+test('executes Arrow queries asynchronously across runtimes', async () => {
+  const engine = await createScanEngine();
+  const result = await engine.queryAsync(makeArrowTable({value: [1, 2]}), {limit: 1});
+
+  expect(result.data.numRows).toBe(1);
+});
+
+/** Wraps simple test columns in the loaders.gl Arrow table shape. */
+function makeArrowTable(columns: Record<string, readonly unknown[]>): ArrowTable {
+  const data = arrow.tableFromArrays(columns);
+  return {shape: 'arrow-table', schema: convertArrowToSchema(data.schema), data};
+}

--- a/modules/scan/test/scan-engine.spec.ts
+++ b/modules/scan/test/scan-engine.spec.ts
@@ -24,9 +24,6 @@ test('creates the Arrow reference engine by default', async () => {
   expect(engine.name).toBe('arrow');
   expect(result.data.schema.fields.map(field => field.name)).toEqual(['name']);
   expect(result.data.toArray().map(row => row?.toJSON())).toEqual([{name: 'b'}]);
-
-  const asyncResult = await engine.queryAsync(makeArrowTable({value: [1, 2]}), {limit: 1});
-  expect(asyncResult.data.numRows).toBe(1);
 });
 
 test('exposes the shared metadata vocabulary from the optional scan package', () => {

--- a/modules/zarr/README.md
+++ b/modules/zarr/README.md
@@ -14,6 +14,7 @@ This module contains loaders for the Zarr format.
 - `OMEZarrSourceLoader` / `OMEZarrImageSource` for `createDataSource()` and `load()`
 - `GeoZarrSourceLoader` / `GeoZarrRasterSource` for georeferenced Zarr data variables
 - `loadZarrConsolidatedMetadata()` for probing consolidated Zarr roots
+- `SpatialDataSourceLoader` / `SpatialDataSource` for typed SpatialData element discovery
 
 ## GeoZarr SourceLoader
 
@@ -68,27 +69,20 @@ const raster = await source.getRaster({channels: [0, 1, 2]});
 
 ## Example: SpatialData-style root browsing
 
-This mirrors the split used in SpatialData.js: first browse consolidated metadata at the store root, then open an image group with the source loader.
+`SpatialDataSourceLoader` discovers typed elements and opens Zarr-backed images, labels, and AnnData
+arrays directly.
 
 ```ts
 import {createDataSource} from '@loaders.gl/core';
-import {loadZarrConsolidatedMetadata, OMEZarrSourceLoader} from '@loaders.gl/zarr';
+import {SpatialDataSourceLoader} from '@loaders.gl/zarr';
 
 const rootUrl = 'https://example.com/spatialdata.zarr';
-const consolidated = await loadZarrConsolidatedMetadata(rootUrl);
-
-console.log(consolidated.topLevelGroups);
-// ['images', 'labels', 'points', 'shapes', 'tables']
-console.log(consolidated.topLevelArrays);
-// []
-
-const imageSource = createDataSource(rootUrl, [OMEZarrSourceLoader], {
-  zarr: {
-    path: 'images/example-image'
-  },
-  omezarr: {}
-});
-
+const spatialDataSource = createDataSource(rootUrl, [SpatialDataSourceLoader]);
+const spatialDataMetadata = await spatialDataSource.getMetadata();
+const imageSource = await spatialDataSource.createRasterSource(
+  'image',
+  spatialDataMetadata.images[0].name
+);
 const imageMetadata = await imageSource.getMetadata();
 ```
 

--- a/modules/zarr/src/index.ts
+++ b/modules/zarr/src/index.ts
@@ -11,6 +11,7 @@ export {
 } from './ome-zarr-source-loader';
 export {GeoZarrSourceLoader, GeoZarrRasterSource} from './geo-zarr-source-loader';
 export {ZarrArraySourceLoader, ZarrArraySource} from './zarr-array-source';
+export {SpatialDataSourceLoader, SpatialDataSource} from './spatial-data-source';
 export type {
   GetZarrArrayParameters,
   ZarrArrayData,
@@ -19,6 +20,14 @@ export type {
   ZarrArraySourceLoaderOptions,
   ZarrArraySourceMetadata
 } from './zarr-array-source';
+export type {
+  SpatialDataElementFormat,
+  SpatialDataElementKind,
+  SpatialDataElementMetadata,
+  SpatialDataSourceLoaderOptions,
+  SpatialDataSourceMetadata,
+  SpatialDataZarrElementSource
+} from './spatial-data-source';
 export type {
   GetOMEZarrParameters,
   LoadConsolidatedMetadataOptions,

--- a/modules/zarr/src/lib/consolidated-zarr.ts
+++ b/modules/zarr/src/lib/consolidated-zarr.ts
@@ -16,6 +16,8 @@ export type ZarrConsolidatedMetadata = {
   metadataPath: '.zmetadata' | 'zmetadata' | 'zarr.json';
   /** Format-specific consolidated metadata entries keyed by Zarr path. */
   metadata: Record<string, unknown>;
+  /** Attributes declared on the root group. */
+  rootAttributes: Record<string, unknown>;
   /** Top-level group paths. */
   topLevelGroups: string[];
   /** Top-level array paths. */
@@ -27,6 +29,7 @@ type V2ConsolidatedMetadata = {
 };
 
 type V3ConsolidatedMetadata = {
+  attributes?: Record<string, unknown>;
   consolidated_metadata?: {
     metadata?: Record<string, unknown>;
   };
@@ -109,6 +112,7 @@ function normalizeConsolidatedMetadata(
       format: 'v3',
       metadataPath,
       metadata: normalizedMetadata,
+      rootAttributes: {...((metadata as V3ConsolidatedMetadata).attributes || {})},
       topLevelGroups: extractV3TopLevelNodes(normalizedMetadata, 'group'),
       topLevelArrays: extractV3TopLevelNodes(normalizedMetadata, 'array')
     };
@@ -123,9 +127,18 @@ function normalizeConsolidatedMetadata(
     format: 'v2',
     metadataPath,
     metadata: normalizedMetadata,
+    rootAttributes: getV2RootAttributes(normalizedMetadata),
     topLevelGroups: extractV2TopLevelNodes(Object.keys(normalizedMetadata), 'zgroup'),
     topLevelArrays: extractV2TopLevelNodes(Object.keys(normalizedMetadata), 'zarray')
   };
+}
+
+/** Extracts root attributes from a consolidated Zarr v2 metadata map. */
+function getV2RootAttributes(metadata: Record<string, unknown>): Record<string, unknown> {
+  const attributes = metadata['.zattrs'];
+  return attributes && typeof attributes === 'object'
+    ? {...(attributes as Record<string, unknown>)}
+    : {};
 }
 
 /** Extracts top-level v2 nodes represented by `.zgroup` or `.zarray` keys. */

--- a/modules/zarr/src/spatial-data-source.ts
+++ b/modules/zarr/src/spatial-data-source.ts
@@ -1,0 +1,342 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {CoreAPI} from '@loaders.gl/loader-utils';
+import {
+  OMEZarrImageSource,
+  OMEZarrSourceLoader,
+  type ZarrSourceLoader,
+  type ZarrSourceLoaderOptions,
+  ZarrSource
+} from './ome-zarr-source-loader';
+import {ZarrArraySource, type ZarrArraySourceLoaderOptions} from './zarr-array-source';
+import type {ZarrConsolidatedMetadata} from './lib/consolidated-zarr';
+
+/** SpatialData element families stored below a container root. */
+export type SpatialDataElementKind = 'image' | 'labels' | 'points' | 'shapes' | 'table';
+
+/** Storage convention used by one SpatialData element. */
+export type SpatialDataElementFormat =
+  | 'ome-zarr'
+  | 'parquet-dataset'
+  | 'geoparquet'
+  | 'anndata-zarr';
+
+/** A normalized SpatialData element discovered without reading its payload. */
+export type SpatialDataElementMetadata = Readonly<{
+  /** Element family. */
+  kind: SpatialDataElementKind;
+  /** Element name within its family namespace. */
+  name: string;
+  /** Zarr group path relative to the SpatialData root. */
+  path: string;
+  /** URL of the element group or its external table payload. */
+  url: string;
+  /** Storage convention used to open the element. */
+  format: SpatialDataElementFormat;
+  /** SpatialData element encoding version when declared. */
+  version?: string;
+  /** Named element axes when declared. */
+  axes?: readonly string[];
+  /** Coordinate transformations retained in their interoperable NGFF representation. */
+  coordinateTransformations?: readonly unknown[];
+  /** Original group attributes for application-specific extensions. */
+  attributes: Readonly<Record<string, unknown>>;
+}>;
+
+/** Normalized metadata for a SpatialData container. */
+export type SpatialDataSourceMetadata = Readonly<{
+  /** SpatialData container format version. */
+  version?: string;
+  /** Every discovered element in stable namespace and name order. */
+  elements: readonly SpatialDataElementMetadata[];
+  /** Image elements. */
+  images: readonly SpatialDataElementMetadata[];
+  /** Label raster elements. */
+  labels: readonly SpatialDataElementMetadata[];
+  /** Point-table elements. */
+  points: readonly SpatialDataElementMetadata[];
+  /** Shape-table elements. */
+  shapes: readonly SpatialDataElementMetadata[];
+  /** AnnData table elements. */
+  tables: readonly SpatialDataElementMetadata[];
+  /** Original root attributes. */
+  attributes: Readonly<Record<string, unknown>>;
+}>;
+
+/** Options for {@link SpatialDataSourceLoader}. */
+export type SpatialDataSourceLoaderOptions = ZarrSourceLoaderOptions;
+
+/** Runtime source returned for a Zarr-backed SpatialData raster or table array. */
+export type SpatialDataZarrElementSource = OMEZarrImageSource | ZarrArraySource;
+
+/** Source loader for SpatialData containers stored as Zarr. */
+export const SpatialDataSourceLoader = {
+  dataType: null as unknown as SpatialDataSource,
+  dataSource: null as unknown as SpatialDataSource,
+  batchType: null as never,
+  name: 'SpatialDataSourceLoader',
+  id: 'spatial-data',
+  module: 'zarr',
+  version: OMEZarrSourceLoader.version,
+  extensions: ['zarr'],
+  mimeTypes: [],
+  type: 'spatial-data',
+  fromUrl: true,
+  fromBlob: false,
+  options: {
+    zarr: {
+      metadataPath: 'auto',
+      path: null,
+      labels: undefined!,
+      requireConsolidatedMetadata: true
+    }
+  } as SpatialDataSourceLoaderOptions,
+  defaultOptions: {
+    zarr: {
+      metadataPath: 'auto',
+      path: null,
+      labels: undefined!,
+      requireConsolidatedMetadata: true
+    }
+  },
+  testURL: (url: string): boolean => /\.zarr(?:$|[/?#])/i.test(url),
+  createDataSource: (
+    data: string,
+    options: SpatialDataSourceLoaderOptions,
+    coreApi?: CoreAPI
+  ): SpatialDataSource => new SpatialDataSource(data, options, coreApi)
+} as const satisfies ZarrSourceLoader<SpatialDataSource>;
+
+/** Discovers and opens the typed elements of a SpatialData Zarr container. */
+export class SpatialDataSource extends ZarrSource {
+  /** Shared normalized metadata discovery request. */
+  private metadataPromise: Promise<SpatialDataSourceMetadata> | null = null;
+
+  /** Creates a SpatialData container source. */
+  constructor(data: string, options: SpatialDataSourceLoaderOptions = {}, coreApi?: CoreAPI) {
+    super(data, options, coreApi);
+  }
+
+  /** Discovers images, labels, points, shapes, and tables without reading payload chunks. */
+  async getMetadata(signal?: AbortSignal): Promise<SpatialDataSourceMetadata> {
+    this.metadataPromise ||= this.discoverMetadata(signal);
+    try {
+      return await this.metadataPromise;
+    } catch (error) {
+      this.metadataPromise = null;
+      throw error;
+    }
+  }
+
+  /** Returns one named element, throwing when the kind or name is absent. */
+  async getElement(
+    kind: SpatialDataElementKind,
+    name: string,
+    signal?: AbortSignal
+  ): Promise<SpatialDataElementMetadata> {
+    const metadata = await this.getMetadata(signal);
+    const element = metadata.elements.find(candidate => candidate.kind === kind && candidate.name === name);
+    if (!element) {
+      throw new Error(`SpatialData ${kind} element ${name} is not available.`);
+    }
+    return element;
+  }
+
+  /** Opens an image or label element as an OME-Zarr raster source. */
+  async createRasterSource(
+    kind: 'image' | 'labels',
+    name: string,
+    signal?: AbortSignal
+  ): Promise<OMEZarrImageSource> {
+    const element = await this.getElement(kind, name, signal);
+    return new OMEZarrImageSource(
+      this.data,
+      {
+        ...this.options,
+        zarr: {...this.options.zarr, path: element.path}
+      },
+      this.hasCoreApi ? this.coreApi : undefined
+    );
+  }
+
+  /** Opens an array below an AnnData table element through the generic Zarr array source. */
+  async createTableArraySource(
+    name: string,
+    arrayPath: string,
+    options: ZarrArraySourceLoaderOptions['zarrArray'] = {},
+    signal?: AbortSignal
+  ): Promise<ZarrArraySource> {
+    const element = await this.getElement('table', name, signal);
+    const normalizedArrayPath = arrayPath.replace(/^\/+|\/+$/g, '');
+    if (!normalizedArrayPath) {
+      throw new Error('SpatialData table array path must not be empty.');
+    }
+    return new ZarrArraySource(
+      this.data,
+      {
+        ...this.options,
+        zarr: {...this.options.zarr, path: element.path},
+        zarrArray: {...options, path: normalizedArrayPath}
+      },
+      this.hasCoreApi ? this.coreApi : undefined
+    );
+  }
+
+  /** Loads and normalizes the consolidated SpatialData element catalog. */
+  private async discoverMetadata(signal?: AbortSignal): Promise<SpatialDataSourceMetadata> {
+    const consolidated = await this.getConsolidatedMetadata(signal);
+    const elements = Object.freeze(discoverSpatialDataElements(this.url, consolidated));
+    const rootSpatialDataAttributes = getObject(consolidated.rootAttributes.spatialdata_attrs);
+    const metadata: SpatialDataSourceMetadata = {
+      version: getString(rootSpatialDataAttributes?.version),
+      elements,
+      images: getElementsByKind(elements, 'image'),
+      labels: getElementsByKind(elements, 'labels'),
+      points: getElementsByKind(elements, 'points'),
+      shapes: getElementsByKind(elements, 'shapes'),
+      tables: getElementsByKind(elements, 'table'),
+      attributes: Object.freeze({...consolidated.rootAttributes})
+    };
+    return Object.freeze(metadata);
+  }
+}
+
+const SPATIAL_DATA_NAMESPACES = Object.freeze([
+  {namespace: 'images', kind: 'image', format: 'ome-zarr'},
+  {namespace: 'labels', kind: 'labels', format: 'ome-zarr'},
+  {namespace: 'points', kind: 'points', format: 'parquet-dataset'},
+  {namespace: 'shapes', kind: 'shapes', format: 'geoparquet'},
+  {namespace: 'tables', kind: 'table', format: 'anndata-zarr'}
+] as const);
+
+/** Discovers direct element groups beneath every SpatialData namespace. */
+function discoverSpatialDataElements(
+  rootUrl: string,
+  consolidated: ZarrConsolidatedMetadata
+): SpatialDataElementMetadata[] {
+  const elements: SpatialDataElementMetadata[] = [];
+  for (const definition of SPATIAL_DATA_NAMESPACES) {
+    const paths = getDirectGroupChildren(consolidated, definition.namespace);
+    for (const path of paths) {
+      const name = path.slice(definition.namespace.length + 1);
+      const attributes = getGroupAttributes(consolidated, path);
+      const spatialDataAttributes = getObject(attributes.spatialdata_attrs);
+      elements.push(
+        Object.freeze({
+          kind: definition.kind,
+          name,
+          path,
+          url: getElementUrl(rootUrl, path, definition.format),
+          format: definition.format,
+          version: getString(spatialDataAttributes?.version) || getString(attributes.version),
+          axes: getAxes(attributes),
+          coordinateTransformations: getCoordinateTransformations(attributes),
+          attributes: Object.freeze({...attributes})
+        })
+      );
+    }
+  }
+  return elements;
+}
+
+/** Returns group paths that are direct children of a namespace. */
+function getDirectGroupChildren(
+  consolidated: ZarrConsolidatedMetadata,
+  namespace: string
+): string[] {
+  const prefix = `${namespace}/`;
+  const paths = new Set<string>();
+  for (const [metadataPath, value] of Object.entries(consolidated.metadata)) {
+    const path = consolidated.format === 'v2'
+      ? metadataPath.endsWith('/.zgroup')
+        ? metadataPath.slice(0, -8)
+        : ''
+      : value && typeof value === 'object' && (value as {node_type?: unknown}).node_type === 'group'
+        ? metadataPath
+        : '';
+    if (!path.startsWith(prefix) || path.slice(prefix.length).includes('/')) continue;
+    paths.add(path);
+  }
+  return [...paths].sort();
+}
+
+/** Returns normalized group attributes across consolidated Zarr generations. */
+function getGroupAttributes(
+  consolidated: ZarrConsolidatedMetadata,
+  path: string
+): Record<string, unknown> {
+  if (consolidated.format === 'v2') {
+    return {...(getObject(consolidated.metadata[`${path}/.zattrs`]) || {})};
+  }
+  const node = getObject(consolidated.metadata[path]);
+  return {...(getObject(node?.attributes) || {})};
+}
+
+/** Returns the external or Zarr URL associated with an element format. */
+function getElementUrl(
+  rootUrl: string,
+  path: string,
+  format: SpatialDataElementFormat
+): string {
+  const baseUrl = `${rootUrl.replace(/\/+$/, '')}/${path}`;
+  if (format === 'parquet-dataset') return `${baseUrl}/points.parquet`;
+  if (format === 'geoparquet') return `${baseUrl}/shapes.parquet`;
+  return baseUrl;
+}
+
+/** Extracts axis names from SpatialData or nested OME metadata. */
+function getAxes(attributes: Record<string, unknown>): readonly string[] | undefined {
+  const directAxes = normalizeAxes(attributes.axes);
+  if (directAxes) return Object.freeze(directAxes);
+  const ome = getObject(attributes.ome);
+  const multiscales = Array.isArray(ome?.multiscales) ? ome.multiscales : [];
+  const multiscale = getObject(multiscales[0]);
+  const axes = normalizeAxes(multiscale?.axes);
+  return axes ? Object.freeze(axes) : undefined;
+}
+
+/** Normalizes string and object axis declarations to names. */
+function normalizeAxes(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const axes = value
+    .map(axis => typeof axis === 'string' ? axis : getString(getObject(axis)?.name))
+    .filter((axis): axis is string => Boolean(axis));
+  return axes.length ? axes : undefined;
+}
+
+/** Extracts coordinate transformations from SpatialData or nested OME metadata. */
+function getCoordinateTransformations(
+  attributes: Record<string, unknown>
+): readonly unknown[] | undefined {
+  if (Array.isArray(attributes.coordinateTransformations)) {
+    return Object.freeze([...attributes.coordinateTransformations]);
+  }
+  const ome = getObject(attributes.ome);
+  const multiscales = Array.isArray(ome?.multiscales) ? ome.multiscales : [];
+  const multiscale = getObject(multiscales[0]);
+  return Array.isArray(multiscale?.coordinateTransformations)
+    ? Object.freeze([...multiscale.coordinateTransformations])
+    : undefined;
+}
+
+/** Filters and freezes one SpatialData element family. */
+function getElementsByKind(
+  elements: readonly SpatialDataElementMetadata[],
+  kind: SpatialDataElementKind
+): readonly SpatialDataElementMetadata[] {
+  return Object.freeze(elements.filter(element => element.kind === kind));
+}
+
+/** Narrows an unknown metadata value to an object. */
+function getObject(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined;
+}
+
+/** Narrows an unknown metadata value to a string. */
+function getString(value: unknown): string | undefined {
+  return typeof value === 'string' && value ? value : undefined;
+}

--- a/modules/zarr/src/spatial-data-source.ts
+++ b/modules/zarr/src/spatial-data-source.ts
@@ -155,7 +155,7 @@ export class SpatialDataSource extends ZarrSource {
       this.data,
       {
         ...this.options,
-        zarr: {...this.options.zarr, path: element.path}
+        zarr: {...this.options.zarr, path: joinZarrPath(this.path, element.path)}
       },
       this.hasCoreApi ? this.coreApi : undefined
     );
@@ -177,7 +177,7 @@ export class SpatialDataSource extends ZarrSource {
       this.data,
       {
         ...this.options,
-        zarr: {...this.options.zarr, path: element.path},
+        zarr: {...this.options.zarr, path: joinZarrPath(this.path, element.path)},
         zarrArray: {...options, path: normalizedArrayPath}
       },
       this.hasCoreApi ? this.coreApi : undefined
@@ -187,8 +187,14 @@ export class SpatialDataSource extends ZarrSource {
   /** Loads and normalizes the consolidated SpatialData element catalog. */
   private async discoverMetadata(signal?: AbortSignal): Promise<SpatialDataSourceMetadata> {
     const consolidated = await this.getConsolidatedMetadata(signal);
-    const elements = Object.freeze(discoverSpatialDataElements(this.url, consolidated));
-    const rootSpatialDataAttributes = getObject(consolidated.rootAttributes.spatialdata_attrs);
+    const spatialDataPath = normalizeZarrPath(this.path);
+    const attributes = spatialDataPath
+      ? getGroupAttributes(consolidated, spatialDataPath)
+      : consolidated.rootAttributes;
+    const elements = Object.freeze(
+      discoverSpatialDataElements(this.url, consolidated, spatialDataPath)
+    );
+    const rootSpatialDataAttributes = getObject(attributes.spatialdata_attrs);
     const metadata: SpatialDataSourceMetadata = {
       version: getString(rootSpatialDataAttributes?.version),
       elements,
@@ -197,7 +203,7 @@ export class SpatialDataSource extends ZarrSource {
       points: getElementsByKind(elements, 'points'),
       shapes: getElementsByKind(elements, 'shapes'),
       tables: getElementsByKind(elements, 'table'),
-      attributes: Object.freeze({...consolidated.rootAttributes})
+      attributes: Object.freeze({...attributes})
     };
     return Object.freeze(metadata);
   }
@@ -214,21 +220,24 @@ const SPATIAL_DATA_NAMESPACES = Object.freeze([
 /** Discovers direct element groups beneath every SpatialData namespace. */
 function discoverSpatialDataElements(
   rootUrl: string,
-  consolidated: ZarrConsolidatedMetadata
+  consolidated: ZarrConsolidatedMetadata,
+  spatialDataPath: string
 ): SpatialDataElementMetadata[] {
   const elements: SpatialDataElementMetadata[] = [];
   for (const definition of SPATIAL_DATA_NAMESPACES) {
-    const paths = getDirectGroupChildren(consolidated, definition.namespace);
-    for (const path of paths) {
-      const name = path.slice(definition.namespace.length + 1);
-      const attributes = getGroupAttributes(consolidated, path);
+    const namespacePath = joinZarrPath(spatialDataPath, definition.namespace);
+    const paths = getDirectGroupChildren(consolidated, namespacePath);
+    for (const fullPath of paths) {
+      const name = fullPath.slice(namespacePath.length + 1);
+      const path = `${definition.namespace}/${name}`;
+      const attributes = getGroupAttributes(consolidated, fullPath);
       const spatialDataAttributes = getObject(attributes.spatialdata_attrs);
       elements.push(
         Object.freeze({
           kind: definition.kind,
           name,
           path,
-          url: getElementUrl(rootUrl, path, definition.format),
+          url: getElementUrl(rootUrl, fullPath, definition.format),
           format: definition.format,
           version: getString(spatialDataAttributes?.version) || getString(attributes.version),
           axes: getAxes(attributes),
@@ -239,6 +248,16 @@ function discoverSpatialDataElements(
     }
   }
   return elements;
+}
+
+/** Joins normalized Zarr group paths without introducing a leading slash. */
+function joinZarrPath(...paths: Array<string | null>): string {
+  return paths.map(normalizeZarrPath).filter(Boolean).join('/');
+}
+
+/** Normalizes an optional Zarr group path for consolidated metadata lookups. */
+function normalizeZarrPath(path: string | null): string {
+  return path?.replace(/^\/+|\/+$/g, '') || '';
 }
 
 /** Returns group paths that are direct children of a namespace. */

--- a/modules/zarr/test/data/spatialdata-v3.zarr/zarr.json
+++ b/modules/zarr/test/data/spatialdata-v3.zarr/zarr.json
@@ -207,20 +207,58 @@
         "node_type": "group",
         "attributes": {}
       },
+      "labels/nuclei": {
+        "zarr_format": 3,
+        "node_type": "group",
+        "attributes": {
+          "spatialdata_attrs": {"version": "0.3"},
+          "coordinateTransformations": [{"type": "identity"}]
+        }
+      },
       "points": {
         "zarr_format": 3,
         "node_type": "group",
         "attributes": {}
+      },
+      "points/transcripts": {
+        "zarr_format": 3,
+        "node_type": "group",
+        "attributes": {
+          "spatialdata_attrs": {"version": "0.2", "feature_key": "gene"},
+          "axes": ["x", "y"],
+          "coordinateTransformations": [{"type": "identity"}]
+        }
       },
       "shapes": {
         "zarr_format": 3,
         "node_type": "group",
         "attributes": {}
       },
+      "shapes/cells": {
+        "zarr_format": 3,
+        "node_type": "group",
+        "attributes": {
+          "spatialdata_attrs": {"version": "0.3"},
+          "axes": ["x", "y"]
+        }
+      },
       "tables": {
         "zarr_format": 3,
         "node_type": "group",
         "attributes": {}
+      },
+      "tables/annotations": {
+        "zarr_format": 3,
+        "node_type": "group",
+        "attributes": {
+          "encoding-type": "anndata",
+          "encoding-version": "0.1.0",
+          "version": "0.2",
+          "spatialdata-encoding-type": "ngff:regions_table",
+          "region": ["cells"],
+          "region_key": "region",
+          "instance_key": "cell_id"
+        }
       }
     }
   }

--- a/modules/zarr/test/ome-zarr-source.node.spec.ts
+++ b/modules/zarr/test/ome-zarr-source.node.spec.ts
@@ -56,7 +56,8 @@ test('OMEZarrImageSource validates pyramid levels and channels', async () => {
 test('loadZarrConsolidatedMetadata handles .zmetadata and extracts top-level groups', async () => {
     const metadata = await loadZarrConsolidatedMetadata(OME_FIXTURE, { fetch: fetchFile });
     expect(metadata.format).toBe('v2');
-    expect(metadata.metadataPath).toBe('.zmetadata');
+  expect(metadata.metadataPath).toBe('.zmetadata');
+  expect(metadata.rootAttributes).toHaveProperty('multiscales');
     expect(metadata.topLevelGroups).toEqual([]);
     expect(metadata.topLevelArrays).toEqual(['0', '1']);
 });
@@ -79,7 +80,8 @@ test('loadZarrConsolidatedMetadata handles v3 zarr.json fixture metadata', async
         fetch: fetchFile
     });
     expect(metadata.format).toBe('v3');
-    expect(metadata.metadataPath).toBe('zarr.json');
+  expect(metadata.metadataPath).toBe('zarr.json');
+  expect(metadata.rootAttributes).toMatchObject({spatialdata_attrs: {version: '0.1.0'}});
     expect(metadata.topLevelGroups).toEqual(['images', 'labels', 'points', 'shapes', 'tables']);
     expect(metadata.topLevelArrays).toEqual([]);
 });

--- a/modules/zarr/test/spatial-data-source.node.spec.ts
+++ b/modules/zarr/test/spatial-data-source.node.spec.ts
@@ -103,4 +103,47 @@ describe('SpatialDataSource', () => {
       points: [{name: 'cells', format: 'parquet-dataset', axes: ['x', 'y']}]
     });
   });
+
+  test('preserves a nested SpatialData container path', async () => {
+    const source = new SpatialDataSource('https://example.com/store.zarr', {
+      zarr: {metadataPath: 'zmetadata', path: '/experiment/'},
+      core: {
+        loadOptions: {
+          fetch: async () =>
+            new Response(
+              JSON.stringify({
+                metadata: {
+                  '.zgroup': {zarr_format: 2},
+                  'experiment/.zgroup': {zarr_format: 2},
+                  'experiment/.zattrs': {spatialdata_attrs: {version: '0.2'}},
+                  'experiment/images/.zgroup': {zarr_format: 2},
+                  'experiment/images/sample/.zgroup': {zarr_format: 2},
+                  'experiment/images/sample/.zattrs': {axes: ['y', 'x']},
+                  'experiment/tables/.zgroup': {zarr_format: 2},
+                  'experiment/tables/observations/.zgroup': {zarr_format: 2}
+                }
+              })
+            )
+        }
+      }
+    });
+
+    const metadata = await source.getMetadata();
+    const imageSource = await source.createRasterSource('image', 'sample');
+    const tableSource = await source.createTableArraySource('observations', 'X');
+
+    expect(metadata).toMatchObject({
+      version: '0.2',
+      images: [
+        {
+          name: 'sample',
+          path: 'images/sample',
+          url: 'https://example.com/store.zarr/experiment/images/sample'
+        }
+      ],
+      tables: [{name: 'observations', path: 'tables/observations'}]
+    });
+    expect(imageSource.options.zarr?.path).toBe('experiment/images/sample');
+    expect(tableSource.options.zarr?.path).toBe('experiment/tables/observations');
+  });
 });

--- a/modules/zarr/test/spatial-data-source.node.spec.ts
+++ b/modules/zarr/test/spatial-data-source.node.spec.ts
@@ -1,0 +1,106 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {pathToFileURL} from 'node:url';
+import {readFile} from 'node:fs/promises';
+import {describe, expect, test} from 'vitest';
+import {resolvePath} from '@loaders.gl/core';
+import {
+  OMEZarrImageSource,
+  SpatialDataSource,
+  ZarrArraySource
+} from '@loaders.gl/zarr';
+
+const FIXTURE_PATH = resolvePath('@loaders.gl/zarr/test/data/spatialdata-v3.zarr');
+const FIXTURE_URL = pathToFileURL(FIXTURE_PATH).href;
+
+function createSpatialDataSource(): SpatialDataSource {
+  return new SpatialDataSource(FIXTURE_URL, {core: {loadOptions: {fetch: fetchFixtureFile}}});
+}
+
+async function fetchFixtureFile(url: string): Promise<Response> {
+  const path = url.startsWith('file:') ? new URL(url).pathname : url;
+  try {
+    return new Response(await readFile(path));
+  } catch {
+    return new Response(null, {status: 404});
+  }
+}
+
+describe('SpatialDataSource', () => {
+  test('discovers typed SpatialData elements and storage references', async () => {
+    const source = createSpatialDataSource();
+    const metadata = await source.getMetadata();
+
+    expect(source).toBeInstanceOf(SpatialDataSource);
+    expect(metadata.version).toBe('0.1.0');
+    expect(metadata.elements.map(element => `${element.kind}:${element.name}`)).toEqual([
+      'image:example-image',
+      'labels:nuclei',
+      'points:transcripts',
+      'shapes:cells',
+      'table:annotations'
+    ]);
+    expect(metadata.points[0]).toMatchObject({
+      format: 'parquet-dataset',
+      axes: ['x', 'y'],
+      version: '0.2'
+    });
+    expect(metadata.points[0].url).toMatch(/points\/transcripts\/points\.parquet$/);
+    expect(metadata.shapes[0].url).toMatch(/shapes\/cells\/shapes\.parquet$/);
+    expect(metadata.tables[0]).toMatchObject({format: 'anndata-zarr', version: '0.2'});
+    expect(Object.isFrozen(metadata.elements)).toBe(true);
+  });
+
+  test('opens discovered raster and AnnData array elements as Zarr sources', async () => {
+    const source = createSpatialDataSource();
+    const imageSource = await source.createRasterSource('image', 'example-image');
+    const tableArraySource = await source.createTableArraySource('annotations', 'X');
+
+    expect(imageSource).toBeInstanceOf(OMEZarrImageSource);
+    await expect(imageSource.getMetadata()).resolves.toMatchObject({width: 439, height: 167});
+    expect(tableArraySource).toBeInstanceOf(ZarrArraySource);
+    expect(tableArraySource.options.zarr?.path).toBe('tables/annotations');
+    expect(tableArraySource.options.zarrArray?.path).toBe('X');
+  });
+
+  test('rejects unknown elements and empty table array paths', async () => {
+    const source = createSpatialDataSource();
+
+    await expect(source.getElement('points', 'missing')).rejects.toThrow(/is not available/);
+    await expect(source.createTableArraySource('annotations', '/')).rejects.toThrow(
+      /must not be empty/
+    );
+  });
+
+  test('discovers legacy v2 SpatialData element groups', async () => {
+    const source = new SpatialDataSource('https://example.com/legacy.zarr', {
+      zarr: {metadataPath: 'zmetadata'},
+      core: {
+        loadOptions: {
+          fetch: async () =>
+            new Response(
+              JSON.stringify({
+                metadata: {
+                  '.zgroup': {zarr_format: 2},
+                  '.zattrs': {spatialdata_attrs: {version: '0.1'}},
+                  'points/.zgroup': {zarr_format: 2},
+                  'points/cells/.zgroup': {zarr_format: 2},
+                  'points/cells/.zattrs': {
+                    spatialdata_attrs: {version: '0.1'},
+                    axes: ['x', 'y']
+                  }
+                }
+              })
+            )
+        }
+      }
+    });
+
+    await expect(source.getMetadata()).resolves.toMatchObject({
+      version: '0.1',
+      points: [{name: 'cells', format: 'parquet-dataset', axes: ['x', 'y']}]
+    });
+  });
+});

--- a/modules/zarr/test/spatial-data-source.spec.ts
+++ b/modules/zarr/test/spatial-data-source.spec.ts
@@ -1,0 +1,23 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {describe, expect, test} from 'vitest';
+import {createDataSource} from '@loaders.gl/core';
+import {SpatialDataSource, SpatialDataSourceLoader} from '@loaders.gl/zarr';
+
+const FIXTURE_URL = '/modules/zarr/test/data/spatialdata-v3.zarr';
+
+describe('SpatialDataSource browser integration', () => {
+  test('discovers the typed SpatialData catalog through createDataSource', async () => {
+    const source = createDataSource(FIXTURE_URL, [SpatialDataSourceLoader]);
+    const metadata = await source.getMetadata();
+
+    expect(source).toBeInstanceOf(SpatialDataSource);
+    expect(metadata.images.map(element => element.name)).toEqual(['example-image']);
+    expect(metadata.labels.map(element => element.name)).toEqual(['nuclei']);
+    expect(metadata.points.map(element => element.name)).toEqual(['transcripts']);
+    expect(metadata.shapes.map(element => element.name)).toEqual(['cells']);
+    expect(metadata.tables.map(element => element.name)).toEqual(['annotations']);
+  });
+});


### PR DESCRIPTION
## Goals

- Make SpatialData Zarr containers first-class loaders.gl sources rather than requiring applications to inspect raw consolidated metadata.
- Normalize images, labels, points, shapes, and tables while preserving the lightweight `@loaders.gl/zarr` package boundary.
- Provide direct source creation for Zarr-backed raster and AnnData array elements, with interoperable references for Parquet-backed geometries and points.

## Changes

- Add `SpatialDataSourceLoader` and `SpatialDataSource`.
- Discover named images, labels, points, shapes, and tables from consolidated Zarr v2 and v3 metadata.
- Preserve element axes, coordinate transformations, encoding versions, original attributes, and canonical payload URLs.
- Open image and label elements as `OMEZarrImageSource` instances.
- Open arrays below AnnData table elements as `ZarrArraySource` instances.
- Report point payloads as Parquet datasets and shape payloads as GeoParquet without adding the full Parquet runtime to `@loaders.gl/zarr`.
- Retain root-group attributes in normalized consolidated metadata.
- Expand the Zarr feature matrix, format documentation, module README, and API reference.
- Extend the deterministic SpatialData fixture and add native Vitest coverage in Node and Chromium.

## Validation

- `yarn install`
- `yarn build`
- `yarn build-workers`
- `yarn test-node`
- `yarn test-headless`
- `yarn test-audit`
- `yarn lint fix`
