### PR TITLE
docs(website): refresh analytical format pages

### DIFF
--- a/docs/modules/arrow/README.md
+++ b/docs/modules/arrow/README.md
@@ -7,6 +7,7 @@ page_style: designed
 
 import {CapabilityHero} from '@site/src/components/docs/capability-hero';
 import {ArrowDataPlaneGraphic} from '@site/src/components/docs/arrow-data-plane-graphic';
+import {ArrowScanLiveExample} from '@site/src/components/docs/arrow-scan-live-example';
 import {DocOrientation, ReferenceBoundary} from '@site/src/components/docs/designed-doc';
 import apacheLogo from '../../images/logos/apache-logo.png';
 
@@ -22,6 +23,8 @@ import apacheLogo from '../../images/logos/apache-logo.png';
     {label: 'ArrowWriter', to: '/docs/modules/arrow/api-reference/arrow-writer'}
   ]}
 />
+
+<ArrowScanLiveExample />
 
 <ArrowDataPlaneGraphic />
 

--- a/docs/modules/arrow/api-reference/arrow-schema-utils.md
+++ b/docs/modules/arrow/api-reference/arrow-schema-utils.md
@@ -10,7 +10,7 @@ import {DocOrientation, ReferenceBoundary} from '@site/src/components/docs/desig
 
 <DocPageHeader
   eyebrow="Arrow schema utilities"
-  title="Make table contracts explicit at the boundary."
+  title="Arrow schema utilities"
   description="These helpers validate Apache Arrow JS table schemas and rename selected fields while preserving vectors and untouched columns. They are useful when a loader or source needs a clear contract before handing data to the next stage."
   tone="cyan"
   meta={['Apache Arrow', 'Schema validation', 'Vector-preserving rename']}

--- a/docs/modules/arrow/api-reference/arrow-table-transport.md
+++ b/docs/modules/arrow/api-reference/arrow-table-transport.md
@@ -10,7 +10,7 @@ import {DocOrientation, ReferenceBoundary} from '@site/src/components/docs/desig
 
 <DocPageHeader
   eyebrow="Arrow worker transport"
-  title="Move the table without moving unrelated memory."
+  title="Arrow table transport"
   description="The transport helpers prepare Arrow tables for structured clone or IPC transfer. They make sliced buffers safe to transfer and keep the schema explicit when data crosses a worker boundary."
   tone="blue"
   meta={['Worker transport', 'Transfer-safe buffers', 'Schema preservation']}

--- a/docs/modules/arrow/api-reference/arrow-variable-width.md
+++ b/docs/modules/arrow/api-reference/arrow-variable-width.md
@@ -10,7 +10,7 @@ import {DocOrientation, ReferenceBoundary} from '@site/src/components/docs/desig
 
 <DocPageHeader
   eyebrow="Arrow variable-width utilities"
-  title="Choose the string representation your runtime can use."
+  title="Arrow variable-width conversion"
   description="These utilities convert Arrow `Utf8`, `Utf8View`, `Binary`, and `BinaryView` vectors and tables while preserving logical values, nulls, and unrelated columns."
   tone="cyan"
   meta={['Utf8 and Binary', 'View types', 'Compatibility conversion']}

--- a/docs/modules/arrow/api-reference/arrow-writer.md
+++ b/docs/modules/arrow/api-reference/arrow-writer.md
@@ -9,12 +9,14 @@ import {ArrowDocsTabs} from '@site/src/components/docs/arrow-docs-tabs';
 import {DocPageHeader} from '@site/src/components/docs/doc-page-header';
 import {DocOrientation, ReferenceBoundary} from '@site/src/components/docs/designed-doc';
 import {WriterPipelineGraphic} from '@site/src/components/docs/writer-pipeline-graphic';
+import apacheLogo from '../../../images/logos/apache-logo.png';
 
 <DocPageHeader
   eyebrow="Arrow writer"
-  title="Write the table shape your next system can reuse."
+  title="ArrowWriter"
   description="ArrowWriter turns typed arrays and table-oriented data into Apache Arrow IPC bytes. Use it when a result should remain columnar across files, streams, workers, or another language."
   tone="cyan"
