### PR TITLE
docs(website): extend designed pages and standards catalog

### DIFF
--- a/docs/developer-guide/standards.md
+++ b/docs/developer-guide/standards.md
@@ -1,85 +1,57 @@
 ---
-title: Standards support
-description: See which geospatial standards loaders.gl recognizes, reads, writes, or exposes through service APIs.
+title: Standards and organizations
+description: Explore the open standards, service protocols, and organizations represented by loaders.gl implementations.
 hide_title: true
 page_style: designed
 ---
 
 import {CapabilityHero} from '@site/src/components/docs/capability-hero';
-import {DocPageHeader} from '@site/src/components/docs/doc-page-header';
 import {StandardsBoundaryGraphic} from '@site/src/components/docs/standards-boundary-graphic';
+import {StandardsOrganizations} from '@site/src/components/docs/standards-organizations';
 import {DocOrientation, ReferenceBoundary} from '@site/src/components/docs/designed-doc';
+import apacheLogo from '../images/logos/apache-logo.png';
 
-<CapabilityHero capability="standards" />
-
-<DocPageHeader
-  eyebrow="Standards and specifications"
-  title="Use standards without hiding their boundaries."
-  description="The support matrix separates implemented formats, service protocols, developing specifications, and intentionally specialized APIs so compatibility is easy to inspect."
-  tone="violet"
-  meta={['OGC formats', 'Web services', 'Capability matrix']}
+<CapabilityHero
+  capability="standards"
+  eyebrow="Standards and organizations"
+  title="loaders.gl ♥ standards"
+  description="Big-data applications should be able to choose open formats without rebuilding their loading path. loaders.gl implements standards deeply, exposes the boundaries honestly, and keeps the application-facing shapes portable."
+  logos={[
+    {alt: 'Open Geospatial Consortium', src: '/images/format-logos/ogc-logo-transparent.png'},
+    {alt: 'glTF', src: '/images/format-logos/gltf-logo.png'},
+    {alt: 'Apache Software Foundation', src: apacheLogo},
+    {alt: 'ArcGIS', src: '/images/format-logos/arcgis-logo.svg'}
+  ]}
   links={[
+    {label: 'All formats', to: '/docs/formats'},
     {label: '3D data formats', to: '/docs/developer-guide/3d-data-formats'},
-    {label: 'CRS guide', to: '/docs/developer-guide/coordinate-reference-systems'}
+    {label: 'Loader categories', to: '/docs/developer-guide/loader-categories'}
   ]}
 />
 
 <StandardsBoundaryGraphic />
 
 <DocOrientation
-  eyebrow="How to read the matrix"
-  title="A standard name is not a blanket promise."
-  description="Support is recorded at the format, protocol, and capability level. Follow the linked module or specification for the exact version, profile, and execution boundary."
+  eyebrow="What support means here"
+  title="Implement the standard. Keep the boundary visible."
+  description="A standards logo is useful only when readers can discover the loader, writer, source, version, and unsupported edge behind it. The catalog below links directly to those implementation pages."
   tone="violet"
   items={[
-    {label: 'Implemented', value: 'A loader, writer, or source exposes the format'},
-    {label: 'Protocol', value: 'A service API may require metadata and follow-up requests'},
-    {label: 'Developing', value: 'Useful support exists while the specification evolves'},
-    {label: 'Boundary', value: 'Unsupported features remain visible in the tables'}
+    {label: 'Decode', value: 'Load standards-shaped files and service responses'},
+    {label: 'Encode', value: 'Write compatible formats where a writer is implemented'},
+    {label: 'Discover', value: 'Read metadata before requesting large payloads'},
+    {label: 'Compose', value: 'Move results through common table, mesh, scene, and tile shapes'}
   ]}
 />
 
+<StandardsOrganizations />
+
 <ReferenceBoundary
-  title="Standards and capability tables"
-  description="The detailed matrix below lists OGC formats, web protocols, and non-OGC formats with their current loaders.gl entry points."
+  title="Conformance lives with each format"
+  description="Follow a format link for supported versions, profiles, extensions, loader and writer entry points, test-backed capabilities, and known gaps. The catalog is a map—not a blanket conformance claim."
   tone="violet"
 />
 
-## OGC Formats
-
-| Format                                                                       | Module                   | Description                                          |
-| ---------------------------------------------------------------------------- | ------------------------ | ---------------------------------------------------- |
-| KML                                                                          | `@loaders.gl/kml`        |
-| GeoPackage                                                                   | `@loaders.gl/geopackage` |
-| [**GML**](/docs/modules/wms/formats/gml) (Geographic Markup Language) format | `@loaders.gl/wms`        | an XML grammar that describes geographical features. |
-| WKT                                                                          | `@loaders.gl/wkt`        |
-| WKB                                                                          | `@loaders.gl/wkt`        |
-| WKT-CRS                                                                      | `@math.gl/proj4`         |                                                      |
-| 3D Tiles                                                                     | `@loaders.gl/3d-tiles`   |                                                      |
-| I3S                                                                          | `@loaders.gl/i3s`        |                                                      |
-
-Developing standards
-
-| Format     |
-| ---------- |
-| GeoParquet |
-| Flatgeobuf |
-
-## OGC Web Standards
-
-| OGC Protocols                                                                   | Supported         | Description                                                                                                                          |
-| ------------------------------------------------------------------------------- | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| [**CSW**](/docs/modules/wms/formats/csw) (Catalog Service for the Web) protocol | `@loaders.gl/wms` | protocol for reading a catalog of geospatial assets and services from a URL.                                                         |
-| [**WMS**](/docs/modules/wms/formats/wms) (Web Map Service) protocol             | `@loaders.gl/wms` | protocol for serving geo-referenced map images over the internet.                                                                    |
-| [**WFS**](/docs/modules/wms/formats/wfs) (Web Feature Service) protocol         | `@loaders.gl/wms` | protocol for serving geo-referenced map features (geometries) over the internet.                                                     |
-| [**WMTS**](/docs/modules/wms/formats/wmts) (Web Map Tile Service) protocol      | `@loaders.gl/wms` | protocol for serving pre-rendered or run-time computed georeferenced map tiles over the Internet.                                    |
-| **WCS** (Web Coverage Service)                                                  | No                | Load coverage data (e.g. geotiff images for satellite data) from a server.                                                           |
-| **WMC**                                                                         | No                | Used in WMS clients to save the configuration of maps and to load them again later. Can also be exchanged between different clients. |
-| **OWS Context**                                                                 | No                | Allows configured information resources to be passed between applications primarily as a collection of services.                     |
-
-## Non-Standards
-
-| Format                                                                                |
-| ------------------------------------------------------------------------------------- | ----------------------- | --- |
-| Shapefile                                                                             | `@loaders.gl/shapefile` |
-| [**LERC**](/docs/modules/lerc/formats/lerc) (Limited Error Raster Compression) format | `@loaders.gl/wms`       | .   |
+Support descriptions deliberately distinguish complete, partial, developing, and unsupported
+capabilities. When a specification is still evolving—such as draft glTF 2.1 features—the format
+page identifies the implemented draft surface and the tests that protect it.

