### PR TITLE
refactor(loader-utils): compose source capability interfaces

### DIFF
--- a/docs/developer-guide/using-sources.mdx
+++ b/docs/developer-guide/using-sources.mdx
@@ -26,7 +26,7 @@ A `SourceLoader` provides general information about the supported resource forma
 
 A `DataSource` instance provides methods to query metadata and to query data for specific geospatial areas or views.
 
-A `DataSource` can (and sometimes must) expose a completely unique API. However a big advantage comes when a `DataSource` conforms to an existing `*Source` interface.
+A `DataSource` can (and sometimes must) expose a completely unique API. However a big advantage comes when a `DataSource` conforms to an existing `*Source` interface. `DataSource` is the implementation base class; the `*Source` interfaces are type-only capability contracts.
 
 This means that applications written against that interface can now support the new source without any changes to existing logic.
 
@@ -42,6 +42,55 @@ This means that applications written against that interface can now support the 
 
 A `DataSource` instance provides methods to query metadata: `await dataSource.getMetadata()`.
 
+## Composing source capabilities
+
+One runtime object can implement several source capabilities while sharing the input, options,
+authentication, caches, and lifecycle supplied by `DataSource`:
+
+```ts
+import {DataSource} from '@loaders.gl/loader-utils';
+import type {
+  DataSourceOptions,
+  ImageSource,
+  ImageSourceMetadata,
+  ImageType,
+  GetImageParameters,
+  RasterData,
+  RasterSource,
+  RasterSourceMetadata,
+  GetRasterParameters
+} from '@loaders.gl/loader-utils';
+
+type CompositeMetadata = ImageSourceMetadata & RasterSourceMetadata;
+
+class CompositeSource
+  extends DataSource<string, DataSourceOptions>
+  implements ImageSource, RasterSource
+{
+  async getMetadata(): Promise<CompositeMetadata> {
+    throw new Error('Return one source-level metadata object rich enough for both capabilities.');
+  }
+
+  async getImage(parameters: GetImageParameters): Promise<ImageType> {
+    throw new Error('Return rendered pixels for the requested extent.');
+  }
+
+  async getRaster(parameters: GetRasterParameters): Promise<RasterData> {
+    throw new Error('Return typed samples for the requested viewport.');
+  }
+}
+```
+
+Existing composite runtimes include MVT and PMTiles sources that implement image- and vector-tile
+capabilities, COPC sources that implement tile and point-cloud scan capabilities, and GeoTIFF
+sources that implement raster and scan-discovery capabilities. Distinct source loaders may still
+be appropriate when endpoints, initialization, or output semantics differ.
+
+Automatic consumers still choose one view at a time. For example, `SourceLayer` classifies a
+multi-capability object into the first matching rendering family: 3D tile, point cloud, raster,
+image, vector, then 2D tile. This classification does not add an implicit capability-selection API;
+callers that need another view should use the corresponding specialized source consumer or adapter.
+
 ## Adapter Sources
 
 While most `SourceLoader` implementations provide an interface for interacting with a specific web service or cloud archive file format (e.g. `PMTilesSourceLoader`), it is also possible to create adapters:
@@ -55,7 +104,7 @@ Just like the appropriate parser loader can be selected automatically from a lis
 
 ## Creating new Sources
 
-Just like applications can create their own loaders, apps can also create (and potentially contribute) their own source loaders and use them with loaders.gl, as long as they follow the required interfaces (e.g, every runtime source instance must inherit from `DataSource`).
+Just like applications can create their own loaders, apps can also create (and potentially contribute) their own source loaders and use them with loaders.gl, as long as they follow the required interfaces (for example, runtime source instances extend `DataSource` and implement one or more source capability interfaces).
 
 ## Raster sources
 

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -115,6 +115,45 @@ Concrete runtime classes are unchanged. For example:
 
 The old top-level `*Source` aliases have been removed, so imports must be updated explicitly.
 