+  logos={[{alt: 'Apache Software Foundation', src: apacheLogo}]}
   meta={['Arrow IPC', 'Typed columns', 'File and stream output']}
   links={[
     {label: 'Arrow format', to: '/docs/modules/arrow/formats/arrow'},

--- a/docs/modules/arrow/api-reference/geoarrow-loader.md
+++ b/docs/modules/arrow/api-reference/geoarrow-loader.md
@@ -7,14 +7,16 @@ page_style: designed
 
 import {ArrowDocsTabs} from '@site/src/components/docs/arrow-docs-tabs';
 import {DocPageHeader} from '@site/src/components/docs/doc-page-header';
+import {DocLiveExample} from '@site/src/components/docs/doc-live-example';
 import {DocOrientation, ReferenceBoundary} from '@site/src/components/docs/designed-doc';
-import {LoaderLiveExample} from '@site/src/components/docs/loader-live-example';
+import {ClientExample} from '@site/src/components';
 
 <DocPageHeader
   eyebrow="GeoArrow loader"
-  title="Read geospatial tables without flattening geometry."
+  title="GeoArrowLoader"
   description="GeoArrowLoader parses Arrow IPC data and recognizes GeoArrow extension metadata so geometry columns remain typed and discoverable alongside their attributes."
   tone="cyan"
+  logos={[{alt: 'Apache Arrow', src: '/images/format-logos/apache-arrow-logo.png'}]}
   meta={['Arrow IPC', 'GeoArrow extensions', 'Feature tables']}
   links={[
     {label: 'GeoArrow format', to: '/docs/modules/arrow/formats/geoarrow'},
@@ -22,9 +24,11 @@ import {LoaderLiveExample} from '@site/src/components/docs/loader-live-example';
   ]}
 />
 
-<ArrowDocsTabs active="geoarrowloader" />
+<DocLiveExample label="GeoArrowLoader map example" height="420px">
+  <ClientExample kind="geospatial" format="GeoArrow" />
+</DocLiveExample>
 
-<LoaderLiveExample />
+<ArrowDocsTabs active="geoarrowloader" />
 
 <DocOrientation
   eyebrow="A geospatial Arrow entry point"

--- a/docs/modules/arrow/api-reference/indexed-arrow-table.md
+++ b/docs/modules/arrow/api-reference/indexed-arrow-table.md
@@ -10,7 +10,7 @@ import {DocOrientation, ReferenceBoundary} from '@site/src/components/docs/desig
 
 <DocPageHeader
   eyebrow="Arrow table view"
-  title="Reorder the rows before you materialize them."
+  title="IndexedArrowTable"
   description="IndexedArrowTable and IndexedArrowVector add a readonly index over Arrow data. Filtering, sorting, slicing, and repeated row views can stay as indexes until an application explicitly asks for copied values."
   tone="blue"
   meta={['Readonly view', 'Lazy materialization', 'Arrow JS']}

--- a/docs/modules/arrow/api-reference/mapped-arrow-table.md
+++ b/docs/modules/arrow/api-reference/mapped-arrow-table.md
@@ -10,7 +10,7 @@ import {DocOrientation, ReferenceBoundary} from '@site/src/components/docs/desig
 
 <DocPageHeader
   eyebrow="Mapped Arrow table"
-  title="Keep Arrow columns. Add application-level keys."
+  title="MappedArrowTable"
   description="`MappedArrowTable` presents an `IndexedArrowTable` through a stable string-keyed view. Filtering, sorting, slicing, and concatenation remain table operations while keyed lookups stay predictable."
   tone="cyan"
   meta={['Indexed Arrow table', 'String-keyed lookup', 'Readonly view']}

--- a/docs/modules/arrow/api-reference/split-arrow-buffers.md
+++ b/docs/modules/arrow/api-reference/split-arrow-buffers.md
@@ -10,7 +10,7 @@ import {DocOrientation, ReferenceBoundary} from '@site/src/components/docs/desig
 
 <DocPageHeader
   eyebrow="Arrow buffer utility"
-  title="Transfer only the bytes this table owns."
+  title="splitArrowBuffers"
   description="splitArrowBuffers rebuilds Arrow JS objects so typed-array views that point into larger buffers become standalone when necessary. Full-buffer views can still be reused."
   tone="blue"
   meta={['Worker-safe transfer', 'Sliced buffers', 'Arrow JS objects']}

--- a/docs/modules/arrow/api-reference/triangulate-wkb-geometry-column.md
+++ b/docs/modules/arrow/api-reference/triangulate-wkb-geometry-column.md
@@ -10,7 +10,7 @@ import {DocOrientation, ReferenceBoundary} from '@site/src/components/docs/desig
 
 <DocPageHeader
   eyebrow="GeoArrow geometry utility"
-  title="Turn WKB polygons into renderer-ready triangles."
+  title="triangulateWKBGeometryColumn"
   description="`triangulateWKBGeometryColumn` converts Polygon and MultiPolygon WKB values into Arrow columns for triangle indexes and source XY vertices, keeping one output row aligned with each input geometry."
   tone="cyan"
   meta={['GeoArrow WKB', 'Polygon triangulation', 'Arrow columns']}

--- a/docs/modules/arrow/api-reference/utf8-utils.md
+++ b/docs/modules/arrow/api-reference/utf8-utils.md
@@ -10,7 +10,7 @@ import {DocOrientation, ReferenceBoundary} from '@site/src/components/docs/desig
 
 <DocPageHeader
   eyebrow="Arrow UTF-8 utilities"
-  title="Inspect text columns without leaving the byte path."
+  title="UTF-8 utilities"
   description="These helpers compare UTF-8 values and parse numeric text directly from Arrow byte ranges. They are designed for hot paths where allocating JavaScript strings would add avoidable work."
   tone="cyan"
   meta={['Utf8 and LargeUtf8', 'Byte-range parsing', 'Allocation-aware']}

--- a/docs/modules/arrow/format.md
+++ b/docs/modules/arrow/format.md
@@ -9,12 +9,14 @@ import {ArrowDocsTabs} from '@site/src/components/docs/arrow-docs-tabs';
 import {ArrowDataPlaneGraphic} from '@site/src/components/docs/arrow-data-plane-graphic';
 import {DocPageHeader} from '@site/src/components/docs/doc-page-header';
 import {DocOrientation, ReferenceBoundary} from '@site/src/components/docs/designed-doc';
+import apacheLogo from '../../images/logos/apache-logo.png';
 
 <DocPageHeader
   eyebrow="Binary columnar data"
-  title="One table shape for the whole pipeline."
+  title="Apache Arrow"
   description="Apache Arrow keeps columns typed and contiguous as they move between decoders, scanners, workers, analytical code, and writers. loaders.gl provides the format adapters and common table contracts around that physical model."
   tone="cyan"
+  logos={[{alt: 'Apache Software Foundation', src: apacheLogo}]}
   meta={['Arrow IPC file and stream', 'Typed columns', 'Zero-copy handoffs']}
   links={[
     {label: 'Arrow overview', to: '/docs/modules/arrow/formats/arrow'},

--- a/docs/modules/arrow/formats/arrow.md
+++ b/docs/modules/arrow/formats/arrow.md
@@ -25,6 +25,11 @@ import apacheLogo from '../../../images/logos/apache-logo.png';
   ]}
 />
 
+## Try a selective read
+
+Use the panel below to inspect Arrow IPC metadata, choose columns, and limit the rows returned from a
+remote table. The same source contract is used by the broader scan architecture.
+
 <ArrowScanLiveExample />
 
 <ArrowDocsTabs active="overview" />
@@ -68,11 +73,6 @@ Arrow stores values by column rather than by row. This layout improves cache loc
 ## Arrow JS
 
 `@loaders.gl/arrow` uses Apache Arrow JS for IPC parsing, writing, and table access. The loaders.gl wrapper adds loader metadata, worker integration, table shape conversion, and utilities for common Arrow table workflows.
-
-## Try a selective read
-
-Use the panel below to inspect Arrow IPC metadata, choose columns, and limit the rows returned from a
-remote table. The same source contract is used by the broader scan architecture.
 
 ## Scan support
 

--- a/docs/modules/arrow/formats/arrow.md
+++ b/docs/modules/arrow/formats/arrow.md
@@ -25,6 +25,8 @@ import apacheLogo from '../../../images/logos/apache-logo.png';
   ]}
 />
 
