### PR TITLE
fix(config): parse YAML aliases and block scalar commas

### DIFF
--- a/modules/config/src/yaml/lib/parsers/parse-yaml.ts
+++ b/modules/config/src/yaml/lib/parsers/parse-yaml.ts
@@ -21,6 +21,7 @@ type YAMLLine = {
 class YAMLParser {
   private readonly lines: YAMLLine[];
   private readonly options: YAMLParseOptions;
+  private readonly anchors = new Map<string, unknown>();
   private lineIndex = 0;
 
   /** Creates a parser for one YAML document. */
@@ -162,9 +163,14 @@ class YAMLParser {
       throw this.error(`Duplicate mapping key: ${keyString}`, this.lineIndex - 1);
     }
     const valueText = entry.slice(separatorIndex + 1).trimStart();
-    result[keyString] = valueText
+    const parsedValue = valueText
       ? this.parseValue(valueText, indent)
       : this.parseNestedValue(indent);
+    if (keyString === '<<') {
+      this.mergeMapping(result, parsedValue);
+    } else {
+      result[keyString] = parsedValue;
+    }
   }
 
   /** Parses a nested block following a mapping or empty sequence item. */
@@ -183,10 +189,15 @@ class YAMLParser {
       const anchoredValue = anchorMatch[2]
         ? this.parseValue(anchorMatch[2], parentIndent)
         : this.parseNestedValue(parentIndent);
+      this.anchors.set(anchorMatch[1], anchoredValue);
       return anchoredValue;
     }
-    if (value.startsWith('*')) {
-      throw this.error(`Unknown YAML alias: ${value.slice(1)}`, this.lineIndex - 1);
+    const aliasMatch = value.match(/^\*([^ ]+)$/);
+    if (aliasMatch) {
+      if (!this.anchors.has(aliasMatch[1])) {
+        throw this.error(`Unknown YAML alias: ${aliasMatch[1]}`, this.lineIndex - 1);
+      }
+      return this.anchors.get(aliasMatch[1]);
     }
     if (
       value === '|' ||
@@ -240,6 +251,18 @@ class YAMLParser {
     return new YAMLFlowParser(key, this.options, message =>
       this.error(message, this.lineIndex - 1)
     ).parse();
+  }
+
+  /** Merges one aliased mapping into a mapping without replacing explicit keys. */
+  private mergeMapping(result: YAMLMapping, value: unknown): void {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+      throw this.error('Merge keys require a mapping alias', this.lineIndex - 1);
+    }
+    for (const [key, entryValue] of Object.entries(value)) {
+      if (!Object.prototype.hasOwnProperty.call(result, key)) {
+        result[key] = entryValue;
+      }
+    }
   }
 
   /** Finds a colon that separates a mapping key from its value. */
@@ -326,7 +349,7 @@ class YAMLFlowParser {
   }
 
   /** Parses a flow collection, quoted scalar, or plain scalar. */
-  private parseValue(stopAtColon = false): unknown {
+  private parseValue({stopAtColon = false, stopAtComma = false} = {}): unknown {
     const character = this.text[this.index];
     if (character === '[') {
       return this.parseArray();
@@ -337,7 +360,7 @@ class YAMLFlowParser {
     if (character === '"' || character === "'") {
       return this.parseQuotedString(character);
     }
-    return this.parseScalar(this.readPlainValue(stopAtColon));
+    return this.parseScalar(this.readPlainValue(stopAtColon, stopAtComma));
   }
 
   /** Parses a flow sequence. */
@@ -350,7 +373,7 @@ class YAMLFlowParser {
         this.index++;
         return result;
       }
-      result.push(this.parseValue());
+      result.push(this.parseValue({stopAtComma: true}));
       this.skipWhitespace();
       if (this.text[this.index] === ',') {
         this.index++;
@@ -370,13 +393,13 @@ class YAMLFlowParser {
         this.index++;
         return result;
       }
-      const key = this.parseValue(true);
+      const key = this.parseValue({stopAtColon: true});
       this.skipWhitespace();
       if (this.text[this.index++] !== ':') {
         throw this.errorFactory('Expected colon in flow mapping');
       }
       this.skipWhitespace();
-      const value = this.parseValue();
+      const value = this.parseValue({stopAtComma: true});
       if (this.options.stringKeys && typeof key !== 'string') {
         throw this.errorFactory('Mapping keys must be strings');
       }
@@ -434,7 +457,7 @@ class YAMLFlowParser {
   }
 
   /** Reads a plain scalar until flow syntax. */
-  private readPlainValue(stopAtColon: boolean): string {
+  private readPlainValue(stopAtColon: boolean, stopAtComma: boolean): string {
     const start = this.index;
     let depth = 0;
     while (this.index < this.text.length) {
@@ -446,7 +469,10 @@ class YAMLFlowParser {
           break;
         }
         depth--;
-      } else if ((character === ',' || (stopAtColon && character === ':')) && depth === 0) {
+      } else if (
+        ((stopAtComma && character === ',') || (stopAtColon && character === ':')) &&
+        depth === 0
+      ) {
         break;
       }
       this.index++;

--- a/modules/config/src/yaml/lib/parsers/parse-yaml.ts
+++ b/modules/config/src/yaml/lib/parsers/parse-yaml.ts
@@ -154,7 +154,8 @@ class YAMLParser {
     if (separatorIndex < 0) {
       throw this.error('Expected a mapping entry', this.lineIndex - 1);
     }
-    const key = this.parseKey(entry.slice(0, separatorIndex).trim());
+    const keyText = entry.slice(0, separatorIndex).trim();
+    const key = this.parseKey(keyText);
     if (this.options.stringKeys && typeof key !== 'string') {
       throw this.error('Mapping keys must be strings', this.lineIndex - 1);
     }
@@ -166,7 +167,7 @@ class YAMLParser {
     const parsedValue = valueText
       ? this.parseValue(valueText, indent)
       : this.parseNestedValue(indent);
-    if (keyString === '<<') {
+    if (keyText === '<<') {
       this.mergeMapping(result, parsedValue);
     } else {
       result[keyString] = parsedValue;
@@ -197,7 +198,7 @@ class YAMLParser {
       if (!this.anchors.has(aliasMatch[1])) {
         throw this.error(`Unknown YAML alias: ${aliasMatch[1]}`, this.lineIndex - 1);
       }
-      return this.anchors.get(aliasMatch[1]);
+      return this.resolveAlias(aliasMatch[1]);
     }
     if (
       value === '|' ||
@@ -215,8 +216,11 @@ class YAMLParser {
     ) {
       return this.parseBlockScalar(parentIndent, value, true);
     }
-    return new YAMLFlowParser(value, this.options, message =>
-      this.error(message, this.lineIndex - 1)
+    return new YAMLFlowParser(
+      value,
+      this.options,
+      message => this.error(message, this.lineIndex - 1),
+      name => this.resolveAlias(name)
     ).parse();
   }
 
@@ -248,19 +252,33 @@ class YAMLParser {
 
   /** Parses a mapping key using the same scalar rules as values. */
   private parseKey(key: string): unknown {
-    return new YAMLFlowParser(key, this.options, message =>
-      this.error(message, this.lineIndex - 1)
+    return new YAMLFlowParser(
+      key,
+      this.options,
+      message => this.error(message, this.lineIndex - 1),
+      name => this.resolveAlias(name)
     ).parse();
   }
 
-  /** Merges one aliased mapping into a mapping without replacing explicit keys. */
-  private mergeMapping(result: YAMLMapping, value: unknown): void {
-    if (!value || typeof value !== 'object' || Array.isArray(value)) {
-      throw this.error('Merge keys require a mapping alias', this.lineIndex - 1);
+  /** Resolves a previously declared anchor. */
+  private resolveAlias(name: string): unknown {
+    if (!this.anchors.has(name)) {
+      throw this.error(`Unknown YAML alias: ${name}`, this.lineIndex - 1);
     }
-    for (const [key, entryValue] of Object.entries(value)) {
-      if (!Object.prototype.hasOwnProperty.call(result, key)) {
-        result[key] = entryValue;
+    return this.anchors.get(name);
+  }
+
+  /** Merges aliased mappings into a mapping without replacing explicit keys. */
+  private mergeMapping(result: YAMLMapping, value: unknown): void {
+    const mappings = Array.isArray(value) ? value : [value];
+    for (const mapping of mappings) {
+      if (!mapping || typeof mapping !== 'object' || Array.isArray(mapping)) {
+        throw this.error('Merge keys require mapping aliases', this.lineIndex - 1);
+      }
+      for (const [key, entryValue] of Object.entries(mapping)) {
+        if (!Object.prototype.hasOwnProperty.call(result, key)) {
+          result[key] = entryValue;
+        }
       }
     }
   }
@@ -328,13 +346,20 @@ class YAMLFlowParser {
   private readonly text: string;
   private readonly options: YAMLParseOptions;
   private readonly errorFactory: (message: string) => Error;
+  private readonly resolveAlias: (name: string) => unknown;
   private index = 0;
 
   /** Creates a flow-value parser. */
-  constructor(text: string, options: YAMLParseOptions, errorFactory: (message: string) => Error) {
+  constructor(
+    text: string,
+    options: YAMLParseOptions,
+    errorFactory: (message: string) => Error,
+    resolveAlias: (name: string) => unknown
+  ) {
     this.text = text;
     this.options = options;
     this.errorFactory = errorFactory;
+    this.resolveAlias = resolveAlias;
   }
 
   /** Parses one value and rejects trailing characters. */
@@ -360,7 +385,24 @@ class YAMLFlowParser {
     if (character === '"' || character === "'") {
       return this.parseQuotedString(character);
     }
+    if (character === '*') {
+      return this.parseAlias();
+    }
     return this.parseScalar(this.readPlainValue(stopAtColon, stopAtComma));
+  }
+
+  /** Parses and resolves an alias inside a flow collection. */
+  private parseAlias(): unknown {
+    this.index++;
+    const start = this.index;
+    while (this.index < this.text.length && !/[\s,\]}]/.test(this.text[this.index])) {
+      this.index++;
+    }
+    const name = this.text.slice(start, this.index);
+    if (!name) {
+      throw this.errorFactory('Expected an alias name');
+    }
+    return this.resolveAlias(name);
   }
 
   /** Parses a flow sequence. */

--- a/modules/config/test/config-parser-boundary.spec.ts
+++ b/modules/config/test/config-parser-boundary.spec.ts
@@ -47,6 +47,29 @@ single: 'it''s fine'
     expect(parseYAMLSync('')).toBeNull();
   });
 
+  test('parses anchors, aliases, merge keys, and commas in block plain scalars', () => {
+    const value = parseYAMLSync(`
+defaults: &defaults
+  color: cyan
+  width: 2
+copy: *defaults
+road:
+  color: purple
+  <<: *defaults
+fill: rgba(136, 45, 23, 0.9)
+flow: [first, second]
+`) as Record<string, unknown>;
+
+    expect(value).toEqual({
+      defaults: {color: 'cyan', width: 2},
+      copy: {color: 'cyan', width: 2},
+      road: {color: 'purple', width: 2},
+      fill: 'rgba(136, 45, 23, 0.9)',
+      flow: ['first', 'second']
+    });
+    expect(value.copy).toBe(value.defaults);
+  });
+
   test.each([
     ['duplicate mapping key', 'a: 1\na: 2', {uniqueKeys: true}, 'Duplicate mapping key'],
     ['unknown alias', 'value: *missing', {}, 'Unknown YAML alias'],

--- a/modules/config/test/config-parser-boundary.spec.ts
+++ b/modules/config/test/config-parser-boundary.spec.ts
@@ -52,18 +52,31 @@ single: 'it''s fine'
 defaults: &defaults
   color: cyan
   width: 2
+secondary: &secondary
+  color: yellow
+  opacity: 0.5
 copy: *defaults
 road:
   color: purple
   <<: *defaults
+combined:
+  <<:
+    - *defaults
+    - *secondary
+flow-aliases: [*defaults, {copy: *secondary}]
+"<<": literal
 fill: rgba(136, 45, 23, 0.9)
 flow: [first, second]
 `) as Record<string, unknown>;
 
     expect(value).toEqual({
       defaults: {color: 'cyan', width: 2},
+      secondary: {color: 'yellow', opacity: 0.5},
       copy: {color: 'cyan', width: 2},
       road: {color: 'purple', width: 2},
+      combined: {color: 'cyan', width: 2, opacity: 0.5},
+      'flow-aliases': [{color: 'cyan', width: 2}, {copy: {color: 'yellow', opacity: 0.5}}],
+      '<<': 'literal',
       fill: 'rgba(136, 45, 23, 0.9)',
       flow: ['first', 'second']
     });


### PR DESCRIPTION
## Goals

- Parse common YAML constructs required by real-world Tangram style documents.
- Preserve strict delimiter handling inside flow collections while accepting commas in block-context plain scalars.
- Close the two @loaders.gl/config gaps found by the tangram.gl comparative parser harness.

## Changes

- Stores block anchors and resolves aliases with the YAML object-identity semantics.
- Applies mapping aliases through the YAML merge key without replacing explicit properties.
- Makes comma termination contextual: commas delimit flow arrays and objects, but remain part of block plain scalars such as rgba(136, 45, 23, 0.9).
- Adds focused conformance coverage for aliases, merge precedence, identity, block scalar commas, and unchanged flow-array parsing.

## Context

Discovered while comparing all classic Tangram YAML styles in visgl/tangram.gl#45. With this change, the two known @loaders.gl/config compatibility gaps in that corpus are addressed.

## Validation

- yarn install
- yarn build
- yarn lint fix
- yarn test-audit
- yarn test-node (405 passed, 6 skipped)
- yarn build-workers
- yarn test-headless (3,949 passed, 39 skipped)
- modules/config test suite (40 passed)
- git diff --check