+### Source capability interfaces
+
+`ImageSource`, `VectorSource`, and `RasterSource` are now type-only capability interfaces, matching
+the existing tile, catalog, and scan source contracts. `DataSource` remains the implementation base
+class. The obsolete `type` and `testURL` statics were removed from the capability contracts;
+runtime source selection continues to use the corresponding fields on `SourceLoader`.
+
+Custom sources that extended one of the old abstract classes should instead extend `DataSource`
+and implement one or more capability interfaces:
+
+```ts
+import {DataSource} from '@loaders.gl/loader-utils';
+import type {
+  DataSourceOptions,
+  GetImageParameters,
+  ImageSource,
+  ImageSourceMetadata,
+  ImageType
+} from '@loaders.gl/loader-utils';
+
+class CustomImageSource
+  extends DataSource<string, DataSourceOptions>
+  implements ImageSource
+{
+  async getMetadata(): Promise<ImageSourceMetadata> {
+    throw new Error('Return normalized image-source metadata.');
+  }
+
+  async getImage(parameters: GetImageParameters): Promise<ImageType> {
+    throw new Error('Load the requested image.');
+  }
+}
+```
+
+Import these contracts with `import type`; they are no longer runtime constructor values. Concrete
+source classes and operational methods such as `getMetadata()`, `getImage()`, `getRaster()`, and
+`getFeatures()` are unchanged. `@loaders.gl/wms` temporarily retains a deprecated structural
+`ImageSource` runtime guard for deck.gl 9.x compatibility; it is not a constructor or base class.
+
 ### Arrow loader and writer variant removal
 
 Redundant Arrow-specific loader and writer variants have been removed where the primary loader or writer already supports Arrow table data.

--- a/docs/whats-new.mdx
+++ b/docs/whats-new.mdx
@@ -168,6 +168,7 @@ Release Date: 2026
 **@loaders.gl/loader-utils**
 
 - `RasterSource`, `RasterData`, `RasterViewport`, and `GetRasterParameters` NEW - shared typed raster contracts for viewport-driven sources.
+- `ImageSource`, `VectorSource`, and `RasterSource` are composable type-only capability interfaces; custom runtimes extend `DataSource` once and can implement several source families without duplicating shared state.
 - `LoaderOptions.core.shape` is now documented as the shared shape default for compatible loaders, with consistent propagation during option normalization and batch parsing.
 
 **@loaders.gl/parquet**