+<ArrowScanLiveExample />
+
 <ArrowDocsTabs active="overview" />
 
 <ArrowDataPlaneGraphic />
@@ -71,8 +73,6 @@ Arrow stores values by column rather than by row. This layout improves cache loc
 
 Use the panel below to inspect Arrow IPC metadata, choose columns, and limit the rows returned from a
 remote table. The same source contract is used by the broader scan architecture.
-
-<ArrowScanLiveExample />
 
 ## Scan support
 

--- a/docs/modules/arrow/formats/geoarrow.md
+++ b/docs/modules/arrow/formats/geoarrow.md
@@ -7,20 +7,27 @@ page_style: designed
 
 import {ArrowDocsTabs} from '@site/src/components/docs/arrow-docs-tabs';
 import {DocPageHeader} from '@site/src/components/docs/doc-page-header';
+import {DocLiveExample} from '@site/src/components/docs/doc-live-example';
 import {DocOrientation, ReferenceBoundary} from '@site/src/components/docs/designed-doc';
 import {GeoArrowFlowGraphic} from '@site/src/components/docs/geoarrow-flow-graphic';
+import {ClientExample} from '@site/src/components';
 
 <DocPageHeader
   eyebrow="Geospatial columnar format"
-  title="Put geometry columns on the Arrow path."
+  title="GeoArrow"
   description="GeoArrow defines the Arrow extension metadata and layouts that let geospatial features travel with typed attribute columns. It is a convention on top of Arrow, so a valid GeoArrow table remains an Arrow table."
   tone="cyan"
+  logos={[{alt: 'Apache Arrow', src: '/images/format-logos/apache-arrow-logo.png'}]}
   meta={['Apache Arrow extensions', 'Geometry columns', 'CRS metadata']}
   links={[
     {label: 'Arrow format', to: '/docs/modules/arrow/formats/arrow'},
     {label: 'CRS guide', to: '/docs/developer-guide/coordinate-reference-systems'}
   ]}
 />
+
+<DocLiveExample label="GeoArrow table map example" height="420px">
+  <ClientExample kind="geospatial" format="GeoArrow" />
+</DocLiveExample>
 
 See [Coordinate Reference Systems](/docs/developer-guide/coordinate-reference-systems) for
 GeoArrow CRS representations, column-specific metadata, and current preservation gaps.

--- a/docs/modules/csv/README.md
+++ b/docs/modules/csv/README.md
@@ -6,20 +6,27 @@ page_style: designed
 ---
 
 import {DocPageHeader} from '@site/src/components/docs/doc-page-header';
+import {DocLiveExample} from '@site/src/components/docs/doc-live-example';
 import {DocOrientation, ReferenceBoundary} from '@site/src/components/docs/designed-doc';
 import {StructuredDataPathGraphic} from '@site/src/components/docs/structured-data-path-graphic';
+import {ClientExample} from '@site/src/components';
 
 <DocPageHeader
   eyebrow="Table module"
-  title="Turn delimited text into a table path."
+  title="@loaders.gl/csv"
   description="The CSV module handles CSV and TSV input through the same loaders.gl APIs used by binary table formats. It can materialize a table, emit batches as records arrive, or write compatible data back to text."
   tone="cyan"
+  logos={[{alt: 'CSV', src: '/images/format-logos/csv-logo.svg'}]}
   meta={['CSV / TSV', 'Streaming', 'Table output']}
   links={[
     {label: 'Table category', to: '/docs/specifications/category-table'},
     {label: 'Streaming loaders', to: '/docs/developer-guide/using-streaming-loaders'}
   ]}
 />
+
+<DocLiveExample label="CSV table map example" height="420px">
+  <ClientExample kind="geospatial" format="CSV" />
+</DocLiveExample>
 
 <StructuredDataPathGraphic />
 

--- a/docs/modules/csv/api-reference/csv-loader.md
+++ b/docs/modules/csv/api-reference/csv-loader.md
@@ -7,19 +7,26 @@ page_style: designed
 
 import {CsvDocsTabs} from '@site/src/components/docs/csv-docs-tabs';
 import {DocPageHeader} from '@site/src/components/docs/doc-page-header';