--- a/docs/docs-sidebar.json
+++ b/docs/docs-sidebar.json
@@ -5,6 +5,7 @@
     "items": [
       "README",
       "developer-guide/get-started",
+      "developer-guide/standards",
       "developer-guide/3d-data-formats",
       "whats-new",
       "upgrade-guide"

--- a/docs/modules/arrow/README.md
+++ b/docs/modules/arrow/README.md
@@ -5,29 +5,23 @@ hide_title: true
 page_style: designed
 ---
 
-import {DocPageHeader} from '@site/src/components/docs/doc-page-header';
 import {CapabilityHero} from '@site/src/components/docs/capability-hero';
 import {ArrowDataPlaneGraphic} from '@site/src/components/docs/arrow-data-plane-graphic';
 import {DocOrientation, ReferenceBoundary} from '@site/src/components/docs/designed-doc';
+import apacheLogo from '../../images/logos/apache-logo.png';
 
-<CapabilityHero capability="arrow" />
-
-<DocPageHeader
+<CapabilityHero
+  capability="arrow"
   eyebrow="Module overview"
   title="@loaders.gl/arrow"
   description="Use Apache Arrow as the common table shape between format loaders, workers, transforms, and writers."
-  tone="cyan"
-  meta={['Apache Arrow', 'GeoArrow', 'Tables and transport']}
+  logos={[{alt: 'Apache Software Foundation', src: apacheLogo}]}
   links={[
     {label: 'Arrow format', to: '/docs/modules/arrow/formats/arrow'},
     {label: 'ArrowLoader', to: '/docs/modules/arrow/api-reference/arrow-loader'},
     {label: 'ArrowWriter', to: '/docs/modules/arrow/api-reference/arrow-writer'}
   ]}
 />
-
-![arrow-logo](./images/apache-arrow-small.png)
-&emsp;
-![apache-logo](../../images/logos/apache-logo.png)
 
 <ArrowDataPlaneGraphic />
 

--- a/docs/modules/arrow/api-reference/arrow-loader.md
+++ b/docs/modules/arrow/api-reference/arrow-loader.md
@@ -8,18 +8,13 @@ page_style: designed
 import {ArrowDocsTabs} from '@site/src/components/docs/arrow-docs-tabs';
 import {ArrowJsStructureGraphic} from '@site/src/components/docs/arrow-js-structure-graphic';
 import {CapabilityHero} from '@site/src/components/docs/capability-hero';
-import {DocPageHeader} from '@site/src/components/docs/doc-page-header';
 import {DocOrientation, ReferenceBoundary} from '@site/src/components/docs/designed-doc';
 
-<CapabilityHero capability="arrow" />
-
-<DocPageHeader
+<CapabilityHero
+  capability="arrow"
   eyebrow="Arrow module / loader"
   title="ArrowLoader"
   description="Read Arrow IPC data and keep its typed, columnar structure as it enters your application."
-  hideTitle
-  tone="cyan"
-  meta={['Input: .arrow / .feather', 'Output: ArrowTable', 'Supports batches']}
   links={[
     {label: 'Arrow format', to: '/docs/modules/arrow/formats/arrow'},
     {label: 'ArrowWriter', to: '/docs/modules/arrow/api-reference/arrow-writer'}

--- a/docs/modules/arrow/formats/arrow.md
+++ b/docs/modules/arrow/formats/arrow.md
@@ -11,16 +11,14 @@ import {ArrowJsStructureGraphic} from '@site/src/components/docs/arrow-js-struct
 import {ArrowScanLiveExample} from '@site/src/components/docs/arrow-scan-live-example';
 import {CapabilityHero} from '@site/src/components/docs/capability-hero';
 import {DocOrientation} from '@site/src/components/docs/designed-doc';
-import {DocPageHeader} from '@site/src/components/docs/doc-page-header';
+import apacheLogo from '../../../images/logos/apache-logo.png';
 
-<CapabilityHero capability="arrow" />
-
-<DocPageHeader
+<CapabilityHero
+  capability="arrow"
   eyebrow="Binary columnar format"
   title="Apache Arrow"
   description="A typed table representation that keeps data compact, shareable, and ready for the next step in a JavaScript pipeline."
-  tone="cyan"
-  meta={['IPC file and stream', 'Typed columns', 'Worker-friendly']}
+  logos={[{alt: 'Apache Software Foundation', src: apacheLogo}]}
   links={[
     {label: 'Arrow module', to: '/docs/modules/arrow'},
     {label: 'Try Arrow', to: '/examples/table/arrow'}

--- a/docs/modules/copc/README.md
+++ b/docs/modules/copc/README.md
@@ -9,13 +9,15 @@ import {CopcDocsTabs} from '@site/src/components/docs/copc-docs-tabs';
 import {CopcRangeGraphic} from '@site/src/components/docs/copc-range-graphic';
 import {DocPageHeader} from '@site/src/components/docs/doc-page-header';
 import {DocOrientation, ReferenceBoundary} from '@site/src/components/docs/designed-doc';
+import copcLogo from '../../images/logos/copc-logo-80.png';
 
 <DocPageHeader
   eyebrow="Point-cloud module"
-  title="Read only the points the view needs."
-  description="COPC packages a LAS point cloud as a range-readable LAZ file with an octree hierarchy. The module combines hierarchy selection, byte ranges, native TypeScript decoding, and Arrow output for cloud-hosted datasets."
+  title="@loaders.gl/copc"
+  description="Read only the points the view needs. COPC packages a LAS point cloud as a range-readable LAZ file with an octree hierarchy for selective cloud access."
   tone="violet"
   meta={['COPC 1.0', 'Cloud range reads', 'Arrow point tables']}
+  logos={[{alt: 'COPC', src: copcLogo}]}
   links={[
     {label: 'COPC format', to: '/docs/modules/copc/formats/copc'},
     {label: 'Scan architecture', to: '/docs/developer-guide/common-scan-architecture'}
@@ -24,8 +26,6 @@ import {DocOrientation, ReferenceBoundary} from '@site/src/components/docs/desig
 
 See [Coordinate Reference Systems](/docs/developer-guide/coordinate-reference-systems) for the
 current COPC/LAS projection-record support and vertical/compound CRS roadmap.
-
-![copc-logo](../../images/logos/copc-logo-80.png)
 
 <p className="badges">
   <img src="https://img.shields.io/badge/From-v4.1-blue.svg?style=flat-square" alt="From-v4.1" />

--- a/docs/modules/copc/api-reference/copc-source-loader.md
+++ b/docs/modules/copc/api-reference/copc-source-loader.md
@@ -9,13 +9,15 @@ import {CopcDocsTabs} from '@site/src/components/docs/copc-docs-tabs';
 import {CopcRangeGraphic} from '@site/src/components/docs/copc-range-graphic';
 import {DocPageHeader} from '@site/src/components/docs/doc-page-header';
 import {DocOrientation, ReferenceBoundary} from '@site/src/components/docs/designed-doc';
+import copcLogo from '../../../images/logos/copc-logo-80.png';
 
 <DocPageHeader
   eyebrow="COPC source"
-  title="Turn one cloud object into a selectable point source."
-  description="COPCSourceLoader connects the COPC hierarchy to loaders.gl's point-cloud source contract. It discovers metadata, selects nodes, range-reads LAZ chunks, and can emit normalized point tiles or Arrow batches."
+  title="COPCSourceLoader"
+  description="Turn one cloud object into a selectable point source. Discover metadata, select nodes, range-read LAZ chunks, and emit normalized point tiles or Arrow batches."
   tone="violet"
   meta={['COPC 1.0', 'Range requests', 'PointCloudTileset']}
+  logos={[{alt: 'COPC', src: copcLogo}]}
   links={[
     {label: 'COPC format', to: '/docs/modules/copc/formats/copc'},
     {label: 'Potree source', to: '/docs/modules/potree/api-reference/potree-source-loader'}

--- a/docs/modules/gltf/README.md
+++ b/docs/modules/gltf/README.md
@@ -16,6 +16,7 @@ import {DocOrientation, ReferenceBoundary} from '@site/src/components/docs/desig
   description="Bring glTF and GLB scenes into an application with linked assets, compressed meshes, typed traversal, and a standards-shaped result."
   tone="pink"
   meta={['glTF and GLB', 'Scenegraph data', 'Draco and meshopt']}
+  logos={[{alt: 'glTF', src: '/images/format-logos/gltf-logo.png'}]}
   links={[
     {label: 'glTF format', to: '/docs/modules/gltf/formats/gltf'},
     {label: 'GLTFLoader', to: '/docs/modules/gltf/api-reference/gltf-loader'},
@@ -24,8 +25,6 @@ import {DocOrientation, ReferenceBoundary} from '@site/src/components/docs/desig
 />
 
 <GltfDocsTabs active="overview" />
-
-![logo](./images/gltf-small.png)
 
 <ThreeDDataFormatsGraphic />
 

--- a/docs/modules/gltf/api-reference/gltf-loader.md
+++ b/docs/modules/gltf/api-reference/gltf-loader.md
@@ -17,6 +17,7 @@ import {DocOrientation, ReferenceBoundary} from '@site/src/components/docs/desig
   hideTitle
   tone="pink"
   meta={['.gltf and .glb', 'Linked assets', 'Draco and meshopt']}
+  logos={[{alt: 'glTF', src: '/images/format-logos/gltf-logo.png'}]}
   links={[
     {label: 'glTF format', to: '/docs/modules/gltf/formats/gltf'},
     {label: 'glTF module', to: '/docs/modules/gltf'},

--- a/docs/modules/gltf/formats/gltf.md
+++ b/docs/modules/gltf/formats/gltf.md
@@ -16,6 +16,7 @@ import {DocOrientation, ReferenceBoundary} from '@site/src/components/docs/desig
   description="A delivery-focused scene format for geometry, materials, hierarchy, animation, and the linked binary or image assets that make a model complete."
   tone="pink"
   meta={['.gltf and .glb', 'Scenegraph data', 'Khronos standard']}
+  logos={[{alt: 'glTF', src: '/images/format-logos/gltf-logo.png'}]}
   links={[
     {label: 'glTF module', to: '/docs/modules/gltf'},
     {label: 'GLTFLoader', to: '/docs/modules/gltf/api-reference/gltf-loader'},

--- a/docs/modules/i3s/README.md
+++ b/docs/modules/i3s/README.md
@@ -6,6 +6,7 @@ page_style: designed
 ---
 
 import {DocPageHeader} from '@site/src/components/docs/doc-page-header';
+import {ClientExample, DocLiveExample} from '@site/src/components';
 import {TiledSceneGraphic} from '@site/src/components/docs/tiled-scene-graphic';
 import {DocOrientation, ReferenceBoundary} from '@site/src/components/docs/designed-doc';
 
@@ -15,6 +16,10 @@ import {DocOrientation, ReferenceBoundary} from '@site/src/components/docs/desig
   description="Read ArcGIS Indexed 3D Scene Layers through the same source and traversal building blocks used for large browser-rendered scenes."
   tone="orange"
   meta={['I3S profiles', 'Scene and point cloud', 'ArcGIS services']}
+  logos={[
+    {alt: 'ArcGIS', src: '/images/format-logos/arcgis-logo.svg'},
+    {alt: 'Open Geospatial Consortium', src: '/images/format-logos/ogc-logo-transparent.png'}
+  ]}
   links={[
     {label: 'I3S format', to: '/docs/modules/i3s/formats/i3s'},
     {label: 'I3SLoader', to: '/docs/modules/i3s/api-reference/i3s-loader'},
@@ -22,9 +27,9 @@ import {DocOrientation, ReferenceBoundary} from '@site/src/components/docs/desig
   ]}
 />
 
-![ogc-logo](../../images/logos/ogc-logo-60.png)
-&nbsp;
-![arcgis-logo](../../images/logos/arcgis-logo.svg)
+<DocLiveExample label="I3S building scene" height="430px">
+  <ClientExample kind="i3s-building-scene-layer" />
+</DocLiveExample>
 
 <TiledSceneGraphic />
 

--- a/docs/modules/i3s/api-reference/i3s-loader.md
+++ b/docs/modules/i3s/api-reference/i3s-loader.md
@@ -6,22 +6,31 @@ page_style: designed
 ---
 
 import {DocPageHeader} from '@site/src/components/docs/doc-page-header';
+import {ClientExample, DocLiveExample} from '@site/src/components';
 import {DocOrientation, ReferenceBoundary} from '@site/src/components/docs/designed-doc';
 import {TiledSceneGraphic} from '@site/src/components/docs/tiled-scene-graphic';
 
 <DocPageHeader
   eyebrow="I3S loader"
-  title="Load ArcGIS scene layers as traversable data."
-  description="Load ArcGIS scene layers as traversable data. `I3SLoader` reads Indexed 3D Scene layers, their geometry and texture resources, and the metadata needed by the shared tiles runtime. Use it for mesh, point, and scene-layer content delivered as JSON, binary nodes, or an SLPK archive."
+  title="I3SLoader"
+  description="Read ArcGIS scene layers, geometry, textures, and the metadata needed by the shared tiles runtime. Use it for mesh, point, and scene-layer content delivered as JSON, binary nodes, or an SLPK archive."
   hideTitle
   tone="orange"
   meta={['I3S 1.x and 2.x', 'Scene and point layers', 'JSON and binary resources']}
+  logos={[
+    {alt: 'ArcGIS', src: '/images/format-logos/arcgis-logo.svg'},
+    {alt: 'Open Geospatial Consortium', src: '/images/format-logos/ogc-logo-transparent.png'}
+  ]}
   links={[
     {label: 'I3S module', to: '/docs/modules/i3s'},
     {label: 'I3S format', to: '/docs/modules/i3s/formats/i3s'},
     {label: 'I3S source', to: '/docs/modules/tiles/api-reference/i3s-source'}
   ]}
 />
+
+<DocLiveExample label="I3S building scene" height="430px">
+  <ClientExample kind="i3s-building-scene-layer" />
+</DocLiveExample>
 
 <TiledSceneGraphic />
 

--- a/docs/modules/i3s/formats/i3s.md
+++ b/docs/modules/i3s/formats/i3s.md
@@ -11,10 +11,14 @@ import {TiledSceneGraphic} from '@site/src/components/docs/tiled-scene-graphic';
 
 <DocPageHeader
   eyebrow="Hierarchical scene-layer format"
-  title="Stream the scene layer the view can use."
-  description="I3S organizes geometry, textures, attributes, and level-of-detail metadata into a node tree delivered through REST resources or Scene Layer Packages."
+  title="I3S"
+  description="Stream only the scene content the view can use. I3S organizes geometry, textures, attributes, and level-of-detail metadata into a node tree delivered through REST resources or Scene Layer Packages."
   tone="orange"
   meta={['I3S 1.7', 'OGC I3S 1.3', 'REST and SLPK']}
+  logos={[
+    {alt: 'ArcGIS', src: '/images/format-logos/arcgis-logo.svg'},
+    {alt: 'Open Geospatial Consortium', src: '/images/format-logos/ogc-logo-transparent.png'}
+  ]}
   links={[
     {label: 'I3S module', to: '/docs/modules/i3s'},
     {label: '3D data formats', to: '/docs/developer-guide/3d-data-formats'}
@@ -39,8 +43,6 @@ import {TiledSceneGraphic} from '@site/src/components/docs/tiled-scene-graphic';
 - _[`@loaders.gl/i3s`](/docs/modules/i3s)_
 - _[I3S community specification](https://github.com/Esri/i3s-spec)_
 - _[OGC I3S Community Standard](https://www.ogc.org/standard/i3s/)_
-
-![arcgis-logo](../../../images/logos/arcgis-logo.svg)
 
 Indexed 3D Scene Layer (I3S) is a hierarchical, streamable format for large geospatial 3D
 datasets. A scene layer organizes geometry, textures, attributes, and level-of-detail information

--- a/docs/modules/i3s/recipes/attribute-driven-colorization.mdx
+++ b/docs/modules/i3s/recipes/attribute-driven-colorization.mdx
@@ -5,7 +5,7 @@ hide_title: true
 page_style: designed
 ---
 
-import {ClientExample} from '@site/src/components';
+import {ClientExample, DocLiveExample} from '@site/src/components';
 import {DocPageHeader} from '@site/src/components/docs/doc-page-header';
 import {DocOrientation, ReferenceBoundary} from '@site/src/components/docs/designed-doc';
 
@@ -22,9 +22,9 @@ import {DocOrientation, ReferenceBoundary} from '@site/src/components/docs/desig
   ]}
 />
 
-<div style={{height: '50vh'}}>
+<DocLiveExample label="I3S attribute-driven colorization">
   <ClientExample kind="i3s-colorization-by-attributes" />
-</div>
+</DocLiveExample>
 
 <DocOrientation
   eyebrow="What this recipe demonstrates"

--- a/docs/modules/i3s/recipes/building-scene-layer.mdx
+++ b/docs/modules/i3s/recipes/building-scene-layer.mdx
@@ -5,7 +5,7 @@ hide_title: true
 page_style: designed
 ---
 
-import {ClientExample} from '@site/src/components';
+import {ClientExample, DocLiveExample} from '@site/src/components';
 import {DocPageHeader} from '@site/src/components/docs/doc-page-header';
 import {DocOrientation, ReferenceBoundary} from '@site/src/components/docs/designed-doc';
 
@@ -26,9 +26,9 @@ import {DocOrientation, ReferenceBoundary} from '@site/src/components/docs/desig
   <img src="https://img.shields.io/badge/From-v3.2-blue.svg?style=flat-square" alt="From-v3.2" />
 </p>
 
-<div style={{height: '50vh'}}>
+<DocLiveExample label="I3S building scene layer">
   <ClientExample kind="i3s-building-scene-layer" />
-</div>
+</DocLiveExample>
 
 <DocOrientation
   eyebrow="What this recipe demonstrates"

--- a/docs/modules/i3s/recipes/picking.mdx
+++ b/docs/modules/i3s/recipes/picking.mdx
@@ -5,7 +5,7 @@ hide_title: true
 page_style: designed
 ---
 
-import {ClientExample} from '@site/src/components';
+import {ClientExample, DocLiveExample} from '@site/src/components';
 import {DocPageHeader} from '@site/src/components/docs/doc-page-header';
 import {DocOrientation, ReferenceBoundary} from '@site/src/components/docs/designed-doc';
 
@@ -22,9 +22,9 @@ import {DocOrientation, ReferenceBoundary} from '@site/src/components/docs/desig
   ]}
 />
 
-<div style={{height: '50vh'}}>
+<DocLiveExample label="I3S feature picking">
   <ClientExample kind="i3s-picking" />
-</div>
+</DocLiveExample>
 
 <DocOrientation
   eyebrow="What this recipe demonstrates"

--- a/docs/modules/las/README.md
+++ b/docs/modules/las/README.md
@@ -12,10 +12,11 @@ import {DocOrientation, ReferenceBoundary} from '@site/src/components/docs/desig
 
 <DocPageHeader
   eyebrow="Point-cloud module"
-  title="Keep the point record, or keep the columns."
-  description="The LAS module reads and writes the established LAS/LAZ exchange formats, including the modern point-record fields that matter for lidar workflows. Choose raw records, a render-ready point cloud, or a typed Mesh Arrow table."
+  title="@loaders.gl/las"
+  description="Keep the point record, or keep the columns. Read and write LAS/LAZ exchange data as raw records, a render-ready point cloud, or a typed Mesh Arrow table."
   tone="blue"
   meta={['LAS 1.0–1.5', 'LAZ point formats 0–10', 'TypeScript reader']}
+  logos={[{alt: 'LAS', src: '/images/format-logos/las-logo.svg'}]}
   links={[
     {label: 'LAS / LAZ format', to: '/docs/modules/las/formats/las'},
     {label: 'Mesh category', to: '/docs/specifications/category-mesh'}
@@ -23,8 +24,6 @@ import {DocOrientation, ReferenceBoundary} from '@site/src/components/docs/desig
 />
 
 <LasDocsTabs active="overview" />
-
-![las-logo](../../images/logos/las-logo.svg)
 
 <PointCloudFormatGraphic />
 

--- a/docs/modules/las/api-reference/las-loader.md
+++ b/docs/modules/las/api-reference/las-loader.md
@@ -11,10 +11,11 @@ import {DocOrientation, ReferenceBoundary} from '@site/src/components/docs/desig
 
 <DocPageHeader
   eyebrow="LAS loader"
-  title="Choose the point shape that fits the next step."
-  description="LASLoader reads LAS and LAZ records with a pure TypeScript implementation. Return a render-ready point cloud for visualization, or select Arrow columns when the data is headed to analysis, workers, scans, or writers."
+  title="LASLoader"
+  description="Choose the point shape that fits the next step. Read LAS and LAZ records into a render-ready point cloud, or select Arrow columns for analysis, workers, scans, and writers."
   tone="blue"
   meta={['LAS / LAZ', 'TypeScript', 'Arrow output']}
+  logos={[{alt: 'LAS', src: '/images/format-logos/las-logo.svg'}]}
   links={[
     {label: 'LAS / LAZ format', to: '/docs/modules/las/formats/las'},
     {label: 'LASWriter', to: '/docs/modules/las/api-reference/las-writer'}

--- a/docs/modules/parquet/README.md
+++ b/docs/modules/parquet/README.md
@@ -5,27 +5,24 @@ hide_title: true
 page_style: designed
 ---
 
-import {DocPageHeader} from '@site/src/components/docs/doc-page-header';
 import {CapabilityHero} from '@site/src/components/docs/capability-hero';
 import {ParquetLayoutGraphic} from '@site/src/components/docs/parquet-layout-graphic';
 import {DocOrientation, ReferenceBoundary} from '@site/src/components/docs/designed-doc';
 
-<CapabilityHero capability="columnar" />
-
-<DocPageHeader
+<CapabilityHero
+  capability="columnar"
   eyebrow="Module overview"
   title="@loaders.gl/parquet"
   description="Use Parquet when column selection, metadata pruning, and Arrow-compatible results matter more than reading the whole file."
-  tone="mint"
-  meta={['Parquet and GeoParquet', 'Arrow output', 'Selective reads']}
+  logos={[
+    {alt: 'Apache Parquet', src: '/images/format-logos/parquet-logo.png'}
+  ]}
   links={[
     {label: 'Parquet format', to: '/docs/modules/parquet/formats/parquet'},
     {label: 'ParquetLoader', to: '/docs/modules/parquet/api-reference/parquet-loader'},
     {label: 'Scan architecture', to: '/docs/developer-guide/common-scan-architecture'}
   ]}
 />
-
-![parquet-logo](./images/parquet-logo-small.png)
 
 <p className="badges">
   <img src="https://img.shields.io/badge/From-v3.1-blue.svg?style=flat-square" alt="From-v3.1" />

--- a/docs/modules/parquet/api-reference/parquet-loader.md
+++ b/docs/modules/parquet/api-reference/parquet-loader.md
@@ -9,18 +9,13 @@ import {ParquetDocsTabs} from '@site/src/components/docs/parquet-docs-tabs';
 import {ParquetLayoutGraphic} from '@site/src/components/docs/parquet-layout-graphic';
 import BrowserOnly from '@docusaurus/BrowserOnly';
 import {CapabilityHero} from '@site/src/components/docs/capability-hero';
-import {DocPageHeader} from '@site/src/components/docs/doc-page-header';
 import {DocOrientation, ReferenceBoundary} from '@site/src/components/docs/designed-doc';
 
-<CapabilityHero capability="columnar" />
-
-<DocPageHeader
+<CapabilityHero
+  capability="columnar"
   eyebrow="Parquet module / loader"
   title="ParquetLoader"
   description="Start with a familiar load call, then opt into Arrow output, batches, or the selective source API as the dataset grows."
-  hideTitle
-  tone="mint"
-  meta={['WASM-backed default', 'Arrow table option', 'Streaming batches']}
   links={[
     {label: 'Parquet format', to: '/docs/modules/parquet/formats/parquet'},
     {label: 'Parquet source', to: '/docs/modules/parquet/api-reference/parquet-source-loader'}

--- a/docs/modules/parquet/api-reference/parquet-source-loader.md
+++ b/docs/modules/parquet/api-reference/parquet-source-loader.md
@@ -6,18 +6,14 @@ page_style: designed
 ---
 
 import {CapabilityHero} from '@site/src/components/docs/capability-hero';
-import {DocPageHeader} from '@site/src/components/docs/doc-page-header';
 import {DocOrientation, ReferenceBoundary} from '@site/src/components/docs/designed-doc';
 import {ParquetLayoutGraphic} from '@site/src/components/docs/parquet-layout-graphic';
 
-<CapabilityHero capability="datasets" />
-
-<DocPageHeader
+<CapabilityHero
+  capability="datasets"
   eyebrow="Parquet source"
-  title="Ask a remote table for a bounded result."
-  description="ParquetSourceLoader discovers schema and row-group metadata, then reads only the columns and byte ranges needed for a request. Results arrive as Arrow batches through a reusable source."
-  tone="cyan"
-  meta={['Remote Parquet', 'Row-group selection', 'Arrow batches']}
+  title="ParquetSourceLoader"
+  description="Ask a remote table for a bounded result. The source discovers schema and row-group metadata, then reads only the columns and byte ranges needed for a request."
   links={[
     {label: 'Scan architecture', to: '/docs/developer-guide/common-scan-architecture'},
     {label: 'Parquet format', to: '/docs/modules/parquet/formats/parquet'}

--- a/docs/modules/parquet/formats/parquet.md
+++ b/docs/modules/parquet/formats/parquet.md
@@ -9,17 +9,16 @@ import {ParquetDocsTabs} from '@site/src/components/docs/parquet-docs-tabs';
 import {ParquetLayoutGraphic} from '@site/src/components/docs/parquet-layout-graphic';
 import {ParquetScanLiveExample} from '@site/src/components/docs/parquet-scan-live-example';
 import {CapabilityHero} from '@site/src/components/docs/capability-hero';
-import {DocPageHeader} from '@site/src/components/docs/doc-page-header';
 import {DocOrientation} from '@site/src/components/docs/designed-doc';
 
-<CapabilityHero capability="columnar" />
-
-<DocPageHeader
+<CapabilityHero
+  capability="columnar"
   eyebrow="Columnar file format"
   title="Apache Parquet"
   description="Organize data into independently useful row groups, column chunks, and pages so readers can fetch less and decode only what they need."
-  tone="mint"
-  meta={['Column-oriented', 'Range-readable', 'Arrow-friendly']}
+  logos={[
+    {alt: 'Apache Parquet', src: '/images/format-logos/parquet-logo.png'}
+  ]}
   links={[
     {label: 'Parquet module', to: '/docs/modules/parquet'},
     {label: 'ParquetLoader', to: '/docs/modules/parquet/api-reference/parquet-loader'}

--- a/docs/modules/textures/README.md
+++ b/docs/modules/textures/README.md
@@ -12,8 +12,8 @@ import {DocOrientation, ReferenceBoundary} from '@site/src/components/docs/desig
 
 <DocPageHeader
   eyebrow="Texture module"
-  title="Ship one texture asset. Choose the GPU format at runtime."
-  description="The textures module handles containers, mip chains, arrays, cube maps, and compressed payloads. Basis Universal can be transcoded on the client to a format supported by the current device."
+  title="@loaders.gl/textures"
+  description="Ship one texture asset and choose the GPU format at runtime. Handle containers, mip chains, arrays, cube maps, and Basis Universal transcoding on the client."
   tone="cyan"
   meta={['KTX / KTX2', 'Basis Universal', 'GPU-oriented payloads']}
   links={[

--- a/website/src/components/docs/capability-hero.jsx
+++ b/website/src/components/docs/capability-hero.jsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, {useEffect, useRef} from 'react';
+import Link from '@docusaurus/Link';
 
 import {FEATURE_CARDS, RenderFeatureVisual} from '../home/features';
 import styles from './capability-hero.module.css';
@@ -15,11 +16,38 @@ const TONE_COLORS = {
 
 /**
  * Renders the welcoming capability card shared by a homepage tentpole and its documentation page.
- * @param {{capability: string}} props Component properties.
+ * @param {{capability: string, eyebrow?: string, title?: string, description?: string, links?: Array<{label: string, to: string}>, logos?: Array<{alt: string, href?: string, src: string}>}} props Component properties.
  * @returns {React.ReactElement} The documentation capability hero.
  */
-export function CapabilityHero({capability}) {
+export function CapabilityHero({
+  capability,
+  eyebrow,
+  title,
+  description,
+  links = [],
+  logos = []
+}) {
   const feature = FEATURE_CARDS.find((candidate) => candidate.id === capability);
+  const heroReference = useRef(null);
+
+  useEffect(() => {
+    const heroElement = heroReference.current;
+    const markdownElement = heroElement?.closest('.theme-doc-markdown');
+    const badgeTarget = heroElement?.querySelector('[data-capability-hero-badges]');
+
+    if (!markdownElement || !badgeTarget) {
+      return;
+    }
+
+    const badgeParagraphs = Array.from(markdownElement.children).filter(
+      (element) => element instanceof HTMLElement && element.classList.contains('badges')
+    );
+
+    for (const badgeParagraph of badgeParagraphs) {
+      badgeTarget.append(...Array.from(badgeParagraph.childNodes));
+      badgeParagraph.remove();
+    }
+  }, []);
 
   if (!feature) {
     throw new Error(`Unknown capability hero: ${capability}`);
@@ -31,15 +59,39 @@ export function CapabilityHero({capability}) {
     <section
       className={styles.hero}
       style={{'--card-accent': colors.accent, '--card-glow': colors.glow}}
-      aria-label={`${feature.eyebrow}: ${feature.title}`}
+      aria-labelledby="capability-hero-title"
+      ref={heroReference}
     >
       <div className={styles.body}>
-        <p className={styles.eyebrow}>
-          {feature.eyebrow}
-          {feature.badge && <span className={styles.badge}>{feature.badge}</span>}
-        </p>
-        <h2 className={styles.title}>{feature.title}</h2>
-        <p className={styles.description}>{feature.description}</p>
+        <div className={styles.topline}>
+          <p className={styles.eyebrow}>
+            {eyebrow || feature.eyebrow}
+            {feature.badge && <span className={styles.badge}>{feature.badge}</span>}
+          </p>
+          <div className={styles.toplineActions}>
+            {logos.length > 0 && (
+              <div className={styles.logos} aria-label="Standards and ecosystem logos">
+                {logos.map((logo) => {
+                  const image = <img src={logo.src} alt={logo.alt} />;
+                  return logo.href ? (
+                    <a className={styles.logoLink} href={logo.href} key={logo.src}>
+                      {image}
+                    </a>
+                  ) : (
+                    <span className={styles.logoLink} key={logo.src}>
+                      {image}
+                    </span>
+                  );
+                })}
+              </div>
+            )}
+            <div className={styles.statusBadges} data-capability-hero-badges aria-label="Page status" />
+          </div>
+        </div>
+        <h1 className={styles.title} id="capability-hero-title">
+          {title || feature.title}
+        </h1>
+        <p className={styles.description}>{description || feature.description}</p>
         <div className={styles.tags} aria-label="Capability highlights">
           {feature.tags.map((tag) => (
             <span className={styles.tag} key={tag}>
@@ -51,6 +103,15 @@ export function CapabilityHero({capability}) {
       <div className={styles.visual}>
         <RenderFeatureVisual type={feature.visual} wide />
       </div>
+      {links.length > 0 && (
+        <nav className={styles.links} aria-label="Related documentation">
+          {links.map((link) => (
+            <Link className={styles.link} key={link.to} to={link.to}>
+              {link.label} <span aria-hidden="true">↗</span>
+            </Link>
+          ))}
+        </nav>
+      )}
     </section>
   );
 }

--- a/website/src/components/docs/capability-hero.module.css
+++ b/website/src/components/docs/capability-hero.module.css
@@ -25,9 +25,23 @@
 }
 
 .body {
-  max-width: 52%;
+  max-width: 58%;
   position: relative;
   z-index: 1;
+}
+
+.topline {
+  align-items: flex-start;
+  display: flex;
+  gap: 1rem;
+  justify-content: space-between;
+}
+
+.toplineActions {
+  align-items: flex-end;
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
 }
 
 .visual {
@@ -69,6 +83,42 @@
   max-width: 32rem;
 }
 
+.logos,
+.statusBadges {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  justify-content: flex-end;
+}
+
+.logos img {
+  display: block;
+  filter: brightness(0) invert(1);
+  height: auto;
+  max-height: 2rem;
+  max-width: 7rem;
+  object-fit: contain;
+  opacity: 0.86;
+  width: auto;
+}
+
+.logoLink,
+.statusBadges a {
+  align-items: center;
+  display: inline-flex;
+  flex: 0 0 auto;
+}
+
+.statusBadges:empty {
+  display: none;
+}
+
+.statusBadges img {
+  display: block;
+  margin: 0;
+}
+
 .description {
   color: rgba(229, 240, 247, 0.72);
   font-size: 0.98rem;
@@ -94,6 +144,45 @@
   padding: 0.52rem 0.65rem;
 }
 
+.links {
+  align-items: stretch;
+  background: rgba(8, 18, 31, 0.66);
+  border: 1px solid rgba(206, 228, 240, 0.2);
+  border-radius: 0.7rem;
+  bottom: 1.5rem;
+  display: flex;
+  flex-wrap: wrap;
+  left: 2.1rem;
+  overflow: hidden;
+  position: absolute;
+  z-index: 2;
+}
+
+.link {
+  border-left: 1px solid rgba(206, 228, 240, 0.16);
+  color: var(--card-accent);
+  font-size: 0.72rem;
+  font-weight: 700;
+  line-height: 1;
+  padding: 0.58rem 0.72rem;
+  text-decoration: none;
+}
+
+.link:first-child {
+  border-left: 0;
+}
+
+.link:hover,
+.link:focus-visible {
+  background: color-mix(in srgb, var(--card-accent) 14%, transparent);
+  color: #fff;
+  text-decoration: none;
+}
+
+.hero:has(.links) {
+  padding-bottom: 5.1rem;
+}
+
 @media (max-width: 760px) {
   .hero {
     min-height: 0;
@@ -102,6 +191,17 @@
 
   .body {
     max-width: 100%;
+  }
+
+  .topline {
+    flex-direction: column;
+  }
+
+  .toplineActions,
+  .logos,
+  .statusBadges {
+    align-items: flex-start;
+    justify-content: flex-start;
   }
 
   .description {
@@ -118,6 +218,17 @@
   .visual > div {
     bottom: 0;
     right: 0;
+  }
+
+  .links {
+    bottom: auto;
+    left: auto;
+    margin-top: 1.25rem;
+    position: relative;
+  }
+
+  .hero:has(.links) {
+    padding-bottom: 26px;
   }
 }
 

--- a/website/src/components/docs/doc-live-example.module.css
+++ b/website/src/components/docs/doc-live-example.module.css
@@ -1,0 +1,94 @@
+.frame {
+  --doc-live-example-height: 420px;
+  background: #081321;
+  border-radius: 22px;
+  height: var(--doc-live-example-height);
+  margin: 1.25rem 0 2.25rem;
+  overflow: hidden;
+  position: relative;
+}
+
+.frame[data-fullscreen] {
+  border-radius: 0;
+  height: 100%;
+}
+
+.content {
+  height: 100%;
+  position: relative;
+}
+
+.content > :global(*) {
+  height: 100%;
+}
+
+.fullscreenButton {
+  align-items: center;
+  backdrop-filter: blur(10px);
+  background: rgba(7, 16, 29, 0.82);
+  border: 1px solid rgba(190, 226, 249, 0.3);
+  border-radius: 10px;
+  box-shadow: 0 10px 28px rgba(2, 8, 18, 0.34);
+  color: #f6f9fc;
+  cursor: pointer;
+  display: flex;
+  font-size: 1.2rem;
+  height: 2.4rem;
+  justify-content: center;
+  line-height: 1;
+  padding: 0;
+  position: absolute;
+  right: 0.85rem;
+  top: 0.85rem;
+  width: 2.4rem;
+  z-index: 4;
+}
+
+.fullscreenButton:hover,
+.fullscreenButton:focus-visible {
+  background: rgba(23, 52, 84, 0.94);
+  border-color: rgba(112, 199, 255, 0.72);
+}
+
+.fullscreenButton:focus-visible,
+.interactionGate:focus-visible {
+  outline: 3px solid rgba(112, 199, 255, 0.42);
+  outline-offset: 2px;
+}
+
+.interactionGate {
+  align-items: flex-end;
+  background: linear-gradient(180deg, transparent 66%, rgba(4, 11, 20, 0.58));
+  border: 0;
+  color: #d9edfc;
+  cursor: zoom-in;
+  display: flex;
+  inset: 0;
+  justify-content: center;
+  padding: 1rem;
+  position: absolute;
+  z-index: 3;
+}
+
+.interactionGate > span {
+  backdrop-filter: blur(10px);
+  background: rgba(7, 16, 29, 0.78);
+  border: 1px solid rgba(190, 226, 249, 0.24);
+  border-radius: 999px;
+  box-shadow: 0 10px 28px rgba(2, 8, 18, 0.3);
+  font-size: 0.78rem;
+  font-weight: 750;
+  letter-spacing: 0.02em;
+  padding: 0.55rem 0.8rem;
+}
+
+.frame :global(.deck-widget) {
+  z-index: 2;
+}
+
+@media (max-width: 560px) {
+  .frame {
+    border-radius: 16px;
+    height: min(var(--doc-live-example-height), 56vh);
+  }
+}

--- a/website/src/components/docs/doc-live-example.tsx
+++ b/website/src/components/docs/doc-live-example.tsx
@@ -1,0 +1,71 @@
+import React, {type ReactNode, useEffect, useRef, useState} from 'react';
+
+import styles from './doc-live-example.module.css';
+
+/** Properties for the reusable documentation demo frame. */
+export type DocLiveExampleProps = {
+  /** Accessible name for the embedded example. */
+  label: string;
+  /** Example application rendered inside the frame. */
+  children: ReactNode;
+  /** Reserved height of the embedded, non-fullscreen example. */
+  height?: string;
+};
+
+/**
+ * Frames a visual example without letting map or scene controls capture page scrolling.
+ * Interaction is enabled when the reader opens the frame fullscreen.
+ */
+export function DocLiveExample({
+  label,
+  children,
+  height = '420px'
+}: DocLiveExampleProps): ReactNode {
+  const frameReference = useRef<HTMLDivElement>(null);
+  const [isFullscreen, setIsFullscreen] = useState(false);
+
+  useEffect(() => {
+    const handleFullscreenChange = (): void => {
+      setIsFullscreen(document.fullscreenElement === frameReference.current);
+    };
+
+    document.addEventListener('fullscreenchange', handleFullscreenChange);
+    return () => document.removeEventListener('fullscreenchange', handleFullscreenChange);
+  }, []);
+
+  const toggleFullscreen = async (): Promise<void> => {
+    if (document.fullscreenElement === frameReference.current) {
+      await document.exitFullscreen();
+    } else {
+      await frameReference.current?.requestFullscreen();
+    }
+  };
+
+  return (
+    <div
+      aria-label={label}
+      className={styles.frame}
+      data-fullscreen={isFullscreen || undefined}
+      ref={frameReference}
+      style={{'--doc-live-example-height': height} as React.CSSProperties}
+    >
+      <div className={styles.content}>{children}</div>
+      <button
+        aria-label={isFullscreen ? `Exit fullscreen ${label}` : `Open ${label} fullscreen`}
+        className={styles.fullscreenButton}
+        onClick={toggleFullscreen}
+        title={isFullscreen ? 'Exit fullscreen' : 'Open fullscreen'}
+        type="button"
+      >
+        <span aria-hidden="true">{isFullscreen ? '×' : '⛶'}</span>
+      </button>
+      {!isFullscreen && (
+        <button className={styles.interactionGate} onClick={toggleFullscreen} type="button">
+          <span>
+            <span aria-hidden="true">⛶</span> Explore fullscreen
+          </span>
+        </button>
+      )}
+    </div>
+  );
+}

--- a/website/src/components/docs/doc-page-header.module.css
+++ b/website/src/components/docs/doc-page-header.module.css
@@ -84,16 +84,6 @@
   text-transform: uppercase;
 }
 
-.identity {
-  color: var(--header-accent);
-  font-family: var(--ifm-font-family-monospace);
-  font-size: clamp(1.55rem, 3vw, 2.2rem);
-  font-weight: 700;
-  letter-spacing: -0.04em;
-  line-height: 1.2;
-  margin: 0 0 0.85rem;
-}
-
 .title {
   color: #f6f9fc;
   font-family: var(--ifm-heading-font-family);
@@ -114,7 +104,7 @@
 
 .description :global(code) {
   background: rgba(112, 199, 255, 0.1) !important;
-  border: 1px solid rgba(112, 199, 255, 0.24) !important;
+  border: 0 !important;
   border-radius: 0.25rem;
   box-shadow: none !important;
   color: var(--header-accent) !important;

--- a/website/src/components/docs/doc-page-header.tsx
+++ b/website/src/components/docs/doc-page-header.tsx
@@ -1,6 +1,5 @@
 import React, {useEffect, useRef, type ReactNode} from 'react';
 import Link from '@docusaurus/Link';
-import {useDoc} from '@docusaurus/plugin-content-docs/client';
 
 import styles from './doc-page-header.module.css';
 
@@ -52,7 +51,7 @@ export type DocPageHeaderProps = {
   notice?: ReactNode;
   /** Optional status and version badges moved out of the long-form reference content. */
   badges?: readonly ReactNode[];
-  /** Render the document identifier as the sole title, omitting the prose title line. */
+  /** @deprecated Page headers now always render exactly one title. */
   hideTitle?: boolean;
 };
 
@@ -77,10 +76,8 @@ export function DocPageHeader({
   links = [],
   logos = [],
   notice,
-  badges = [],
-  hideTitle = false
+  badges = []
 }: DocPageHeaderProps): ReactNode {
-  const {metadata} = useDoc();
   const headerReference = useRef<HTMLElement>(null);
 
   useEffect(() => {
@@ -101,8 +98,6 @@ export function DocPageHeader({
       badgeParagraph.remove();
     }
   }, []);
-
-  const renderIdentity = !hideTitle && metadata.title !== title;
 
   return (
     <section
@@ -137,18 +132,9 @@ export function DocPageHeader({
             </div>
           </div>
         </div>
-        {!renderIdentity ? (
-          <h1 className={styles.title} id="doc-page-header-title">
-            {title}
-          </h1>
-        ) : (
-          <>
-            <p className={styles.identity}>{metadata.title}</p>
-            <h1 className={styles.title} id="doc-page-header-title">
-              {title}
-            </h1>
-          </>
-        )}
+        <h1 className={styles.title} id="doc-page-header-title">
+          {title}
+        </h1>
         <p className={styles.description}>{renderDescription(description)}</p>
         {notice ? <div className={styles.notice}>{notice}</div> : null}
       </div>

--- a/website/src/components/docs/iceberg-scan-live-example.module.css
+++ b/website/src/components/docs/iceberg-scan-live-example.module.css
@@ -1,8 +1,11 @@
 .exampleFrame {
   margin: 28px 0;
   padding: 18px;
-  border: 1px solid var(--ifm-color-gray-400);
-  border-radius: 8px;
+  border: 1px solid rgba(112, 199, 255, 0.2);
+  border-radius: 18px;
+  background: linear-gradient(145deg, rgba(16, 30, 49, 0.97), rgba(10, 22, 38, 0.98));
+  box-shadow: 0 20px 54px rgba(0, 0, 0, 0.18);
+  color: #e4edf6;
 }
 
 .exampleHeader,
@@ -21,12 +24,13 @@
 .exampleTitle {
   margin: 0;
   font-size: 18px;
+  color: #f6f9fc;
 }
 
 .exampleDescription {
   max-width: 720px;
   margin: 6px 0 0;
-  color: var(--ifm-color-gray-700);
+  color: rgba(219, 231, 244, 0.72);
   font-size: 13px;
 }
 
@@ -34,7 +38,7 @@
   padding: 7px 10px;
   border: 1px solid rgba(76, 175, 80, 0.55);
   border-radius: 999px;
-  color: var(--ifm-color-gray-900);
+  color: #dff7e9;
   font-size: 12px;
   font-weight: 800;
   white-space: nowrap;
@@ -60,10 +64,10 @@
   flex: 1 1 0;
   min-width: 0;
   padding: 9px 6px;
-  border: 1px solid var(--ifm-color-gray-400);
+  border: 1px solid rgba(173, 200, 219, 0.16);
   border-radius: 8px;
-  background: var(--ifm-color-white);
-  color: var(--ifm-color-gray-900);
+  background: rgba(6, 15, 27, 0.5);
+  color: #e4edf6;
   font-size: 12px;
   font-weight: 800;
   text-align: center;
@@ -76,7 +80,7 @@
 
 .stageArrow {
   flex: 0 0 24px;
-  color: var(--ifm-color-gray-600);
+  color: rgba(219, 231, 244, 0.48);
   font-weight: 800;
   text-align: center;
 }
@@ -91,7 +95,7 @@
 
 .sourcePickerLabel,
 .queryInputLabel {
-  color: var(--ifm-color-gray-700);
+  color: rgba(219, 231, 244, 0.68);
   font-size: 11px;
   font-weight: 800;
   text-transform: uppercase;
@@ -101,7 +105,7 @@
 .queryHint,
 .planHeader span,
 .previewHeading span {
-  color: var(--ifm-color-gray-600);
+  color: rgba(219, 231, 244, 0.52);
   font-size: 10px;
 }
 
@@ -130,10 +134,10 @@
   min-width: 0;
   min-height: 62px;
   padding: 8px 9px;
-  border: 1px solid var(--ifm-color-gray-400);
+  border: 1px solid rgba(173, 200, 219, 0.2);
   border-radius: 6px;
-  background: var(--ifm-color-white);
-  color: var(--ifm-color-gray-900);
+  background: rgba(6, 15, 27, 0.68);
+  color: #e4edf6;
   font-family: var(--ifm-font-family-monospace);
   font-size: 12px;
   resize: vertical;
@@ -164,13 +168,13 @@
 
 .planPanel {
   padding: 10px 12px;
-  border: 1px solid var(--ifm-color-gray-300);
+  border: 1px solid rgba(173, 200, 219, 0.15);
   border-radius: 8px;
-  background: var(--ifm-color-gray-200);
+  background: rgba(6, 15, 27, 0.5);
 }
 
 .planHeader {
-  color: var(--ifm-color-gray-900);
+  color: #e4edf6;
   font-size: 12px;
 }
 
@@ -187,13 +191,13 @@
 }
 
 .metricValue {
-  color: var(--ifm-color-gray-900);
+  color: #f6f9fc;
   font-size: 15px;
   font-weight: 800;
 }
 
 .metricLabel {
-  color: var(--ifm-color-gray-700);
+  color: rgba(219, 231, 244, 0.68);
   font-size: 11px;
 }
 
@@ -202,20 +206,21 @@
   border: 1px solid rgba(211, 47, 47, 0.35);
   border-radius: 8px;
   background: rgba(211, 47, 47, 0.08);
-  color: var(--ifm-color-gray-900);
+  color: #f1d9df;
   font-size: 13px;
 }
 
 .previewFrame {
   overflow: hidden;
-  border: 1px solid var(--ifm-color-gray-400);
-  border-radius: 8px;
+  border: 1px solid rgba(173, 200, 219, 0.16);
+  border-radius: 14px;
+  background: rgba(6, 15, 27, 0.48);
 }
 
 .previewHeading {
   padding: 10px 12px;
-  background: var(--ifm-color-gray-200);
-  color: var(--ifm-color-gray-900);
+  background: rgba(26, 45, 70, 0.94);
+  color: #e4edf6;
   font-size: 12px;
 }
 
@@ -228,7 +233,7 @@
   min-width: 100%;
   margin: 0;
   border-collapse: collapse;
-  color: var(--ifm-color-gray-900);
+  color: #e4edf6;
   font-size: 11px;
   white-space: nowrap;
 }
@@ -236,13 +241,21 @@
 .previewTable th,
 .previewTable td {
   padding: 7px 9px;
-  border-bottom: 1px solid var(--ifm-color-gray-300);
+  border: 0 !important;
+  border-bottom: 1px solid rgba(165, 151, 184, 0.12) !important;
+  background: rgba(13, 27, 46, 0.82) !important;
+  color: #e4edf6 !important;
   text-align: left;
 }
 
 .previewTable th {
-  background: var(--ifm-color-white);
+  background: rgba(19, 39, 65, 0.94) !important;
+  color: #b9ddf7 !important;
   font-weight: 800;
+}
+
+.previewTable tbody tr:nth-child(even) td {
+  background: rgba(20, 35, 56, 0.86) !important;
 }
 
 .previewTable tr:last-child td {

--- a/website/src/components/docs/scan-query-panel.module.css
+++ b/website/src/components/docs/scan-query-panel.module.css
@@ -1,9 +1,10 @@
 .panel {
   margin: 14px 0;
   padding: 14px;
-  border: 1px solid #d8dee9;
-  border-radius: 8px;
-  background: #fbfcfe;
+  border: 1px solid rgba(173, 200, 219, 0.16);
+  border-radius: 14px;
+  background: rgba(6, 15, 27, 0.5);
+  color: #e4edf6;
 }
 
 .panelHeader {
@@ -16,7 +17,7 @@
 .panelHint,
 .fieldHint,
 .emptyState {
-  color: #667085;
+  color: rgba(219, 231, 244, 0.56);
 }
 
 .panelHint {
@@ -28,7 +29,7 @@
   flex-wrap: wrap;
   gap: 12px;
   margin-bottom: 10px;
-  color: #475467;
+  color: rgba(219, 231, 244, 0.72);
   font-size: 0.82rem;
 }
 
@@ -39,18 +40,18 @@
 }
 
 .supported {
-  color: #067647;
-  background: #ecfdf3;
+  color: #a8f0c7;
+  background: rgba(33, 143, 88, 0.18);
 }
 
 .unsupported {
-  color: #7a2e0e;
-  background: #fff4ed;
+  color: #ffccb8;
+  background: rgba(180, 72, 39, 0.18);
 }
 
 .supportMessage {
   margin: -4px 0 12px;
-  color: #7a2e0e;
+  color: #ffccb8;
   font-size: 0.82rem;
 }
 
@@ -81,14 +82,15 @@
   display: inline-flex;
   gap: 4px;
   padding: 5px 7px;
-  border: 1px solid #d0d5dd;
+  border: 1px solid rgba(173, 200, 219, 0.18);
   border-radius: 5px;
-  background: #ffffff;
+  background: rgba(13, 27, 46, 0.82);
+  color: #e4edf6;
   font-size: 0.82rem;
 }
 
 .columnType {
-  color: #667085;
+  color: rgba(219, 231, 244, 0.5);
   font-size: 0.7rem;
 }
 
@@ -103,12 +105,14 @@
 .select {
   min-width: 180px;
   padding: 7px;
-  border: 1px solid #d0d5dd;
+  border: 1px solid rgba(173, 200, 219, 0.2);
   border-radius: 5px;
+  background: rgba(7, 16, 29, 0.82);
+  color: #e4edf6;
 }
 
 .select {
-  background: #ffffff;
+  background: rgba(7, 16, 29, 0.82);
 }
 
 .applyButton {
@@ -117,13 +121,13 @@
   border: 0;
   border-radius: 5px;
   color: #ffffff;
-  background: #475467;
+  background: #3479d8;
   cursor: pointer;
 }
 
 .applyButton:hover:not(:disabled),
 .applyButton:focus-visible {
-  background: #344054;
+  background: #458be8;
 }
 
 .applyButton:focus-visible,
@@ -135,7 +139,7 @@
 }
 
 .applyButton:disabled {
-  background: #98a2b3;
+  background: #42526a;
   cursor: not-allowed;
 }
 

--- a/website/src/components/docs/standards-organizations.module.css
+++ b/website/src/components/docs/standards-organizations.module.css
@@ -1,0 +1,105 @@
+.catalog {
+  margin: 2.5rem 0 4rem;
+}
+
+.section + .section {
+  margin-top: 5rem;
+}
+
+.sectionHeader {
+  margin: 0 auto 1.5rem;
+  max-width: 72ch;
+}
+
+.sectionHeader > p,
+.eyebrow {
+  color: #9b8cff;
+  font-size: 0.7rem;
+  font-weight: 760;
+  letter-spacing: 0.13em;
+  margin: 0 0 0.65rem;
+  text-transform: uppercase;
+}
+
+.sectionHeader h2 {
+  font-size: clamp(2rem, 4vw, 3rem);
+  letter-spacing: -0.05em;
+  line-height: 1;
+  margin: 0;
+}
+
+.sectionHeader > span {
+  color: var(--ifm-font-color-secondary);
+  display: block;
+  font-size: 1.03rem;
+  line-height: 1.65;
+  margin-top: 0.85rem;
+  max-width: 48rem;
+}
+
+.grid {
+  display: grid;
+  gap: 0.85rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.card {
+  background:
+    radial-gradient(circle at 92% 8%, rgba(117, 95, 255, 0.16), transparent 15rem),
+    linear-gradient(145deg, rgba(16, 30, 49, 0.97), rgba(10, 22, 38, 0.98));
+  border: 1px solid rgba(155, 140, 255, 0.24);
+  border-radius: 18px;
+  box-shadow: 0 18px 44px rgba(0, 0, 0, 0.16);
+  color: #f4f8fb;
+  min-height: 15rem;
+  padding: 1.35rem;
+}
+
+.card h3 {
+  color: #f6f9fc;
+  font-size: 1.55rem;
+  letter-spacing: -0.035em;
+  margin: 0;
+}
+
+.description {
+  color: rgba(219, 231, 244, 0.72);
+  line-height: 1.55;
+  margin: 0.7rem 0 1.15rem;
+}
+
+.links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.links a {
+  background: rgba(8, 18, 31, 0.52);
+  border: 1px solid rgba(206, 228, 240, 0.18);
+  border-radius: 0.55rem;
+  color: #b9adff;
+  font-size: 0.72rem;
+  font-weight: 720;
+  line-height: 1;
+  padding: 0.5rem 0.58rem;
+  text-decoration: none;
+}
+
+.links a:hover,
+.links a:focus-visible {
+  background: rgba(155, 140, 255, 0.14);
+  border-color: rgba(155, 140, 255, 0.5);
+  color: #fff;
+  text-decoration: none;
+}
+
+@media (max-width: 760px) {
+  .grid {
+    grid-template-columns: 1fr;
+  }
+
+  .card {
+    min-height: 0;
+  }
+}

--- a/website/src/components/docs/standards-organizations.tsx
+++ b/website/src/components/docs/standards-organizations.tsx
@@ -1,0 +1,209 @@
+import React, {type ReactNode} from 'react';
+import Link from '@docusaurus/Link';
+
+import styles from './standards-organizations.module.css';
+
+type StandardsLink = {
+  /** Standard or implementation family displayed to readers. */
+  label: string;
+  /** Documentation or example destination. */
+  to: string;
+};
+
+type StandardsGroup = {
+  /** Short context for the group. */
+  eyebrow: string;
+  /** Organization or workload name. */
+  title: string;
+  /** Plain-language relationship to loaders.gl. */
+  description: string;
+  /** Implemented formats and services in this group. */
+  links: readonly StandardsLink[];
+};
+
+const STANDARD_FAMILIES: readonly StandardsGroup[] = [
+  {
+    eyebrow: 'Scenes, meshes, textures',
+    title: '3D and graphics',
+    description: 'Portable scene, tiled-world, point-cloud, mesh-compression, and GPU texture formats.',
+    links: [
+      {label: 'glTF / GLB', to: '/docs/modules/gltf/formats/gltf'},
+      {label: '3D Tiles', to: '/docs/modules/3d-tiles/formats/3d-tiles'},
+      {label: 'I3S / SLPK', to: '/docs/modules/i3s/formats/i3s'},
+      {label: 'Draco', to: '/docs/modules/draco/formats/draco'},
+      {label: 'KTX / KTX2', to: '/docs/modules/textures/formats/ktx'},
+      {label: 'Basis', to: '/docs/modules/textures/formats/basis'},
+      {label: 'LAS / LAZ', to: '/docs/modules/las/formats/las'},
+      {label: 'COPC', to: '/docs/modules/copc/formats/copc'},
+      {label: 'OpenUSD', to: '/docs/modules/scene/formats/usd'}
+    ]
+  },
+  {
+    eyebrow: 'Typed data at scale',
+    title: 'Columnar and analytical',
+    description: 'Formats that preserve schemas, columns, batches, and cloud-selective layouts.',
+    links: [
+      {label: 'Apache Arrow', to: '/docs/modules/arrow/formats/arrow'},
+      {label: 'GeoArrow', to: '/docs/modules/arrow/formats/geoarrow'},
+      {label: 'Apache Parquet', to: '/docs/modules/parquet/formats/parquet'},
+      {label: 'GeoParquet', to: '/docs/modules/parquet/formats/geoparquet'},
+      {label: 'Apache Avro', to: '/examples/table/avro'},
+      {label: 'Apache ORC', to: '/docs/modules/orc/formats/orc'},
+      {label: 'Apache Iceberg', to: '/docs/modules/parquet/api-reference/iceberg-table-source'}
+    ]
+  },
+  {
+    eyebrow: 'Portable spatial data',
+    title: 'Geospatial files',
+    description: 'Interoperable feature, raster, catalog, geometry, and archive formats.',
+    links: [
+      {label: 'GeoJSON', to: '/docs/modules/json/formats/geojson'},
+      {label: 'KML / KMZ', to: '/docs/modules/kml/formats/kml'},
+      {label: 'GeoPackage', to: '/docs/modules/geopackage/formats/geopackage'},
+      {label: 'GeoTIFF', to: '/docs/modules/geotiff/formats/geotiff'},
+      {label: 'FlatGeobuf', to: '/docs/modules/flatgeobuf/formats/flatgeobuf'},
+      {label: 'Shapefile', to: '/docs/modules/shapefile/formats/shapefile'},
+      {label: 'WKT / WKB', to: '/docs/modules/wkt/formats/wkt'},
+      {label: 'WKT-CRS', to: '/docs/modules/wkt/formats/wkt-crs'},
+      {label: 'STAC', to: '/docs/modules/stac/formats/stac'}
+    ]
+  },
+  {
+    eyebrow: 'Metadata plus requests',
+    title: 'Network services',
+    description: 'Standards and vendor APIs where discovery is followed by bounded requests.',
+    links: [
+      {label: 'WMS', to: '/docs/modules/wms/formats/wms'},
+      {label: 'WMTS', to: '/docs/modules/wms/formats/wmts'},
+      {label: 'WFS', to: '/docs/modules/wms/formats/wfs'},
+      {label: 'WCS', to: '/docs/modules/wms/formats/wcs'},
+      {label: 'CSW', to: '/docs/modules/wms/formats/csw'},
+      {label: 'OGC API', to: '/docs/modules/wms/services/ogc-api'},
+      {label: 'ArcGIS REST', to: '/docs/modules/services'}
+    ]
+  }
+];
+
+const ORGANIZATIONS: readonly StandardsGroup[] = [
+  {
+    eyebrow: 'Open data systems',
+    title: 'Apache',
+    description: 'Binary table, storage, serialization, and table-catalog projects used by large-data pipelines.',
+    links: [
+      {label: 'Arrow', to: '/docs/modules/arrow/formats/arrow'},
+      {label: 'Parquet', to: '/docs/modules/parquet/formats/parquet'},
+      {label: 'Avro', to: '/examples/table/avro'},
+      {label: 'ORC', to: '/docs/modules/orc/formats/orc'},
+      {label: 'Iceberg', to: '/docs/modules/parquet/api-reference/iceberg-table-source'}
+    ]
+  },
+  {
+    eyebrow: 'Portable 3D and GPU assets',
+    title: 'Khronos',
+    description: 'Scene and texture standards designed to move renderable assets between tools and runtimes.',
+    links: [
+      {label: 'glTF', to: '/docs/modules/gltf/formats/gltf'},
+      {label: 'GLB', to: '/docs/modules/gltf/formats/glb'},
+      {label: 'KTX / KTX2', to: '/docs/modules/textures/formats/ktx'},
+      {label: 'Basis in glTF', to: '/docs/modules/gltf/formats/gltf#khr_texture_basisu'}
+    ]
+  },
+  {
+    eyebrow: 'Open geospatial interoperability',
+    title: 'OGC',
+    description: 'File formats, geometry models, coordinate descriptions, tiled scenes, and web-service protocols.',
+    links: [
+      {label: '3D Tiles', to: '/docs/modules/3d-tiles/formats/3d-tiles'},
+      {label: 'I3S', to: '/docs/modules/i3s/formats/i3s'},
+      {label: 'GeoPackage', to: '/docs/modules/geopackage/formats/geopackage'},
+      {label: 'GeoTIFF', to: '/docs/modules/geotiff/formats/geotiff'},
+      {label: 'KML', to: '/docs/modules/kml/formats/kml'},
+      {label: 'GML', to: '/docs/modules/wms/formats/gml'},
+      {label: 'WKT / WKB', to: '/docs/modules/wkt/formats/wkt'},
+      {label: 'Web services', to: '/docs/modules/wms'}
+    ]
+  },
+  {
+    eyebrow: 'Scene and mapping services',
+    title: 'Esri / ArcGIS',
+    description: 'Scene layers, raster compression, and ArcGIS REST services connected to common loaders.gl sources.',
+    links: [
+      {label: 'I3S / SLPK', to: '/docs/modules/i3s/formats/i3s'},
+      {label: 'LERC', to: '/docs/modules/lerc/formats/lerc'},
+      {label: 'FeatureServer', to: '/docs/modules/services/arcgis-feature-server'},
+      {label: 'MapServer', to: '/docs/modules/services/arcgis-map-server'},
+      {label: 'ImageServer', to: '/docs/modules/services/arcgis-image-server'},
+      {label: 'VectorTileServer', to: '/docs/modules/services/arcgis-vector-tile-server'},
+      {label: 'SceneServer', to: '/docs/modules/services/arcgis-scene-server'}
+    ]
+  },
+  {
+    eyebrow: 'Internet and point-cloud standards',
+    title: 'IETF, ASPRS, Cesium, AOUSD',
+    description: 'Important specifications stewarded outside the four largest format families.',
+    links: [
+      {label: 'IETF GeoJSON', to: '/docs/modules/json/formats/geojson'},
+      {label: 'ASPRS LAS / LAZ', to: '/docs/modules/las/formats/las'},
+      {label: 'Cesium 3D Tiles', to: '/docs/modules/3d-tiles/formats/3d-tiles'},
+      {label: 'AOUSD OpenUSD', to: '/docs/modules/scene/formats/usd'},
+      {label: 'COPC', to: '/docs/modules/copc/formats/copc'}
+    ]
+  }
+];
+
+/** Renders implemented standards first, then the organizations that steward them. */
+export function StandardsOrganizations(): ReactNode {
+  return (
+    <div className={styles.catalog}>
+      <StandardsSection
+        eyebrow="Implemented catalog"
+        title="Standards by workload"
+        description="Start with the kind of data you have. Every link lands on the loaders.gl page that records the real implementation boundary."
+        groups={STANDARD_FAMILIES}
+      />
+      <StandardsSection
+        eyebrow="Ecosystem map"
+        title="Organizations"
+        description="The same catalog grouped by the communities and standards bodies that define or steward it."
+        groups={ORGANIZATIONS}
+      />
+    </div>
+  );
+}
+
+function StandardsSection({eyebrow, title, description, groups}: {
+  /** Short section label. */
+  eyebrow: string;
+  /** Section title. */
+  title: string;
+  /** Section introduction. */
+  description: string;
+  /** Cards rendered in the section. */
+  groups: readonly StandardsGroup[];
+}): ReactNode {
+  return (
+    <section className={styles.section}>
+      <header className={styles.sectionHeader}>
+        <p>{eyebrow}</p>
+        <h2>{title}</h2>
+        <span>{description}</span>
+      </header>
+      <div className={styles.grid}>
+        {groups.map(group => (
+          <article className={styles.card} key={group.title}>
+            <p className={styles.eyebrow}>{group.eyebrow}</p>
+            <h3>{group.title}</h3>
+            <p className={styles.description}>{group.description}</p>
+            <div className={styles.links}>
+              {group.links.map(link => (
+                <Link key={link.to} to={link.to}>
+                  {link.label} <span aria-hidden="true">↗</span>
+                </Link>
+              ))}
+            </div>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/website/src/components/index.tsx
+++ b/website/src/components/index.tsx
@@ -1,6 +1,7 @@
 export {default as makeExample} from './example/make-example';
 export {default as ExamplesIndex} from './example/examples-index';
 export {ClientExample} from './example/client-example';
+export {DocLiveExample} from './docs/doc-live-example';
 
 export {default as Home} from './home';
 export {default as InfoPanel} from './info-panel';

--- a/website/src/examples/home-demo.jsx
+++ b/website/src/examples/home-demo.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useEffect, useMemo, useState} from 'react';
 
 import Map from 'react-map-gl';
 import maplibregl from 'maplibre-gl';
@@ -21,24 +21,46 @@ const INITIAL_VIEW_STATE = {
 };
 
 export default function App() {
-
-  function renderLayers() {
+  const [viewState, setViewState] = useState(INITIAL_VIEW_STATE);
+  const layers = useMemo(() => {
     const loadOptions = {i3s: {coordinateSystem: COORDINATE_SYSTEM.LNGLAT_OFFSETS}};
-    const layers = new SourceLayer({
+    return new SourceLayer({
       data: 'https://tiles.arcgis.com/tiles/z2tnIkrLQ2BRzr6P/arcgis/rest/services/SanFrancisco_Bldgs/SceneServer/layers/0',
       loaders: [I3SLoader],
       loadOptions
     });
-    return layers;
-  }
+  }, []);
+  const widgets = useMemo(() => [new FullscreenWidget({id: 'home-demo-fullscreen'})], []);
+
+  useEffect(() => {
+    const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    if (prefersReducedMotion) {
+      return undefined;
+    }
+
+    const startedAt = performance.now();
+    let animationFrame = 0;
+    const updateView = (time) => {
+      const phase = ((time - startedAt) / 32000) * Math.PI * 2;
+      setViewState({
+        ...INITIAL_VIEW_STATE,
+        longitude: INITIAL_VIEW_STATE.longitude + Math.sin(phase) * 0.0012,
+        bearing: Math.sin(phase) * 2.4
+      });
+      animationFrame = requestAnimationFrame(updateView);
+    };
+
+    animationFrame = requestAnimationFrame(updateView);
+    return () => cancelAnimationFrame(animationFrame);
+  }, []);
 
   return (
     <div style={{position: 'relative', height: '100%'}}>
       <DeckGL
-        initialViewState={INITIAL_VIEW_STATE}
-        layers={renderLayers()}
+        viewState={viewState}
+        layers={layers}
         controller={false}
-        widgets={[new FullscreenWidget({id: 'home-demo-fullscreen'})]}
+        widgets={widgets}
       >
         <Map
           reuseMaps

--- a/website/static/images/format-logos/arcgis-logo.svg
+++ b/website/static/images/format-logos/arcgis-logo.svg
@@ -1,5 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 120" role="img" aria-label="ArcGIS">
-  <rect width="320" height="120" rx="24" fill="#fff"/>
   <circle cx="62" cy="60" r="36" fill="#007ac2"/>
   <path d="M36 61c13-12 32-18 52-15M38 76c15-10 32-13 49-8M51 34c5 13 5 34 0 51M70 29c-5 15-5 37 1 62" fill="none" stroke="#fff" stroke-width="4" stroke-linecap="round"/>
   <text x="116" y="76" fill="#1f2937" font-family="Arial, sans-serif" font-size="44" font-weight="700">ArcGIS</text>


### PR DESCRIPTION
## Goals

- Make designed documentation pages easier to scan with one clear title and a consistent hero hierarchy.
- Place interactive examples immediately below page headers without letting them capture normal page scrolling.
- Give standards and their stewarding organizations a first-class destination.

## Changes

- Remove automatic secondary page identities and consolidate the Arrow and Parquet tentpole heroes.
- Add a reusable fullscreen-gated embedded example frame and apply it to I3S module, loader, and recipe pages.
- Move format logos into high hero positions and make the ArcGIS artwork transparent-theme friendly.
- Add a Standards and organizations catalog grouped by workload and standards body, including Apache, Khronos, OGC, Esri/ArcGIS, IETF, ASPRS, Cesium, and AOUSD formats.
- Add subtle motion to the homepage I3S scene.
- Restyle Iceberg results and shared scan-query controls for dark designed pages.

## Verification

- `yarn lint fix`
- `yarn build`
- `yarn build-workers`
- `yarn test-node` — 391 passed
- `yarn test-headless` — 3,819 passed
- `cd website && yarn build`
- Browser-verified the standards, Arrow, I3S, Iceberg, and homepage layouts at desktop width.