--- a/modules/loader-utils/src/index.ts
+++ b/modules/loader-utils/src/index.ts
@@ -405,7 +405,7 @@ export type {
 export type {CatalogSource, CatalogSourceCapabilities} from './lib/sources/catalog-source';
 export type {GeoServiceType, ServiceCapabilities} from './lib/sources/service-capabilities';
 
-export {ImageSource} from './lib/sources/image-source';
+export type {ImageSource} from './lib/sources/image-source';
 export type {ImageType} from './lib/sources/utils/image-type';
 export type {ImageSourceMetadata} from './lib/sources/image-source';
 export type {GetImageParameters} from './lib/sources/image-source';
@@ -428,8 +428,9 @@ export type {ImageTileSource} from './lib/sources/image-tile-source';
 export type {VectorTileSource} from './lib/sources/vector-tile-source';
 export type {VectorTile} from './lib/sources/vector-tile-source';
 
-export {RasterSource, getRasterViewportBoundingBox} from './lib/sources/raster-source';
+export {getRasterViewportBoundingBox} from './lib/sources/raster-source';
 export type {
+  RasterSource,
   RasterChannelDataType,
   RasterBoundingBox,
   RasterViewport,

--- a/modules/loader-utils/src/lib/sources/image-source.ts
+++ b/modules/loader-utils/src/lib/sources/image-source.ts
@@ -3,19 +3,16 @@
 // Copyright (c) vis.gl contributors
 
 // TODO - can we import from schema?
-import {ImageType} from './utils/image-type';
+import type {ImageType} from './utils/image-type';
 import type {CRSIdentifier} from '@math.gl/crs';
 // TODO - remove (this breaks WMS layer)
 
 /**
  * ImageSource - data sources that allow images to be queried by (geospatial) extents
  */
-export abstract class ImageSource {
-  static type: string = 'template';
-  static testURL = (url: string): boolean => false;
-
-  abstract getMetadata(): Promise<ImageSourceMetadata>;
-  abstract getImage(parameters: GetImageParameters): Promise<ImageType>;
+export interface ImageSource {
+  getMetadata(): Promise<ImageSourceMetadata>;
+  getImage(parameters: GetImageParameters): Promise<ImageType>;
 }
 
 // PARAMETER TYPES

--- a/modules/loader-utils/src/lib/sources/raster-source.ts
+++ b/modules/loader-utils/src/lib/sources/raster-source.ts
@@ -160,20 +160,15 @@ export type RasterSourceMetadata = {
  * @typeParam ParametersT Request parameters accepted by the source.
  * @typeParam MetadataT Metadata returned by the source.
  */
-export abstract class RasterSource<
+export interface RasterSource<
   DataT extends RasterData = RasterData,
   ParametersT extends GetRasterParameters = GetRasterParameters,
   MetadataT extends RasterSourceMetadata = RasterSourceMetadata
 > {
-  /** Canonical source type identifier used during source selection. */
-  static type: string = 'template';
-  /** URL matcher used during automatic source selection. */
-  static testURL = (url: string): boolean => false;
-
   /** Returns normalized dataset metadata without loading raster samples. */
-  abstract getMetadata(): Promise<MetadataT>;
+  getMetadata(): Promise<MetadataT>;
   /** Loads raster samples for the supplied viewport request. */
-  abstract getRaster(parameters: ParametersT): Promise<DataT>;
+  getRaster(parameters: ParametersT): Promise<DataT>;
 }
 
 /**

--- a/modules/loader-utils/src/lib/sources/tile-source-adapter.ts
+++ b/modules/loader-utils/src/lib/sources/tile-source-adapter.ts
@@ -1,8 +1,8 @@
 // loaders.gl
 // SPDX-License-Identifier: MIT
 
-import {TileSource, GetTileParameters, GetTileDataParameters} from './tile-source';
-import {ImageSource, ImageSourceMetadata} from './image-source';
+import type {TileSource, GetTileParameters, GetTileDataParameters} from './tile-source';
+import type {ImageSource, ImageSourceMetadata} from './image-source';
 
 /**
  * MapTileSource - data sources that allow data to be queried by (geospatial) extents

--- a/modules/loader-utils/src/lib/sources/vector-source.ts
+++ b/modules/loader-utils/src/lib/sources/vector-source.ts
@@ -15,13 +15,10 @@ export type VectorSourceData = GeoJSONTable | BinaryFeatureCollection | ArrowTab
  * @note
  * - If geospatial, bounding box is expected to be in web mercator coordinates
  */
-export abstract class VectorSource {
-  static type: string = 'template';
-  static testURL = (url: string): boolean => false;
-
-  abstract getSchema(): Promise<Schema>;
-  abstract getMetadata(options: {formatSpecificMetadata?: boolean}): Promise<VectorSourceMetadata>;
-  abstract getFeatures(parameters: GetFeaturesParameters): Promise<VectorSourceData>;
+export interface VectorSource {
+  getSchema(): Promise<Schema>;
+  getMetadata(options: {formatSpecificMetadata?: boolean}): Promise<VectorSourceMetadata>;
+  getFeatures(parameters: GetFeaturesParameters): Promise<VectorSourceData>;
 }
 
 // PARAMETER TYPES

--- a/modules/loader-utils/test/lib/sources/source-capabilities.spec.ts
+++ b/modules/loader-utils/test/lib/sources/source-capabilities.spec.ts
@@ -1,0 +1,155 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {expect, test} from 'vitest';
+import type {
+  DataSourceOptions,
+  GetImageParameters,
+  GetRasterParameters,
+  GetTileDataParameters,
+  GetTileParameters,
+  ImageSource,
+  ImageSourceMetadata,
+  ImageType,
+  RasterData,
+  RasterSource,
+  RasterSourceMetadata,
+  TableScanSource,
+  TileSource
+} from '../../../src';
+import {createScanQueryMetadata, DataSource} from '../../../src';
+
+type CompositeSourceMetadata = ImageSourceMetadata & RasterSourceMetadata;
+
+/** Test source that exposes several independent capabilities from one runtime object. */
+class CompositeSource
+  extends DataSource<string, DataSourceOptions>
+  implements ImageSource, RasterSource, TileSource, TableScanSource<string>
+{
+  /** Creates a source with shared `DataSource` state for every capability. */
+  constructor() {
+    super('composite://source', {});
+  }
+
+  /** Returns one rich metadata object that satisfies each visual capability. */
+  async getMetadata(): Promise<CompositeSourceMetadata> {
+    return {
+      name: 'composite',
+      keywords: [],
+      layers: [],
+      width: 1,
+      height: 1,
+      bandCount: 1,
+      dtype: 'uint8'
+    };
+  }
+
+  /** Returns a one-pixel image. */
+  async getImage(parameters: GetImageParameters): Promise<ImageType> {
+    return {data: new Uint8Array([parameters.width]), width: 1, height: 1};
+  }
+
+  /** Returns a one-pixel typed raster. */
+  async getRaster(parameters: GetRasterParameters): Promise<RasterData> {
+    return {
+      data: new Uint8Array([parameters.viewport.width]),
+      width: 1,
+      height: 1,
+      bandCount: 1,
+      dtype: 'uint8'
+    };
+  }
+
+  /** Returns one tile payload. */
+  async getTile(parameters: GetTileParameters): Promise<unknown> {
+    return parameters;
+  }
+
+  /** Adapts the deck.gl tile request shape to the flat tile method. */
+  async getTileData(parameters: GetTileDataParameters): Promise<unknown> {
+    return this.getTile(parameters.index);
+  }
+
+  /** Describes the source's table-scan capability. */
+  async getQueryMetadata() {
+    return createScanQueryMetadata({
+      sourceType: 'composite',
+      queryType: 'table',
+      execution: {status: 'supported', method: 'read'},
+      schema: {fields: [], metadata: {}},
+      capabilities: {
+        table: {
+          projection: 'unsupported',
+          predicate: 'unsupported',
+          limit: 'unsupported',
+          streaming: true,
+          cancellation: true
+        }
+      }
+    });
+  }
+
+  /** Emits one deterministic batch through the scan capability. */
+  async *read(): AsyncIterable<string> {
+    yield 'batch';
+  }
+}
+
+test('DataSource capability interfaces compose on one runtime object', async () => {
+  const source = new CompositeSource();
+  const imageSource: ImageSource = source;
+  const rasterSource: RasterSource = source;
+  const tileSource: TileSource = source;
+  const tableScanSource: TableScanSource<string> = source;
+
+  expect((await imageSource.getMetadata()).name).toBe('composite');
+  expect((await rasterSource.getMetadata()).width).toBe(1);
+  expect(await imageSource.getImage(createImageParameters())).toMatchObject({width: 1, height: 1});
+  expect(await rasterSource.getRaster({viewport: createRasterViewport()})).toMatchObject({
+    width: 1,
+    height: 1,
+    bandCount: 1
+  });
+  expect(await tileSource.getTile({x: 1, y: 2, z: 3})).toMatchObject({x: 1, y: 2, z: 3});
+  expect((await tableScanSource.getQueryMetadata()).execution).toEqual({
+    status: 'supported',
+    method: 'read'
+  });
+
+  const batches: string[] = [];
+  for await (const batch of tableScanSource.read()) {
+    batches.push(batch);
+  }
+  expect(batches).toEqual(['batch']);
+});
+
+/** Creates the smallest valid image request. */
+function createImageParameters(): GetImageParameters {
+  return {
+    layers: [],
+    boundingBox: [
+      [0, 0],
+      [1, 1]
+    ],
+    width: 1,
+    height: 1
+  };
+}
+
+/** Creates the smallest valid raster viewport. */
+function createRasterViewport(): GetRasterParameters['viewport'] {
+  return {
+    id: 'composite',
+    width: 1,
+    height: 1,
+    zoom: 0,
+    center: [0, 0],
+    bounds: [
+      [0, 0],
+      [1, 1]
+    ],
+    project: coordinates => coordinates,
+    unprojectPosition: position => position as [number, number, number]
+  };
+}

--- a/modules/services/src/arcgis/arcgis-image-server-source-loader.ts
+++ b/modules/services/src/arcgis/arcgis-image-server-source-loader.ts
@@ -8,10 +8,11 @@ import type {
   CoreAPI,
   SourceLoader,
   DataSourceOptions,
+  ImageSource,
   ImageSourceMetadata,
   GetImageParameters
 } from '@loaders.gl/loader-utils';
-import {DataSource, ImageSource} from '@loaders.gl/loader-utils';
+import {DataSource} from '@loaders.gl/loader-utils';
 import type {LERCData} from '@loaders.gl/lerc';
 import {LERCLoader} from '@loaders.gl/lerc';
 import {buildArcGISResourceURL} from './arcgis-url-utils';

--- a/modules/wms/src/index.ts
+++ b/modules/wms/src/index.ts
@@ -139,7 +139,7 @@ export {DEFAULT_SERVICE_LOADERS, ServiceRequestError, ServiceRuntime} from './se
 export type {ServiceEndpoint, ServiceEndpointPreferences} from './capability-graph';
 export {CapabilityGraph, discoverServiceGraph} from './capability-graph';
 
-export {ImageSource} from '@loaders.gl/loader-utils';
+export {ImageSource} from './lib/deprecated/image-source-compatibility';
 export type {ImageType} from '@loaders.gl/images';
 export {createImageSource} from './lib/deprecated/create-image-source';
 

--- a/modules/wms/src/lib/deprecated/image-source-compatibility.ts
+++ b/modules/wms/src/lib/deprecated/image-source-compatibility.ts
@@ -1,0 +1,28 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {ImageSource as ImageSourceContract} from '@loaders.gl/loader-utils';
+
+/** Type-only image source capability retained by the WMS package. */
+export type ImageSource = ImageSourceContract;
+
+/**
+ * Structural compatibility guard for deck.gl 9.x `instanceof ImageSource` checks.
+ *
+ * @deprecated `ImageSource` is a type-only capability contract. Do not construct or extend this
+ * value; use it only for compatibility with deck.gl versions that still perform the legacy check.
+ */
+export const ImageSource = {
+  /** Recognizes the image-source capability without requiring a shared implementation class. */
+  [Symbol.hasInstance](value: unknown): value is ImageSourceContract {
+    return Boolean(
+      value &&
+        (typeof value === 'object' || typeof value === 'function') &&
+        'getMetadata' in value &&
+        typeof value.getMetadata === 'function' &&
+        'getImage' in value &&
+        typeof value.getImage === 'function'
+    );
+  }
+};

--- a/modules/wms/src/wfs-source-loader.ts
+++ b/modules/wms/src/wfs-source-loader.ts
@@ -10,11 +10,13 @@ import {
 import type {
   CoreAPI,
   DataSourceOptions,
+  SourceLoader,
+  VectorSource,
   VectorSourceMetadata,
   GetFeaturesParameters,
   VectorSourceData
 } from '@loaders.gl/loader-utils';
-import {SourceLoader, DataSource, VectorSource, mergeOptions} from '@loaders.gl/loader-utils';
+import {DataSource, mergeOptions} from '@loaders.gl/loader-utils';
 
 import type {WFSCapabilities} from './wfs-capabilities-loader';
 import {WFSCapabilitiesLoaderWithParser} from './wfs-capabilities-loader-with-parser';

--- a/modules/wms/src/wms-source-loader.ts
+++ b/modules/wms/src/wms-source-loader.ts
@@ -7,10 +7,11 @@ import type {
   CoreAPI,
   SourceLoader,
   DataSourceOptions,
+  ImageSource,
   ImageSourceMetadata,
   GetImageParameters
 } from '@loaders.gl/loader-utils';
-import {DataSource, ImageSource, mergeOptions} from '@loaders.gl/loader-utils';
+import {DataSource, mergeOptions} from '@loaders.gl/loader-utils';
 
 import type {ImageType} from '@loaders.gl/images';
 import {ImageBitmapLoader} from '@loaders.gl/images';

--- a/modules/wms/test/wms/wms-source.spec.ts
+++ b/modules/wms/test/wms/wms-source.spec.ts
@@ -4,7 +4,7 @@
 
 import {expect, test} from 'vitest';
 import {withFetchMock, mockResults, requestInits} from '../test-utils/fetch-spy';
-import {WMSSourceLoader} from '@loaders.gl/wms';
+import {ImageSource, WMSSourceLoader} from '@loaders.gl/wms';
 const WMS_SERVICE_URL = 'https:/mock-wms-service';
 const WMS_VERSION = '1.3.0';
 test('WMSSourceLoader#constructor', async () => {
@@ -13,6 +13,12 @@ test('WMSSourceLoader#constructor', async () => {
   expect(getCapabilitiesUrl, 'getCapabilitiesURL').toBe(
     `https:/mock-wms-service?SERVICE=WMS&VERSION=${WMS_VERSION}&REQUEST=GetCapabilities`
   );
+});
+test('ImageSource legacy runtime guard recognizes the structural capability', () => {
+  const wmsImageSource = WMSSourceLoader.createDataSource(WMS_SERVICE_URL, {});
+
+  expect(wmsImageSource instanceof ImageSource).toBe(true);
+  expect({} instanceof ImageSource).toBe(false);
 });
 test('WMSSourceLoader#getMapURL', async () => {
   let wmsImageSource = WMSSourceLoader.createDataSource(WMS_SERVICE_URL, {});


### PR DESCRIPTION
## Goals

- Make source families composable capabilities while keeping `DataSource` as the single implementation base.
- Avoid prefixed-method API churn and preserve all established operational method names.
- Clarify migration and automatic consumer precedence for multi-capability sources.

## Changes

- Convert `ImageSource`, `VectorSource`, and `RasterSource` from abstract classes to interfaces.
- Remove capability-level `type` and `testURL` statics; source selection remains on `SourceLoader`.
- Export and import the converted contracts as types throughout loader-utils, services, and WMS implementations.
- Add a synthetic `DataSource` conformance test implementing image, raster, tile, and table-scan capabilities.
- Add v5 migration guidance and a composable-source architecture example covering MVT, PMTiles, COPC, GeoTIFF, and `SourceLayer` precedence.
- Retain a deprecated, non-constructible structural `ImageSource` guard in `@loaders.gl/wms` for deck.gl 9.x compatibility.

## Validation

- `yarn lint fix`
- `yarn test-audit` — 0 violations
- `yarn build`
- `yarn build-workers`
- `yarn test-node` — 59 files passed, 386 tests passed, 6 skipped
- `yarn test-headless` — 548 files passed, 1 skipped; 3,578 tests passed, 39 skipped