+import {DocLiveExample} from '@site/src/components/docs/doc-live-example';
 import {DocOrientation, ReferenceBoundary} from '@site/src/components/docs/designed-doc';
+import {ClientExample} from '@site/src/components';
 
 <DocPageHeader
   eyebrow="CSV module · loader API"
   title="CSVLoader"
   description="Load CSV and TSV text into a table shape that suits the next stage of your application, from familiar JavaScript rows to typed Apache Arrow columns."
   tone="blue"
+  logos={[{alt: 'CSV', src: '/images/format-logos/csv-logo.svg'}]}
   meta={['From v1.0', 'CSV / TSV', 'Arrow output']}
   links={[
     {label: 'CSV format', to: '/docs/modules/csv/formats/csv'},
     {label: 'CSV module', to: '/docs/modules/csv'}
   ]}
 />
+
+<DocLiveExample label="CSVLoader table map example" height="420px">
+  <ClientExample kind="geospatial" format="CSV" />
+</DocLiveExample>
 
 <CsvDocsTabs active="csvloader" />
 

--- a/docs/modules/csv/benchmarks.md
+++ b/docs/modules/csv/benchmarks.md
@@ -12,7 +12,7 @@ import {DocOrientation, ReferenceBoundary} from '@site/src/components/docs/desig
 
 <DocPageHeader
   eyebrow="CSV module · live benchmark"
-  title="Measure the parse path your table actually uses."
+  title="CSV benchmarks"
   description="CSV performance depends on row width, quoting, conversion, and whether the application consumes one table or batches. This browser benchmark keeps the fixture and run visible so the result has useful context."
   tone="mint"
   meta={['CSV', 'Table output', 'Browser runtime']}

--- a/docs/modules/csv/format.md
+++ b/docs/modules/csv/format.md
@@ -12,9 +12,10 @@ import {DocOrientation, ReferenceBoundary} from '@site/src/components/docs/desig
 
 <DocPageHeader
   eyebrow="Delimited text format"
-  title="Turn a text stream into a table."
+  title="CSV, TSV, and DSV"
   description="CSV, TSV, and related delimiter-separated files are simple to transport but varied in headers, quoting, types, and line endings. The CSV module makes those choices explicit and returns the same table shapes used by other loaders."
   tone="mint"
+  logos={[{alt: 'CSV', src: '/images/format-logos/csv-logo.svg'}]}
   meta={['CSV / TSV / DSV', 'Streaming parser', 'Arrow-compatible output']}
   links={[
     {label: 'CSV module', to: '/docs/modules/csv'},

--- a/docs/modules/csv/formats/csv.md
+++ b/docs/modules/csv/formats/csv.md
@@ -7,20 +7,27 @@ page_style: designed
 
 import {CsvDocsTabs} from '@site/src/components/docs/csv-docs-tabs';
 import {DocPageHeader} from '@site/src/components/docs/doc-page-header';
+import {DocLiveExample} from '@site/src/components/docs/doc-live-example';
 import {DocOrientation, ReferenceBoundary} from '@site/src/components/docs/designed-doc';
 import {StructuredDataPathGraphic} from '@site/src/components/docs/structured-data-path-graphic';
+import {ClientExample} from '@site/src/components';
 
 <DocPageHeader
   eyebrow="Delimited text formats"
-  title="Start with a table anyone can inspect."
+  title="CSV, TSV, and DSV"
   description="CSV, TSV, and DSV use plain text to represent rows and fields. Their simplicity makes them useful for exchange, command-line tools, spreadsheets, and streaming pipelines."
   tone="cyan"
+  logos={[{alt: 'CSV', src: '/images/format-logos/csv-logo.svg'}]}
   meta={['Plain text', 'Streaming-friendly', 'Tabular data']}
   links={[
     {label: 'CSV module', to: '/docs/modules/csv'},
     {label: 'Streaming loaders', to: '/docs/developer-guide/using-streaming-loaders'}
   ]}
 />
+
+<DocLiveExample label="CSV format map example" height="420px">
+  <ClientExample kind="geospatial" format="CSV" />
+</DocLiveExample>
 
 <CsvDocsTabs active="overview" />
 

--- a/docs/modules/json/README.md
+++ b/docs/modules/json/README.md
@@ -11,7 +11,7 @@ import {StructuredDataPathGraphic} from '@site/src/components/docs/structured-da
 
 <DocPageHeader
   eyebrow="Structured data module"
-  title="Use JSON where it is strongest, then choose a shape."
+  title="@loaders.gl/json"
   description="The JSON module covers arbitrary documents, newline-delimited records, tabular arrays, and GeoJSON. Applications can preserve nested structures or ask for table and feature outputs when that is the better next step."
   tone="yellow"
   meta={['JSON / NDJSON', 'GeoJSON', 'Table and feature output']}

--- a/docs/modules/json/api-reference/geojson-loader.md
+++ b/docs/modules/json/api-reference/geojson-loader.md
@@ -8,14 +8,16 @@ page_style: designed
 import {JsonDocsTabs} from '@site/src/components/docs/json-docs-tabs';
 import {GeoArrowFlowGraphic} from '@site/src/components/docs/geoarrow-flow-graphic';
 import {DocPageHeader} from '@site/src/components/docs/doc-page-header';
+import {DocLiveExample} from '@site/src/components/docs/doc-live-example';
 import {DocOrientation, ReferenceBoundary} from '@site/src/components/docs/designed-doc';
-import {LoaderLiveExample} from '@site/src/components/docs/loader-live-example';
+import {ClientExample} from '@site/src/components';
 
 <DocPageHeader
   eyebrow="GeoJSON loader"
-  title="Start with features. Convert later when you need to."
+  title="GeoJSONLoader"
   description="GeoJSONLoader preserves the familiar feature and geometry model while supporting binary geometry, Arrow tables, and incremental parsing for larger documents."
   tone="cyan"
+  logos={[{alt: 'GeoJSON', src: '/images/format-logos/geojson-logo.svg'}]}
   meta={['RFC 7946', 'Streaming parser', 'Arrow and binary output']}
   links={[
     {label: 'GeoJSON format', to: '/docs/modules/json/formats/geojson'},
@@ -23,9 +25,11 @@ import {LoaderLiveExample} from '@site/src/components/docs/loader-live-example';
   ]}
 />
 
-<JsonDocsTabs active="geojsonloader" tryItHref="/examples/geospatial/geojson" />
+<DocLiveExample label="GeoJSONLoader map example" height="420px">
+  <ClientExample kind="geospatial" format="GeoJSON" />
+</DocLiveExample>
 
-<LoaderLiveExample />
+<JsonDocsTabs active="geojsonloader" tryItHref="/examples/geospatial/geojson" />
 
 <GeoArrowFlowGraphic />
 

--- a/docs/modules/json/format.md
+++ b/docs/modules/json/format.md
@@ -11,7 +11,7 @@ import {DocOrientation, ReferenceBoundary} from '@site/src/components/docs/desig
 
 <DocPageHeader
   eyebrow="Document and table format"
-  title="Start with JSON. Keep the next step open."
+  title="JSON"
   description="The JSON module handles arbitrary documents, row arrays, newline-delimited records, GeoJSON, and JSON output. Choose the result shape that matches the application instead of writing a new parser path for each variant."
   tone="blue"
   meta={['JSON and NDJSON', 'GeoJSON', 'Rows and Arrow tables']}

--- a/docs/modules/json/formats/geojson-geometry.md
+++ b/docs/modules/json/formats/geojson-geometry.md
@@ -10,7 +10,7 @@ import {DocOrientation, ReferenceBoundary} from '@site/src/components/docs/desig
 
 <DocPageHeader
   eyebrow="GeoJSON geometry"
-  title="Keep geometry simple at the interchange boundary."
+  title="GeoJSON Geometry"
   description="GeoJSON geometry objects describe coordinates and their type without carrying feature properties. They are useful on their own when a pipeline needs geometry before it assembles complete features."
   tone="mint"
   meta={['Point and line', 'Polygon and multiparts', 'JSON interchange']}

--- a/docs/modules/json/formats/geojson.md
+++ b/docs/modules/json/formats/geojson.md
@@ -6,20 +6,27 @@ page_style: designed
 ---
 
 import {DocPageHeader} from '@site/src/components/docs/doc-page-header';
+import {DocLiveExample} from '@site/src/components/docs/doc-live-example';
 import {StructuredDataPathGraphic} from '@site/src/components/docs/structured-data-path-graphic';
 import {DocOrientation, ReferenceBoundary} from '@site/src/components/docs/designed-doc';
+import {ClientExample} from '@site/src/components';
 
 <DocPageHeader
   eyebrow="Readable feature format"
-  title="Keep geometry and properties in one familiar object."
+  title="GeoJSON"
   description="GeoJSON represents geographic features as JSON objects with explicit geometry and application properties. It is easy to inspect, exchange, and connect to web mapping code."
   tone="cyan"
+  logos={[{alt: 'GeoJSON', src: '/images/format-logos/geojson-logo.svg'}]}
   meta={['RFC 7946', 'Feature collections', 'Human-readable']}
   links={[
     {label: 'JSON module', to: '/docs/modules/json'},
     {label: 'GeoJSON loader', to: '/docs/modules/json/api-reference/geojson-loader'}
   ]}
 />
+
+<DocLiveExample label="GeoJSON format map example" height="420px">
+  <ClientExample kind="geospatial" format="GeoJSON" />
+</DocLiveExample>
 
 <StructuredDataPathGraphic />
 

--- a/docs/modules/json/formats/json.md
+++ b/docs/modules/json/formats/json.md
@@ -12,7 +12,7 @@ import {StructuredDataPathGraphic} from '@site/src/components/docs/structured-da
 
 <DocPageHeader
   eyebrow="Structured text format"
-  title="Start with readable data. Stream it when it grows."
+  title="JSON"
   description="JSON represents nested values in a form that works naturally across browsers, services, and configuration files. loaders.gl also provides line-oriented loaders when records should arrive incrementally."
   tone="cyan"
   meta={['JSON documents', 'NDJSON and JSONL', 'Table output']}

--- a/docs/modules/json/jsonpath.md
+++ b/docs/modules/json/jsonpath.md
@@ -10,7 +10,7 @@ import {DocOrientation, ReferenceBoundary} from '@site/src/components/docs/desig
 
 <DocPageHeader
   eyebrow="JSON module · streaming selection"
-  title="Point a streaming parser at the array that matters."
+  title="JSONPath"
   description="loaders.gl implements the JSONPath features needed to identify a streamable array while keeping parsing small and predictable. The selector describes a path, not a general-purpose query language."
   tone="yellow"
   meta={['RFC 9535 subset', 'Streaming arrays', 'Predictable selectors']}

--- a/docs/modules/orc/README.md
+++ b/docs/modules/orc/README.md
@@ -8,12 +8,15 @@ page_style: designed
 import {DocPageHeader} from '@site/src/components/docs/doc-page-header';
 import {CrossFormatScanEngineGraphic} from '@site/src/components/docs/cross-format-scan-engine-graphic';
 import {DocOrientation, ReferenceBoundary} from '@site/src/components/docs/designed-doc';
+import {OrcCloudLiveExample} from '@site/src/components/docs/orc-cloud-live-example';
+import apacheLogo from '../../images/logos/apache-logo.png';
 
 <DocPageHeader
   eyebrow="ORC module"
-  title="Bring ORC tables into the common data path."
+  title="@loaders.gl/orc"
   description="`@loaders.gl/orc` reads and writes Apache ORC files. Its source API exposes metadata and a portable scan contract while keeping the current materialized execution model explicit."
   tone="yellow"
+  logos={[{alt: 'Apache Software Foundation', src: apacheLogo}]}
   meta={['Apache ORC', 'Read and write', 'Arrow tables']}
   links={[
     {label: 'ORC format', to: '/docs/modules/orc/formats/orc'},
@@ -21,6 +24,8 @@ import {DocOrientation, ReferenceBoundary} from '@site/src/components/docs/desig
     {label: 'Scan architecture', to: '/docs/developer-guide/common-scan-architecture'}
   ]}
 />
+
+<OrcCloudLiveExample />
 
 <CrossFormatScanEngineGraphic />
 

--- a/docs/modules/orc/formats/orc.md
+++ b/docs/modules/orc/formats/orc.md
@@ -9,18 +9,22 @@ import {DocPageHeader} from '@site/src/components/docs/doc-page-header';
 import {CrossFormatScanEngineGraphic} from '@site/src/components/docs/cross-format-scan-engine-graphic';
 import {DocOrientation, ReferenceBoundary} from '@site/src/components/docs/designed-doc';
 import {OrcCloudLiveExample} from '@site/src/components/docs/orc-cloud-live-example';
+import apacheLogo from '../../../images/logos/apache-logo.png';
 
 <DocPageHeader
   eyebrow="Columnar file format"
-  title="Read typed columns from a striped file."
+  title="Apache ORC"
   description="Apache ORC stores a schema, encoded column streams, and statistics in a compact file layout. Its footer makes the structure discoverable before the data is materialized."
   tone="violet"
+  logos={[{alt: 'Apache Software Foundation', src: apacheLogo}]}
   meta={['Apache ORC', 'Columnar stripes', 'Arrow output']}
   links={[
     {label: 'ORC module', to: '/docs/modules/orc'},
     {label: 'Scan architecture', to: '/docs/developer-guide/common-scan-architecture'}
   ]}
 />
+
+<OrcCloudLiveExample />
 
 <CrossFormatScanEngineGraphic />
 
@@ -36,8 +40,6 @@ import {OrcCloudLiveExample} from '@site/src/components/docs/orc-cloud-live-exam
     {label: 'Output', value: 'Arrow tables with portable scan semantics'}
   ]}
 />
-
-<OrcCloudLiveExample />
 
 <p className="badges">
   <a href="/docs/developer-guide/common-scan-architecture">

--- a/docs/modules/parquet/README.md
+++ b/docs/modules/parquet/README.md
@@ -7,6 +7,7 @@ page_style: designed
 
 import {CapabilityHero} from '@site/src/components/docs/capability-hero';
 import {ParquetLayoutGraphic} from '@site/src/components/docs/parquet-layout-graphic';
+import {ParquetScanLiveExample} from '@site/src/components/docs/parquet-scan-live-example';
 import {DocOrientation, ReferenceBoundary} from '@site/src/components/docs/designed-doc';
 
 <CapabilityHero
@@ -23,6 +24,8 @@ import {DocOrientation, ReferenceBoundary} from '@site/src/components/docs/desig
     {label: 'Scan architecture', to: '/docs/developer-guide/common-scan-architecture'}
   ]}
 />
+
+<ParquetScanLiveExample />
 
 <p className="badges">
   <img src="https://img.shields.io/badge/From-v3.1-blue.svg?style=flat-square" alt="From-v3.1" />

--- a/docs/modules/parquet/api-reference/delta-table-source.md
+++ b/docs/modules/parquet/api-reference/delta-table-source.md
@@ -10,7 +10,7 @@ import {DocOrientation, ReferenceBoundary} from '@site/src/components/docs/desig
 
 <DocPageHeader
   eyebrow="Versioned table source"
-  title="Read a Delta snapshot as a table, not a log."
+  title="DeltaTableSource"
   description="DeltaTableSource replays the transaction log to determine the active Parquet files, then uses the common source and scan contracts for metadata, filtering, projection, limits, and streaming Arrow results."
   tone="violet"
   meta={['Delta Lake', 'Snapshot replay', 'Parquet and Arrow']}

--- a/docs/modules/parquet/api-reference/geoparquet-loader.md
+++ b/docs/modules/parquet/api-reference/geoparquet-loader.md
@@ -7,13 +7,16 @@ page_style: designed
 
 import {ParquetDocsTabs} from '@site/src/components/docs/parquet-docs-tabs';
 import {DocPageHeader} from '@site/src/components/docs/doc-page-header';
+import {DocLiveExample} from '@site/src/components/docs/doc-live-example';
 import {DocOrientation, ReferenceBoundary} from '@site/src/components/docs/designed-doc';
+import {ClientExample} from '@site/src/components';
 
 <DocPageHeader
   eyebrow="Parquet module · geospatial loader"
   title="GeoParquetLoader"
   description="Read GeoParquet files into loaders.gl geospatial tables while preserving the metadata that describes geometry columns, coordinate systems, and encodings."
   tone="mint"
+  logos={[{alt: 'Apache Parquet', src: '/images/format-logos/parquet-logo.png'}]}
   meta={['From v5.0', 'GeoParquet', 'Arrow output']}
   links={[
     {label: 'GeoParquet format', to: '/docs/modules/parquet/formats/geoparquet'},
@@ -21,6 +24,10 @@ import {DocOrientation, ReferenceBoundary} from '@site/src/components/docs/desig
     {label: 'Parquet module', to: '/docs/modules/parquet'}
   ]}
 />
+
+<DocLiveExample label="GeoParquetLoader map example" height="420px">
+  <ClientExample kind="geospatial" format="GeoParquet" />
+</DocLiveExample>
 
 <ParquetDocsTabs active="geoparquetloader" />
 

--- a/docs/modules/parquet/api-reference/geoparquet-loader.md
+++ b/docs/modules/parquet/api-reference/geoparquet-loader.md
@@ -26,7 +26,7 @@ import {ClientExample} from '@site/src/components';
 />
 
 <DocLiveExample label="GeoParquetLoader map example" height="420px">
-  <ClientExample kind="geospatial" format="GeoParquet" />
+  <ClientExample kind="geospatial" format="GeoParquet" parquetLoaderName="geoparquet" />
 </DocLiveExample>
 
 <ParquetDocsTabs active="geoparquetloader" />

--- a/docs/modules/parquet/api-reference/iceberg-table-source.md
+++ b/docs/modules/parquet/api-reference/iceberg-table-source.md
@@ -7,12 +7,14 @@ page_style: designed
 
 import {DocPageHeader} from '@site/src/components/docs/doc-page-header';
 import {DocOrientation, ReferenceBoundary} from '@site/src/components/docs/designed-doc';
+import apacheLogo from '../../../images/logos/apache-logo.png';
 
 <DocPageHeader
   eyebrow="Versioned table source"
-  title="Turn manifests into a bounded table read."
+  title="IcebergTableSource"
   description="IcebergTableSource reads table metadata and manifests, selects the relevant Parquet data files, and delegates physical decoding to the shared Parquet source path."
   tone="violet"
+  logos={[{alt: 'Apache Software Foundation', src: apacheLogo}]}
   meta={['Apache Iceberg', 'Manifest planning', 'Arrow batches']}
   links={[
     {label: 'Scan architecture', to: '/docs/developer-guide/common-scan-architecture'},

--- a/docs/modules/parquet/api-reference/parquet-writer.md
+++ b/docs/modules/parquet/api-reference/parquet-writer.md
@@ -12,9 +12,10 @@ import {WriterPipelineGraphic} from '@site/src/components/docs/writer-pipeline-g
 
 <DocPageHeader
   eyebrow="Parquet writer"
-  title="Write the table your storage and query systems expect."
+  title="ParquetWriter"
   description="ParquetWriter encodes loaders.gl table data, including Arrow-backed tables, into typed columnar Parquet. GeoArrow metadata can be carried into GeoParquet schema metadata when the input describes geometry columns."
   tone="cyan"
+  logos={[{alt: 'Apache Parquet', src: '/images/format-logos/parquet-logo.png'}]}
   meta={['Parquet', 'Arrow input', 'GeoParquet metadata']}
   links={[
     {label: 'GeoParquet format', to: '/docs/modules/parquet/formats/geoparquet'},

--- a/docs/modules/parquet/format.md
+++ b/docs/modules/parquet/format.md
@@ -11,9 +11,10 @@ import {DocOrientation, ReferenceBoundary} from '@site/src/components/docs/desig
 
 <DocPageHeader
   eyebrow="Columnar file format"
-  title="Read the columns the application actually needs."
+  title="Apache Parquet"
   description="Parquet stores typed columns in independently addressable pages. loaders.gl combines its format reader with Arrow output, metadata-first sources, range requests, and GeoParquet conventions for cloud-friendly data access."
   tone="orange"
+  logos={[{alt: 'Apache Parquet', src: '/images/format-logos/parquet-logo.png'}]}
   meta={['Column and page pruning', 'Arrow output', 'GeoParquet metadata']}
   links={[
     {label: 'Parquet overview', to: '/docs/modules/parquet/formats/parquet'},

--- a/docs/modules/parquet/formats/geoparquet.md
+++ b/docs/modules/parquet/formats/geoparquet.md
@@ -8,19 +8,26 @@ page_style: designed
 import {ParquetDocsTabs} from '@site/src/components/docs/parquet-docs-tabs';
 import {GeoArrowFlowGraphic} from '@site/src/components/docs/geoarrow-flow-graphic';
 import {DocPageHeader} from '@site/src/components/docs/doc-page-header';
+import {DocLiveExample} from '@site/src/components/docs/doc-live-example';
 import {DocOrientation, ReferenceBoundary} from '@site/src/components/docs/designed-doc';
+import {ClientExample} from '@site/src/components';
 
 <DocPageHeader
   eyebrow="Geospatial columnar format"
-  title="Put geometry into the Parquet table contract."
+  title="GeoParquet"
   description="GeoParquet adds geospatial metadata and encoding conventions to Parquet. The result is still a Parquet table, but readers can discover geometry columns, encodings, bounds, and coordinate meaning without a sidecar format."
   tone="cyan"
+  logos={[{alt: 'Apache Parquet', src: '/images/format-logos/parquet-logo.png'}]}
   meta={['Parquet', 'Geo metadata', 'WKB and GeoArrow encodings']}
   links={[
     {label: 'Parquet format', to: '/docs/modules/parquet/formats/parquet'},
     {label: 'GeoArrow format', to: '/docs/modules/arrow/formats/geoarrow'}
   ]}
 />
+
+<DocLiveExample label="GeoParquet table map example" height="420px">
+  <ClientExample kind="geospatial" format="GeoParquet" />
+</DocLiveExample>
 
 <ParquetDocsTabs active="geoparquet" />
 
@@ -44,10 +51,6 @@ import {DocOrientation, ReferenceBoundary} from '@site/src/components/docs/desig
     <img src="https://img.shields.io/badge/Scan-Supported-2f855a.svg?style=flat-square" alt="Scan supported" />
   </a>
 </p>
-
-![parquet-logo](../images/parquet-logo-small.png)
-&emsp;
-![apache-logo](../../../images/logos/apache-logo.png)
 
 - _[`loaders.gl/parquet`](/docs/modules/parquet)_
 - _[geoparquet.org](https://geoparquet.org)_

--- a/docs/modules/parquet/formats/parquet.md
+++ b/docs/modules/parquet/formats/parquet.md
@@ -25,6 +25,8 @@ import {DocOrientation} from '@site/src/components/docs/designed-doc';
   ]}
 />
 
+<ParquetScanLiveExample />
+
 <ParquetDocsTabs active="overview" />
 
 <ParquetLayoutGraphic />
@@ -48,17 +50,11 @@ Use the panel below to inspect Parquet metadata, select columns, and limit the A
 from a remote file. The reader can plan the request from the footer before decoding the selected
 data ranges.
 
-<ParquetScanLiveExample />
-
 <p className="badges">
   <a href="/docs/developer-guide/common-scan-architecture">
     <img src="https://img.shields.io/badge/Scan-Supported-2f855a.svg?style=flat-square" alt="Scan supported" />
   </a>
 </p>
-
-![parquet-logo](../images/parquet-logo-small.png)
-&emsp;
-![apache-logo](../../../images/logos/apache-logo.png)
 
 - _[`@loaders.gl/parquet`](/docs/modules/parquet)_
 - _[Apache Parquet format specification](https://github.com/apache/parquet-format)_

--- a/docs/modules/parquet/formats/parquet.md
+++ b/docs/modules/parquet/formats/parquet.md
@@ -25,6 +25,12 @@ import {DocOrientation} from '@site/src/components/docs/designed-doc';
   ]}
 />
 
+## Try a range-aware read
+
+Use the panel below to inspect Parquet metadata, select columns, and limit the Arrow rows returned
+from a remote file. The reader can plan the request from the footer before decoding the selected
+data ranges.
+
 <ParquetScanLiveExample />
 
 <ParquetDocsTabs active="overview" />
@@ -43,12 +49,6 @@ import {DocOrientation} from '@site/src/components/docs/designed-doc';
     {label: 'Output', value: 'Object rows, Arrow tables, or incremental batches'}
   ]}
 />
-
-## Try a range-aware read
-
-Use the panel below to inspect Parquet metadata, select columns, and limit the Arrow rows returned
-from a remote file. The reader can plan the request from the footer before decoding the selected
-data ranges.
 
 <p className="badges">
   <a href="/docs/developer-guide/common-scan-architecture">

--- a/examples/website/geospatial/app.tsx
+++ b/examples/website/geospatial/app.tsx
@@ -122,6 +122,8 @@ export const INITIAL_VIEW_STATE = {
 type AppProps = {
   /** Controls which examples are shown */
   format?: string;
+  /** Selects the initial loader for GeoParquet examples. */
+  parquetLoaderName?: ParquetLoaderName;
   /** Whether to hide the example controls, metadata, and descriptive overlay. */
   hideChrome?: boolean;
   /** Any informational text to display in the overlay */
@@ -150,7 +152,9 @@ type AppState = {
  */
 export default function App(props: AppProps = {}) {
   const [tableFormat, setTableFormat] = useState<TableFormat>('geoarrow');
-  const [parquetLoaderName, setParquetLoaderName] = useState<ParquetLoaderName>('parquet');
+  const [parquetLoaderName, setParquetLoaderName] = useState<ParquetLoaderName>(
+    props.parquetLoaderName ?? 'parquet'
+  );
   const previousTableFormat = useRef(tableFormat);
   const loadRequestIdRef = useRef(0);
   const availableExamples = useMemo(


### PR DESCRIPTION
## Goals

- Make analytical and table-format pages identifiable in a sub-second scan.
- Put the strongest interactive data example immediately below the hero.
- Use correct format and standards marks without duplicating logos lower in the page.

## Changes

- Refresh the Arrow, Parquet, CSV, JSON, GeoArrow, GeoJSON, GeoParquet, and ORC documentation families.
- Replace slogan-only hero titles with package, format, loader, writer, source, or utility identities; retain friendly explanations in descriptions and orientation cards.
- Move Arrow, Parquet, and ORC query panels directly below their hero cards.
- Add fullscreen-gated CSV, GeoJSON, GeoArrow, and GeoParquet examples to their format and API entry pages.
- Raise CSV, GeoJSON, Apache Arrow, Apache Parquet, and Apache organization marks into the hero area.
- Remove duplicate low-page Parquet and Apache logos and obsolete generic loader demo placements.

## Verification

- `yarn lint fix`
- `yarn build`
- `yarn build-workers`
- `yarn test-node` — 391 passed
- `yarn test-headless` — 3,819 passed
- `cd website && yarn build`
