### PR TITLE
test(coverage): exercise GeoArrow and FlatGeobuf internals

### DIFF
--- a/modules/flatgeobuf/test/flatgeobuf-geometry-boundaries.spec.ts
+++ b/modules/flatgeobuf/test/flatgeobuf-geometry-boundaries.spec.ts
@@ -1,0 +1,332 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {Builder} from 'flatbuffers';
+import {expect, test, vi} from 'vitest';
+import {convertWKBToGeometry, WKBBuilder} from '@loaders.gl/gis';
+import {
+  decodeFlatGeobufGeometry,
+  FlatGeobufGeometryType,
+  getFlatGeobufGeometryBounds,
+  type FlatGeobufHeader,
+  writeFlatGeobufGeometry,
+  writeFlatGeobufGeometryToWKB
+} from '../src/lib/flatgeobuf-reader';
+
+type GeometryFixture = {
+  arrayBuffer: ArrayBuffer;
+  geometryOffset: number;
+};
+
+type GeometryDescription = {
+  type: FlatGeobufGeometryType;
+  xy?: number[];
+  z?: number[];
+  ends?: number[];
+  parts?: GeometryDescription[];
+};
+
+const BASE_HEADER: FlatGeobufHeader = {
+  geometryType: FlatGeobufGeometryType.Unknown,
+  hasZ: false,
+  columns: [],
+  featuresCount: 0,
+  indexNodeSize: 0,
+  headerLength: 0,
+  featureOffset: 0
+};
+
+/** Creates a FlatBuffers numeric vector in reverse builder order. */
+function createNumericVector(
+  builder: Builder,
+  values: number[] | undefined,
+  byteWidth: 4 | 8
+): number {
+  if (!values) return 0;
+  builder.startVector(byteWidth, values.length, byteWidth);
+  for (let index = values.length - 1; index >= 0; index--) {
+    if (byteWidth === 8) builder.addFloat64(values[index]);
+    else builder.addInt32(values[index]);
+  }
+  return builder.endVector();
+}
+
+/** Builds one FlatGeobuf Geometry table, including recursively nested parts. */
+function createGeometryTable(builder: Builder, description: GeometryDescription): number {
+  const partOffsets = (description.parts || []).map(part => createGeometryTable(builder, part));
+  let parts = 0;
+  if (partOffsets.length > 0) {
+    builder.startVector(4, partOffsets.length, 4);
+    for (let index = partOffsets.length - 1; index >= 0; index--) {
+      builder.addOffset(partOffsets[index]);
+    }
+    parts = builder.endVector();
+  }
+  const xy = createNumericVector(builder, description.xy, 8);
+  const z = createNumericVector(builder, description.z, 8);
+  const ends = createNumericVector(builder, description.ends, 4);
+  builder.startObject(8);
+  if (ends) builder.addFieldOffset(0, ends, 0);
+  if (xy) builder.addFieldOffset(1, xy, 0);
+  if (z) builder.addFieldOffset(2, z, 0);
+  builder.addFieldInt8(6, description.type, 0);
+  if (parts) builder.addFieldOffset(7, parts, 0);
+  return builder.endObject();
+}
+
+/** Creates a standalone FlatGeobuf Geometry table fixture. */
+function createGeometryFixture(description: GeometryDescription): GeometryFixture {
+  const builder = new Builder(256);
+  const root = createGeometryTable(builder, description);
+  builder.finish(root);
+  const bytes = builder.asUint8Array().slice();
+  const arrayBuffer = bytes.buffer as ArrayBuffer;
+  return {
+    arrayBuffer,
+    geometryOffset: new DataView(arrayBuffer).getUint32(0, true)
+  };
+}
+
+/** Creates a recording GeoArrow builder surface for direct writer assertions. */
+function createRecordingBuilder(): any {
+  return {
+    writeNullGeometry: vi.fn(),
+    beginPoint: vi.fn(),
+    beginMultiPoint: vi.fn(),
+    beginLineString: vi.fn(),
+    beginMultiLineString: vi.fn(),
+    beginPolygon: vi.fn(),
+    beginLinearRing: vi.fn(),
+    beginMultiPolygon: vi.fn(),
+    writeCoordinate: vi.fn()
+  };
+}
+
+/** Writes a fixture through the two-pass WKB builder and returns its bytes. */
+function writeFixtureToWKB(
+  fixture: GeometryFixture,
+  header: FlatGeobufHeader,
+  geometryTypeOverride?: FlatGeobufGeometryType
+): Uint8Array {
+  const measure = new WKBBuilder({mode: 'measure', hasZ: header.hasZ});
+  writeFlatGeobufGeometryToWKB(
+    measure,
+    fixture.arrayBuffer,
+    fixture.geometryOffset,
+    header,
+    geometryTypeOverride
+  );
+  const byteLength = measure.finishGeometry();
+  const bytes = new Uint8Array(byteLength);
+  const writer = new WKBBuilder({mode: 'write', target: bytes, hasZ: header.hasZ});
+  writeFlatGeobufGeometryToWKB(
+    writer,
+    fixture.arrayBuffer,
+    fixture.geometryOffset,
+    header,
+    geometryTypeOverride
+  );
+  writer.finishGeometry();
+  return bytes;
+}
+
+test.each([
+  [FlatGeobufGeometryType.Point, [1, 2], undefined, {type: 'Point', coordinates: [1, 2]}],
+  [
+    FlatGeobufGeometryType.MultiPoint,
+    [1, 2, 3, 4],
+    undefined,
+    {
+      type: 'MultiPoint',
+      coordinates: [
+        [1, 2],
+        [3, 4]
+      ]
+    }
+  ],
+  [
+    FlatGeobufGeometryType.LineString,
+    [0, 0, 2, 3],
+    undefined,
+    {
+      type: 'LineString',
+      coordinates: [
+        [0, 0],
+        [2, 3]
+      ]
+    }
+  ],
+  [
+    FlatGeobufGeometryType.MultiLineString,
+    [0, 0, 1, 1, 2, 2],
+    [2, 3],
+    {
+      type: 'MultiLineString',
+      coordinates: [
+        [
+          [0, 0],
+          [1, 1]
+        ],
+        [[2, 2]]
+      ]
+    }
+  ],
+  [
+    FlatGeobufGeometryType.Polygon,
+    [0, 0, 1, 0, 0, 0],
+    [3],
+    {
+      type: 'Polygon',
+      coordinates: [
+        [
+          [0, 0],
+          [1, 0],
+          [0, 0]
+        ]
+      ]
+    }
+  ]
+] as const)('FlatGeobuf direct geometry writers cover type %s', (type, xy, ends, expectedGeometry) => {
+  const fixture = createGeometryFixture({type, xy: [...xy], ends: ends ? [...ends] : undefined});
+  const builder = createRecordingBuilder();
+  writeFlatGeobufGeometry(builder, fixture.arrayBuffer, fixture.geometryOffset, BASE_HEADER);
+  expect(builder.writeCoordinate).toHaveBeenCalledTimes(xy.length / 2);
+  expect(
+    decodeFlatGeobufGeometry(fixture.arrayBuffer, fixture.geometryOffset, BASE_HEADER)
+  ).toEqual(expectedGeometry);
+  expect(
+    getFlatGeobufGeometryBounds(fixture.arrayBuffer, fixture.geometryOffset, BASE_HEADER)
+  ).toEqual([
+    Math.min(...xy.filter((_, index) => index % 2 === 0)),
+    Math.min(...xy.filter((_, index) => index % 2 === 1)),
+    Math.max(...xy.filter((_, index) => index % 2 === 0)),
+    Math.max(...xy.filter((_, index) => index % 2 === 1))
+  ]);
+  expect(convertWKBToGeometry(writeFixtureToWKB(fixture, BASE_HEADER).buffer)).toEqual(
+    expectedGeometry
+  );
+});
+
+test('FlatGeobuf geometry writers preserve Z coordinates and default missing part ends', () => {
+  const fixture = createGeometryFixture({
+    type: FlatGeobufGeometryType.LineString,
+    xy: [1, 2, 3, 4],
+    z: [5, 6]
+  });
+  const header = {...BASE_HEADER, hasZ: true};
+  const builder = createRecordingBuilder();
+  writeFlatGeobufGeometry(builder, fixture.arrayBuffer, fixture.geometryOffset, header);
+  expect(builder.writeCoordinate.mock.calls).toEqual([
+    [1, 2, 5],
+    [3, 4, 6]
+  ]);
+  expect(decodeFlatGeobufGeometry(fixture.arrayBuffer, fixture.geometryOffset, header)).toEqual({
+    type: 'LineString',
+    coordinates: [
+      [1, 2, 5],
+      [3, 4, 6]
+    ]
+  });
+});
+
+test('FlatGeobuf nested multipolygon and collection writers recurse through part tables', () => {
+  const polygon = {
+    type: FlatGeobufGeometryType.Polygon,
+    xy: [0, 0, 2, 0, 0, 0],
+    ends: [3]
+  };
+  const multiPolygon = createGeometryFixture({
+    type: FlatGeobufGeometryType.MultiPolygon,
+    parts: [polygon, {...polygon, xy: [3, 3, 4, 3, 3, 3]}]
+  });
+  const builder = createRecordingBuilder();
+  writeFlatGeobufGeometry(
+    builder,
+    multiPolygon.arrayBuffer,
+    multiPolygon.geometryOffset,
+    BASE_HEADER
+  );
+  expect(builder.beginMultiPolygon).toHaveBeenCalledWith(2);
+  expect(builder.beginPolygon).toHaveBeenCalledTimes(2);
+  expect(
+    getFlatGeobufGeometryBounds(multiPolygon.arrayBuffer, multiPolygon.geometryOffset, BASE_HEADER)
+  ).toEqual([0, 0, 4, 3]);
+  expect(convertWKBToGeometry(writeFixtureToWKB(multiPolygon, BASE_HEADER).buffer)?.type).toBe(
+    'MultiPolygon'
+  );
+
+  const collection = createGeometryFixture({
+    type: FlatGeobufGeometryType.GeometryCollection,
+    parts: [
+      {type: FlatGeobufGeometryType.Point, xy: [8, 9]},
+      {type: FlatGeobufGeometryType.LineString, xy: [-1, -2, 3, 4]}
+    ]
+  });
+  expect(convertWKBToGeometry(writeFixtureToWKB(collection, BASE_HEADER).buffer)).toEqual({
+    type: 'GeometryCollection',
+    geometries: [
+      {type: 'Point', coordinates: [8, 9]},
+      {
+        type: 'LineString',
+        coordinates: [
+          [-1, -2],
+          [3, 4]
+        ]
+      }
+    ]
+  });
+  expect(
+    getFlatGeobufGeometryBounds(collection.arrayBuffer, collection.geometryOffset, BASE_HEADER)
+  ).toEqual([-1, -2, 8, 9]);
+});
+
+test('FlatGeobuf geometry boundary errors are explicit and absent geometries stay absent', () => {
+  const empty = createGeometryFixture({type: FlatGeobufGeometryType.Point});
+  expect(getFlatGeobufGeometryBounds(empty.arrayBuffer, undefined, BASE_HEADER)).toBeUndefined();
+  expect(
+    getFlatGeobufGeometryBounds(empty.arrayBuffer, empty.geometryOffset, BASE_HEADER)
+  ).toBeUndefined();
+  expect(() =>
+    writeFlatGeobufGeometryToWKB(
+      new WKBBuilder({mode: 'measure'}),
+      empty.arrayBuffer,
+      undefined,
+      BASE_HEADER
+    )
+  ).toThrow('Cannot write an absent');
+
+  const builder = createRecordingBuilder();
+  writeFlatGeobufGeometry(builder, empty.arrayBuffer, undefined, BASE_HEADER);
+  expect(builder.writeNullGeometry).toHaveBeenCalledOnce();
+
+  const unsupported = createGeometryFixture({type: FlatGeobufGeometryType.GeometryCollection});
+  expect(() =>
+    writeFlatGeobufGeometry(
+      builder,
+      unsupported.arrayBuffer,
+      unsupported.geometryOffset,
+      BASE_HEADER
+    )
+  ).toThrow('Unsupported FlatGeobuf geometry type');
+  expect(() =>
+    decodeFlatGeobufGeometry(unsupported.arrayBuffer, unsupported.geometryOffset, BASE_HEADER)
+  ).toThrow('Unsupported FlatGeobuf geometry type');
+
+  const noParts = createGeometryFixture({type: FlatGeobufGeometryType.MultiPolygon});
+  expect(() =>
+    writeFlatGeobufGeometry(builder, noParts.arrayBuffer, noParts.geometryOffset, BASE_HEADER)
+  ).toThrow('has no polygon parts');
+  expect(() =>
+    writeFlatGeobufGeometryToWKB(
+      new WKBBuilder({mode: 'measure'}),
+      noParts.arrayBuffer,
+      noParts.geometryOffset,
+      BASE_HEADER
+    )
+  ).toThrow('has no polygon parts');
+
+  expect(
+    decodeFlatGeobufGeometry(noParts.arrayBuffer, noParts.geometryOffset, BASE_HEADER)
+  ).toEqual({type: 'MultiPolygon', coordinates: [[[]]]});
+});

--- a/modules/geoarrow/src/lib/kernels/decode-wkt-native.ts
+++ b/modules/geoarrow/src/lib/kernels/decode-wkt-native.ts
@@ -552,7 +552,11 @@ class WKTParser {
         this.geometryCollectionDepth--;
         break;
     }
-    if (coordinates === null || (coordinates === undefined && geometries === undefined))
+    if (
+      coordinates === null ||
+      geometries === null ||
+      (coordinates === undefined && geometries === undefined)
+    )
       return null;
     if (!this.readCharacter(')')) return null;
 

--- a/modules/geoarrow/test/geoarrow-adapter-boundaries.spec.ts
+++ b/modules/geoarrow/test/geoarrow-adapter-boundaries.spec.ts
@@ -1,0 +1,366 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import * as arrow from 'apache-arrow';
+import {expect, test} from 'vitest';
+import {
+  inferGeoArrowCoordinateLayoutFromArrowType,
+  inferGeoArrowDimensionFromArrowType,
+  inferGeoArrowEncodingFromArrowType,
+  makeArrowVectorFromGeoArrowColumn,
+  makeGeoArrowColumnFromArrowVector
+} from '../src/lib/arrow-geoarrow-adapter';
+
+/** Creates a coordinate field with an optional semantic dimension child name. */
+function makeCoordinateType(size: number, childName = 'item'): arrow.FixedSizeList {
+  return new arrow.FixedSizeList(size, new arrow.Field(childName, new arrow.Float64(), true));
+}
+
+/** Wraps one type in the requested number of variable-length list levels. */
+function nestListType(type: arrow.DataType, depth: number, large = false): arrow.DataType {
+  let nestedType = type;
+  for (let index = 0; index < depth; index++) {
+    const field = new arrow.Field('item', nestedType, true);
+    nestedType = large ? new arrow.LargeList(field) : new arrow.List(field);
+  }
+  return nestedType;
+}
+
+/** Converts Arrow row wrappers and typed arrays into stable assertion values. */
+function normalizeArrowValue(value: any): unknown {
+  if (value == null) return value;
+  if (typeof value.toJSON === 'function') return normalizeArrowValue(value.toJSON());
+  if (ArrayBuffer.isView(value)) return Array.from(value as ArrayLike<unknown>);
+  if (Array.isArray(value)) return value.map(normalizeArrowValue);
+  if (typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, child]) => [key, normalizeArrowValue(child)])
+    );
+  }
+  return value;
+}
+
+test('Arrow adapter infers every serialized, union, and native encoding family', () => {
+  const serializedCases: [arrow.DataType, string][] = [
+    [new arrow.Binary(), 'geoarrow.wkb'],
+    [new arrow.LargeBinary(), 'geoarrow.wkb'],
+    [new arrow.BinaryView(), 'geoarrow.wkb'],
+    [new arrow.Utf8(), 'geoarrow.wkt'],
+    [new arrow.LargeUtf8(), 'geoarrow.wkt'],
+    [new arrow.Utf8View(), 'geoarrow.wkt']
+  ];
+  for (const [type, encoding] of serializedCases) {
+    expect(inferGeoArrowEncodingFromArrowType(type)).toBe(encoding);
+  }
+
+  const coordinate = makeCoordinateType(2);
+  expect(inferGeoArrowEncodingFromArrowType(coordinate)).toBe('geoarrow.point');
+  expect(inferGeoArrowEncodingFromArrowType(nestListType(coordinate, 1))).toBe(
+    'geoarrow.linestring'
+  );
+  expect(inferGeoArrowEncodingFromArrowType(nestListType(coordinate, 2, true))).toBe(
+    'geoarrow.polygon'
+  );
+  expect(inferGeoArrowEncodingFromArrowType(nestListType(coordinate, 3))).toBe(
+    'geoarrow.multipolygon'
+  );
+  const union = new arrow.DenseUnion([1], [new arrow.Field('Point', coordinate, true)]);
+  expect(inferGeoArrowEncodingFromArrowType(union)).toBe('geoarrow.geometry');
+  expect(() => inferGeoArrowEncodingFromArrowType(nestListType(coordinate, 4))).toThrow(
+    'Cannot infer GeoArrow encoding'
+  );
+  expect(() => inferGeoArrowEncodingFromArrowType(new arrow.Int32())).toThrow(
+    'does not terminate in coordinates'
+  );
+});
+
+test('Arrow adapter infers dimensions from child names, widths, nesting, and mixed unions', () => {
+  expect(inferGeoArrowDimensionFromArrowType(makeCoordinateType(2, 'xy'))).toBe('xy');
+  expect(inferGeoArrowDimensionFromArrowType(makeCoordinateType(3, 'xyz'))).toBe('xyz');
+  expect(inferGeoArrowDimensionFromArrowType(makeCoordinateType(3, 'xym'))).toBe('xym');
+  expect(inferGeoArrowDimensionFromArrowType(makeCoordinateType(4, 'xyzm'))).toBe('xyzm');
+  expect(inferGeoArrowDimensionFromArrowType(makeCoordinateType(3))).toBe('xyz');
+  expect(inferGeoArrowDimensionFromArrowType(makeCoordinateType(4))).toBe('xyzm');
+  expect(() => inferGeoArrowDimensionFromArrowType(makeCoordinateType(5))).toThrow(
+    'require 2, 3, or 4 values'
+  );
+
+  const separatedCases: [string[], string][] = [
+    [['x', 'y'], 'xy'],
+    [['x', 'y', 'z'], 'xyz'],
+    [['x', 'y', 'm'], 'xym'],
+    [['x', 'y', 'z', 'm'], 'xyzm']
+  ];
+  for (const [names, dimension] of separatedCases) {
+    const type = new arrow.Struct(
+      names.map(name => new arrow.Field(name, new arrow.Float64(), true))
+    );
+    expect(inferGeoArrowDimensionFromArrowType(type)).toBe(dimension);
+    expect(inferGeoArrowCoordinateLayoutFromArrowType(type)).toBe('separated');
+  }
+
+  expect(inferGeoArrowDimensionFromArrowType(nestListType(makeCoordinateType(2), 2))).toBe('xy');
+  const mixedUnion = new arrow.DenseUnion(
+    [1, 12, 23, 34],
+    [
+      new arrow.Field('Point', makeCoordinateType(2), true),
+      new arrow.Field('LineString Z', nestListType(makeCoordinateType(3), 1), true),
+      new arrow.Field('Polygon M', nestListType(makeCoordinateType(3, 'xym'), 2), true),
+      new arrow.Field('MultiPoint ZM', nestListType(makeCoordinateType(4), 1), true)
+    ]
+  );
+  expect(inferGeoArrowDimensionFromArrowType(mixedUnion)).toBe('xyzm');
+  expect(inferGeoArrowCoordinateLayoutFromArrowType(mixedUnion)).toBe('interleaved');
+  expect(inferGeoArrowCoordinateLayoutFromArrowType(new arrow.Int32())).toBeNull();
+  expect(() => inferGeoArrowDimensionFromArrowType(new arrow.Int32())).toThrow(
+    'Cannot infer GeoArrow dimension'
+  );
+});
+
+test('Arrow adapter round-trips sliced native, serialized, nullable, and large-offset vectors', () => {
+  const coordinate = makeCoordinateType(2);
+  const vectors = [
+    arrow.vectorFromArray([[1, 2], null, [3, 4]], coordinate).slice(1, 3),
+    arrow.vectorFromArray([Uint8Array.of(1, 2), null], new arrow.Binary()),
+    arrow.vectorFromArray([Uint8Array.of(3, 4), null], new arrow.LargeBinary()),
+    arrow.vectorFromArray(['a', null, 'bc'], new arrow.Utf8()),
+    arrow.vectorFromArray(['large', null], new arrow.LargeUtf8()),
+    arrow
+      .vectorFromArray(
+        [
+          [
+            [1, 2],
+            [3, 4]
+          ],
+          null,
+          [[5, 6]]
+        ],
+        nestListType(coordinate, 1) as arrow.List
+      )
+      .slice(1, 3)
+  ];
+
+  for (const vector of vectors) {
+    const column = makeGeoArrowColumnFromArrowVector(vector);
+    const roundTrip = makeArrowVectorFromGeoArrowColumn(column);
+    expect(roundTrip.length).toBe(vector.length);
+    expect(roundTrip.type.toString()).toBe(vector.type.toString());
+    expect(
+      Array.from({length: vector.length}, (_, index) => normalizeArrowValue(roundTrip.get(index)))
+    ).toEqual(
+      Array.from({length: vector.length}, (_, index) => normalizeArrowValue(vector.get(index)))
+    );
+  }
+});
+
+test('Arrow adapter emits every primitive Arrow type and packs strided values', () => {
+  const arrays = [
+    new Int8Array([1]),
+    new Uint8Array([1]),
+    new Uint8ClampedArray([1]),
+    new Int16Array([1]),
+    new Uint16Array([1]),
+    new Int32Array([1]),
+    new Uint32Array([1]),
+    new BigInt64Array([1n]),
+    new BigUint64Array([1n]),
+    new Float32Array([1]),
+    new Float64Array([1])
+  ];
+  for (const values of arrays) {
+    const vector = makeArrowVectorFromGeoArrowColumn({
+      encoding: 'geoarrow.point',
+      dimension: 'xy',
+      coordinateLayout: 'interleaved',
+      chunks: [{kind: 'primitive', length: 1, values}]
+    } as any);
+    expect(vector.length).toBe(1);
+  }
+
+  const strided = makeArrowVectorFromGeoArrowColumn({
+    encoding: 'geoarrow.point',
+    dimension: 'xy',
+    coordinateLayout: 'interleaved',
+    chunks: [
+      {
+        kind: 'primitive',
+        length: 2,
+        values: Float64Array.of(0, 10, 1, 20, 2),
+        offset: 1,
+        stride: 2
+      }
+    ]
+  } as any);
+  expect(Array.from(strided.toArray())).toEqual([10, 20]);
+
+  const unsupportedValues = {
+    0: 1,
+    length: 1,
+    constructor: {name: 'UnsupportedNumericArray'},
+    subarray() {
+      return this;
+    }
+  };
+  expect(() =>
+    makeArrowVectorFromGeoArrowColumn({
+      encoding: 'geoarrow.point',
+      dimension: 'xy',
+      coordinateLayout: 'interleaved',
+      chunks: [{kind: 'primitive', length: 1, values: unsupportedValues}]
+    } as any)
+  ).toThrow('Unsupported GeoArrow primitive values');
+});
+
+test('Arrow adapter normalizes offsets, sliced children, Struct children, and validity bitmaps', () => {
+  const primitive = {kind: 'primitive', length: 6, values: Float64Array.of(0, 1, 2, 3, 4, 5)};
+  const fixed = makeArrowVectorFromGeoArrowColumn({
+    encoding: 'geoarrow.point',
+    dimension: 'xy',
+    coordinateLayout: 'interleaved',
+    chunks: [
+      {
+        kind: 'fixed-size-list',
+        length: 2,
+        size: 2,
+        offset: 1,
+        child: primitive,
+        validity: {values: Uint8Array.of(0b00000100), bitOffset: 1}
+      }
+    ]
+  } as any);
+  expect(fixed.length).toBe(2);
+  expect(fixed.nullCount).toBe(1);
+
+  const list = makeArrowVectorFromGeoArrowColumn({
+    encoding: 'geoarrow.linestring',
+    dimension: 'xy',
+    coordinateLayout: 'interleaved',
+    chunks: [
+      {
+        kind: 'list',
+        length: 1,
+        offsets: Int32Array.of(2, 4),
+        offsetBase: 2,
+        child: {
+          kind: 'fixed-size-list',
+          length: 2,
+          size: 2,
+          child: {kind: 'primitive', length: 4, values: Float64Array.of(1, 2, 3, 4)}
+        }
+      }
+    ]
+  } as any);
+  expect(list.type).toBeInstanceOf(arrow.List);
+  expect(list.get(0)?.length).toBe(2);
+
+  const largeList = makeArrowVectorFromGeoArrowColumn({
+    encoding: 'geoarrow.linestring',
+    dimension: 'xy',
+    coordinateLayout: 'interleaved',
+    chunks: [
+      {
+        kind: 'list',
+        length: 1,
+        offsets: BigInt64Array.of(5n, 6n),
+        offsetBase: 5n,
+        child: {
+          kind: 'fixed-size-list',
+          length: 1,
+          size: 2,
+          child: {kind: 'primitive', length: 2, values: Float64Array.of(7, 8)}
+        }
+      }
+    ]
+  } as any);
+  expect(largeList.type).toBeInstanceOf(arrow.LargeList);
+
+  const struct = makeArrowVectorFromGeoArrowColumn({
+    encoding: 'geoarrow.point',
+    dimension: 'xy',
+    coordinateLayout: 'separated',
+    chunks: [
+      {
+        kind: 'struct',
+        length: 1,
+        offset: 1,
+        children: {
+          x: {kind: 'primitive', length: 2, values: Float64Array.of(1, 9)},
+          y: {kind: 'primitive', length: 2, values: Float64Array.of(2, 8)}
+        }
+      }
+    ]
+  } as any);
+  expect(struct.get(0)?.x).toBe(9);
+  expect(struct.get(0)?.y).toBe(8);
+});
+
+test('Arrow adapter validates dense-union null carriers and dimension suffixes', () => {
+  const validUnion = makeArrowVectorFromGeoArrowColumn({
+    encoding: 'geoarrow.geometry',
+    dimension: 'xyz',
+    coordinateLayout: 'interleaved',
+    chunks: [
+      {
+        kind: 'dense-union',
+        length: 1,
+        typeIds: Uint8Array.of(1),
+        valueOffsets: Int32Array.of(0),
+        children: [
+          {
+            name: 'Point',
+            typeId: 1,
+            dimension: 'xyz',
+            data: {
+              kind: 'fixed-size-list',
+              length: 1,
+              size: 3,
+              child: {kind: 'primitive', length: 3, values: Float64Array.of(1, 2, 3)}
+            }
+          }
+        ]
+      }
+    ]
+  } as any);
+  expect(validUnion.type).toBeInstanceOf(arrow.DenseUnion);
+  expect((validUnion.type as arrow.DenseUnion).children[0].name).toBe('Point Z');
+
+  const malformedNullCases = [
+    {typeIds: Uint8Array.of(9), valueOffsets: Int32Array.of(0)},
+    {typeIds: Uint8Array.of(1), valueOffsets: Int32Array.of(-1)},
+    {typeIds: Uint8Array.of(1), valueOffsets: Int32Array.of(1)},
+    {typeIds: Uint8Array.of(1), valueOffsets: Int32Array.of(0), childValidity: undefined},
+    {typeIds: Uint8Array.of(1), valueOffsets: Int32Array.of(0), childValidity: Uint8Array.of(1)}
+  ];
+  for (const malformed of malformedNullCases) {
+    expect(() =>
+      makeArrowVectorFromGeoArrowColumn({
+        encoding: 'geoarrow.geometry',
+        dimension: 'xy',
+        coordinateLayout: 'interleaved',
+        chunks: [
+          {
+            kind: 'dense-union',
+            length: 1,
+            validity: {values: Uint8Array.of(0)},
+            typeIds: malformed.typeIds,
+            valueOffsets: malformed.valueOffsets,
+            children: [
+              {
+                name: 'Point',
+                typeId: 1,
+                data: {
+                  kind: 'fixed-size-list',
+                  length: 1,
+                  size: 2,
+                  validity: malformed.childValidity ? {values: malformed.childValidity} : undefined,
+                  child: {kind: 'primitive', length: 2, values: Float64Array.of(1, 2)}
+                }
+              }
+            ]
+          }
+        ]
+      } as any)
+    ).toThrow('dense-union null');
+  }
+});

--- a/modules/geoarrow/test/geoarrow-converter-fallback.spec.ts
+++ b/modules/geoarrow/test/geoarrow-converter-fallback.spec.ts
@@ -1,0 +1,278 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import * as arrow from 'apache-arrow';
+import {expect, test, vi} from 'vitest';
+import type {GeoArrowEncoding} from '@loaders.gl/schema';
+
+vi.mock('../src/lib/kernels/decode-wkt-native', async importOriginal => {
+  const original = await importOriginal<typeof import('../src/lib/kernels/decode-wkt-native')>();
+  return {
+    ...original,
+    decodeWKTNativeVector: vi.fn(() => null),
+    decodeWKTUnionVector: vi.fn(() => null),
+    decodeWKTGeometryCollectionVector: vi.fn(() => null)
+  };
+});
+
+/** Loads the converter after the optimized WKT kernels have been replaced by declining kernels. */
+async function loadFallbackConverter(): Promise<
+  typeof import('../src/geoarrow-converter/convert-geoarrow-geometry')
+> {
+  return await import('../src/geoarrow-converter/convert-geoarrow-geometry');
+}
+
+test.each([
+  ['geoarrow.point', 'POINT (1 2)', 'FixedSizeList[2]'],
+  ['geoarrow.linestring', 'LINESTRING (0 0, 1 1)', 'List'],
+  ['geoarrow.polygon', 'POLYGON ((0 0, 1 0, 0 0))', 'List'],
+  ['geoarrow.multipoint', 'MULTIPOINT ((1 2), (3 4))', 'List'],
+  ['geoarrow.multilinestring', 'MULTILINESTRING ((0 0, 1 1))', 'List'],
+  ['geoarrow.multipolygon', 'MULTIPOLYGON (((0 0, 1 0, 0 0)))', 'List']
+] as const)('compatibility fallback converts WKT to %s interleaved coordinates', async (targetEncoding, wkt, expectedType) => {
+  const {convertGeoArrowVector} = await loadFallbackConverter();
+  const result = convertGeoArrowVector(
+    arrow.vectorFromArray([wkt, null], new arrow.Utf8()),
+    'geoarrow.wkt',
+    targetEncoding,
+    {fallback: 'geojson'}
+  );
+  expect(result.length).toBe(2);
+  expect(result.type.toString()).toContain(expectedType);
+  expect(result.get(1)).toBeNull();
+});
+
+test.each([
+  ['geoarrow.point', 'POINT ZM (1 2 3 4)'],
+  ['geoarrow.linestring', 'LINESTRING ZM (0 1 2 3, 4 5 6 7)'],
+  ['geoarrow.polygon', 'POLYGON ZM ((0 0 1 2, 1 0 3 4, 0 0 1 2))'],
+  ['geoarrow.multipoint', 'MULTIPOINT ZM ((1 2 3 4), (5 6 7 8))'],
+  ['geoarrow.multilinestring', 'MULTILINESTRING ZM ((0 0 1 2, 3 4 5 6))'],
+  ['geoarrow.multipolygon', 'MULTIPOLYGON ZM (((0 0 1 2, 1 0 3 4, 0 0 1 2)))']
+] as const)('compatibility fallback converts WKT to separated large-offset %s coordinates', async (targetEncoding, wkt) => {
+  const {convertGeoArrowVector} = await loadFallbackConverter();
+  const result = convertGeoArrowVector(
+    arrow.vectorFromArray([wkt], new arrow.Utf8()),
+    'geoarrow.wkt',
+    targetEncoding,
+    {
+      fallback: 'geojson',
+      coordinates: 'separated',
+      dimension: 'xyzm',
+      offsetType: 'int64'
+    }
+  );
+  expect(result.length).toBe(1);
+  expect(result.type.toString()).toMatch(/Struct|LargeList/);
+});
+
+test('compatibility fallback builds a dense union with every geometry family and null carrier', async () => {
+  const {convertGeoArrowVector, convertGeoArrowVectorCellToGeoJSON} = await loadFallbackConverter();
+  const wkts = [
+    'POINT (1 2)',
+    'LINESTRING (0 0, 1 1)',
+    'POLYGON ((0 0, 1 0, 0 0))',
+    'MULTIPOINT ((1 2), (3 4))',
+    'MULTILINESTRING ((0 0, 1 1))',
+    'MULTIPOLYGON (((0 0, 1 0, 0 0)))',
+    'GEOMETRYCOLLECTION (POINT (9 8), LINESTRING (1 2, 3 4))',
+    null
+  ];
+  const union = convertGeoArrowVector(
+    arrow.vectorFromArray(wkts, new arrow.Utf8()),
+    'geoarrow.wkt',
+    'geoarrow.geometry',
+    {
+      fallback: 'geojson',
+      geometryTypes: [
+        'Point',
+        'LineString',
+        'Polygon',
+        'MultiPoint',
+        'MultiLineString',
+        'MultiPolygon',
+        'GeometryCollection'
+      ]
+    }
+  );
+
+  expect(union.type).toBeInstanceOf(arrow.DenseUnion);
+  expect((union.type as arrow.DenseUnion).children.map(field => field.name)).toEqual([
+    'Point',
+    'LineString',
+    'Polygon',
+    'MultiPoint',
+    'MultiLineString',
+    'MultiPolygon',
+    'GeometryCollection'
+  ]);
+  expect(
+    wkts.map(
+      (_, rowIndex) =>
+        convertGeoArrowVectorCellToGeoJSON(union, rowIndex, 'geoarrow.geometry')?.type || null
+    )
+  ).toEqual([
+    'Point',
+    'LineString',
+    'Polygon',
+    'MultiPoint',
+    'MultiLineString',
+    'MultiPolygon',
+    'GeometryCollection',
+    null
+  ]);
+});
+
+test('compatibility fallback builds nullable separated GeometryCollections with large offsets', async () => {
+  const {convertGeoArrowVector, convertGeoArrowVectorCellToGeoJSON} = await loadFallbackConverter();
+  const collection = convertGeoArrowVector(
+    arrow.vectorFromArray(
+      [
+        'GEOMETRYCOLLECTION (POINT Z (1 2 3), LINESTRING Z (0 0 0, 1 1 1))',
+        'GEOMETRYCOLLECTION EMPTY',
+        null
+      ],
+      new arrow.Utf8()
+    ),
+    'geoarrow.wkt',
+    'geoarrow.geometrycollection',
+    {
+      fallback: 'geojson',
+      coordinates: 'separated',
+      dimension: 'xyz',
+      offsetType: 'int64',
+      geometryTypes: ['GeometryCollection Z']
+    }
+  );
+
+  expect(collection.type).toBeInstanceOf(arrow.LargeList);
+  expect(collection.nullCount).toBe(1);
+  expect(convertGeoArrowVectorCellToGeoJSON(collection, 0, 'geoarrow.geometrycollection')).toEqual({
+    type: 'GeometryCollection',
+    geometries: [
+      {type: 'Point', coordinates: [1, 2, 3]},
+      {
+        type: 'LineString',
+        coordinates: [
+          [0, 0, 0],
+          [1, 1, 1]
+        ]
+      }
+    ]
+  });
+  expect(convertGeoArrowVectorCellToGeoJSON(collection, 1, 'geoarrow.geometrycollection')).toEqual({
+    type: 'GeometryCollection',
+    geometries: []
+  });
+  expect(
+    convertGeoArrowVectorCellToGeoJSON(collection, 2, 'geoarrow.geometrycollection')
+  ).toBeNull();
+});
+
+test('compatibility fallback preserves WKT coordinate arity through WKB and back', async () => {
+  const {convertGeoArrowVector} = await loadFallbackConverter();
+  const source = arrow.vectorFromArray(
+    ['POINT (1 2)', 'POINT Z (3 4 5)', 'POINT M (6 7 8)', 'POINT ZM (9 10 11 12)', null],
+    new arrow.Utf8()
+  );
+  const wkb = convertGeoArrowVector(source, 'geoarrow.wkt', 'geoarrow.wkb', {
+    fallback: 'geojson'
+  });
+  const roundTrip = convertGeoArrowVector(wkb, 'geoarrow.wkb', 'geoarrow.wkt', {
+    fallback: 'geojson'
+  });
+  expect(Array.from({length: roundTrip.length}, (_, index) => roundTrip.get(index))).toEqual([
+    'POINT (1 2)',
+    'POINT Z (3 4 5)',
+    'POINT Z (6 7 8)',
+    'POINT ZM (9 10 11 12)',
+    null
+  ]);
+});
+
+test.each([
+  ['geoarrow.point', 'LINESTRING (0 0, 1 1)', 'cannot encode LineString'],
+  ['geoarrow.linestring', 'POINT (1 2)', 'cannot encode Point'],
+  ['geoarrow.polygon', 'POINT (1 2)', 'cannot encode Point'],
+  ['geoarrow.multilinestring', 'POINT (1 2)', 'cannot encode Point'],
+  ['geoarrow.multipolygon', 'POINT (1 2)', 'cannot encode Point']
+] as const)('compatibility fallback rejects incompatible %s geometry families', async (targetEncoding, wkt, message) => {
+  const {convertGeoArrowVector} = await loadFallbackConverter();
+  expect(() =>
+    convertGeoArrowVector(
+      arrow.vectorFromArray([wkt], new arrow.Utf8()),
+      'geoarrow.wkt',
+      targetEncoding,
+      {fallback: 'geojson'}
+    )
+  ).toThrow(message);
+});
+
+test('compatibility fallback rejects non-collections, recursive collections, and disabled fallback', async () => {
+  const {convertGeoArrowVector} = await loadFallbackConverter();
+  expect(() =>
+    convertGeoArrowVector(
+      arrow.vectorFromArray(['POINT (1 2)'], new arrow.Utf8()),
+      'geoarrow.wkt',
+      'geoarrow.geometrycollection',
+      {fallback: 'geojson'}
+    )
+  ).toThrow('cannot encode Point as geoarrow.geometrycollection');
+
+  expect(() =>
+    convertGeoArrowVector(
+      arrow.vectorFromArray(
+        ['GEOMETRYCOLLECTION (GEOMETRYCOLLECTION (POINT (1 2)))'],
+        new arrow.Utf8()
+      ),
+      'geoarrow.wkt',
+      'geoarrow.geometry',
+      {fallback: 'geojson'}
+    )
+  ).toThrow('do not support recursive GeometryCollections');
+
+  expect(() =>
+    convertGeoArrowVector(
+      arrow.vectorFromArray(['POINT (1 2)'], new arrow.Utf8()),
+      'geoarrow.wkt',
+      'geoarrow.point',
+      {fallback: 'error'}
+    )
+  ).toThrow('No direct GeoArrow conversion kernel');
+});
+
+test.each([
+  Number.NaN,
+  -1,
+  1.5,
+  Number.MAX_SAFE_INTEGER + 1
+])('conversion rejects invalid GeometryCollection depth %s before dispatch', async maximumDepth => {
+  const {convertGeoArrowVector} = await loadFallbackConverter();
+  expect(() =>
+    convertGeoArrowVector(
+      arrow.vectorFromArray(['POINT (1 2)'], new arrow.Utf8()),
+      'geoarrow.wkt',
+      'geoarrow.point',
+      {maxGeometryCollectionDepth: maximumDepth}
+    )
+  ).toThrow('non-negative safe integer');
+});
+
+test('compatibility fallback selects dimension bands from declared geometry types', async () => {
+  const {convertGeoArrowVector} = await loadFallbackConverter();
+  const cases: [string, GeoArrowEncoding, string][] = [
+    ['POINT Z (1 2 3)', 'geoarrow.point', 'Point Z'],
+    ['POINT M (1 2 3)', 'geoarrow.point', 'Point M'],
+    ['POINT ZM (1 2 3 4)', 'geoarrow.point', 'Point ZM']
+  ];
+  for (const [wkt, targetEncoding, geometryType] of cases) {
+    const result = convertGeoArrowVector(
+      arrow.vectorFromArray([wkt], new arrow.Utf8()),
+      'geoarrow.wkt',
+      targetEncoding,
+      {fallback: 'geojson', geometryTypes: [geometryType as any]}
+    );
+    expect(result.length).toBe(1);
+  }
+});

--- a/modules/geoarrow/test/geoarrow-kernel-boundaries.spec.ts
+++ b/modules/geoarrow/test/geoarrow-kernel-boundaries.spec.ts
@@ -1,0 +1,398 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import * as arrow from 'apache-arrow';
+import {expect, test} from 'vitest';
+import {
+  convertFeaturesToGeoArrowTable,
+  convertGeoArrowGeometry,
+  getGeoArrowBounds,
+  getGeoArrowNativeGeometry,
+  getGeoArrowRowBounds,
+  inspectGeoArrowVector
+} from '@loaders.gl/geoarrow';
+import type {GeoArrowEncoding} from '@loaders.gl/schema';
+import {convertGeometryToWKB} from '@loaders.gl/gis';
+import {encodeGeoArrowBoxVector} from '../src/lib/kernels/encode-geoarrow-box';
+import {encodeGeoArrowWKTVector} from '../src/lib/kernels/encode-geoarrow-wkt';
+
+/** Creates the minimum vector surface needed by row-oriented boundary kernels. */
+function makeValueVector(values: unknown[], type: arrow.DataType = new arrow.Null()): arrow.Vector {
+  return {
+    length: values.length,
+    type,
+    data: [],
+    get: (index: number) => values[index]
+  } as unknown as arrow.Vector;
+}
+
+/** Creates an Arrow-like nested value that deliberately uses `get()` traversal. */
+function makeVectorValue(values: unknown[]): {length: number; get(index: number): unknown} {
+  return {length: values.length, get: index => values[index]};
+}
+
+test('GeoArrow scalar bounds traverse every supported row representation', () => {
+  const vectorValue = makeVectorValue([
+    {x: -4, y: 8},
+    {toArray: () => Float64Array.of(9, -2)},
+    [Number.NaN, 100],
+    null
+  ]);
+
+  expect(getGeoArrowBounds(null, 'geoarrow.point')).toBeNull();
+  expect(getGeoArrowBounds({xmin: 1, ymin: 2, xmax: 3, ymax: 4}, 'geoarrow.box')).toEqual([
+    1, 2, 3, 4
+  ]);
+  expect(getGeoArrowBounds({xmin: 'bad'}, 'geoarrow.box')).toBeNull();
+  expect(getGeoArrowBounds({x: 3, y: 5}, 'geoarrow.point')).toEqual([3, 5, 3, 5]);
+  expect(getGeoArrowBounds({x: 3, y: 'bad'}, 'geoarrow.point')).toBeNull();
+  expect(getGeoArrowBounds({toArray: () => Float32Array.of(-1, 7)}, 'geoarrow.point')).toEqual([
+    -1, 7, -1, 7
+  ]);
+  expect(getGeoArrowBounds(vectorValue, 'geoarrow.multilinestring')).toEqual([-4, -2, 9, 8]);
+  expect(
+    getGeoArrowBounds(
+      [Float64Array.of(1, 2), [7, 9], ['bad', 3], Number.POSITIVE_INFINITY],
+      'geoarrow.linestring'
+    )
+  ).toEqual([1, 2, 7, 9]);
+  expect(getGeoArrowBounds([['bad']], 'geoarrow.linestring')).toBeNull();
+
+  const pointWKB = new Uint8Array(convertGeometryToWKB({type: 'Point', coordinates: [-7, 11]}));
+  expect(getGeoArrowBounds(pointWKB, 'geoarrow.wkb')).toEqual([-7, 11, -7, 11]);
+});
+
+test('GeoArrow Box kernel covers nested, separated, dimensional, null, WKT, and WKB rows', () => {
+  const rows = [
+    null,
+    {xmin: -1, ymin: -2, xmax: 8, ymax: 9, zmin: 1, zmax: 5, mmin: 10, mmax: 20},
+    {coordinates: [[1, 2, 3, 4], {x: 5, y: 6, z: 7, m: 8}]},
+    {geometries: makeVectorValue([{toArray: () => Float64Array.of(-5, -6, -7, -8)}])},
+    makeVectorValue([Float32Array.of(2, 3, 4, 5)]),
+    {coordinates: ['bad']}
+  ];
+  const source = makeValueVector(rows);
+
+  for (const dimension of ['xy', 'xyz', 'xym', 'xyzm'] as const) {
+    const boxes = encodeGeoArrowBoxVector(source, 'geoarrow.geometry', dimension);
+    expect(boxes.length).toBe(rows.length);
+    expect(boxes.nullCount).toBe(2);
+    expect(boxes.type.toString()).toContain('Struct');
+  }
+
+  const inferred = encodeGeoArrowBoxVector(source, 'geoarrow.geometry');
+  expect(inferred.type.toString()).toContain('zmin');
+
+  const wkt = encodeGeoArrowBoxVector(
+    makeValueVector(['POINT M (1 2 3)', 'LINESTRING EMPTY', null], new arrow.Utf8()),
+    'geoarrow.wkt',
+    'xym'
+  );
+  expect(wkt.length).toBe(3);
+  expect(wkt.nullCount).toBe(2);
+
+  const wkbValues = [
+    new Uint8Array(convertGeometryToWKB({type: 'Point', coordinates: [1, 2]})),
+    new Uint8Array(convertGeometryToWKB({type: 'Point', coordinates: [3, 4, 5]})),
+    null
+  ];
+  const wkb = encodeGeoArrowBoxVector(
+    makeValueVector(wkbValues, new arrow.Binary()),
+    'geoarrow.wkb'
+  );
+  expect(wkb.length).toBe(3);
+  expect(wkb.nullCount).toBe(1);
+});
+
+test.each([
+  ['geoarrow.point', {x: 1, y: 2}, 'POINT (1 2)'],
+  ['geoarrow.point', {toArray: () => Float64Array.of(1, 2, 3)}, 'POINT Z (1 2 3)'],
+  ['geoarrow.linestring', makeVectorValue([[0, 1], {x: 2, y: 3}]), 'LINESTRING (0 1, 2 3)'],
+  ['geoarrow.linestring', [], 'LINESTRING EMPTY'],
+  [
+    'geoarrow.polygon',
+    [
+      [
+        [0, 0],
+        [1, 0],
+        [0, 0]
+      ]
+    ],
+    'POLYGON ((0 0, 1 0, 0 0))'
+  ],
+  ['geoarrow.polygon', [], 'POLYGON EMPTY'],
+  ['geoarrow.multipoint', [[1, 2], Float64Array.of(3, 4)], 'MULTIPOINT ((1 2), (3 4))'],
+  ['geoarrow.multipoint', [], 'MULTIPOINT EMPTY'],
+  [
+    'geoarrow.multilinestring',
+    [
+      [
+        [0, 0],
+        [1, 1]
+      ],
+      makeVectorValue([
+        [2, 2],
+        [3, 3]
+      ])
+    ],
+    'MULTILINESTRING ((0 0, 1 1), (2 2, 3 3))'
+  ],
+  ['geoarrow.multilinestring', [], 'MULTILINESTRING EMPTY'],
+  [
+    'geoarrow.multipolygon',
+    [
+      [
+        [
+          [0, 0],
+          [1, 0],
+          [0, 0]
+        ]
+      ]
+    ],
+    'MULTIPOLYGON (((0 0, 1 0, 0 0)))'
+  ],
+  ['geoarrow.multipolygon', [], 'MULTIPOLYGON EMPTY']
+] as const)('native WKT kernel traverses %s row representations', (encoding, value, expectedWKT) => {
+  const vector = makeValueVector([value]);
+  const dimension = expectedWKT.includes(' Z ') ? 'xyz' : 'xy';
+  const encoded = encodeGeoArrowWKTVector(vector, encoding, dimension);
+  expect(encoded?.get(0)).toBe(expectedWKT);
+});
+
+test('native WKT kernel rejects malformed shapes and non-native encodings conservatively', () => {
+  const malformedCases: [GeoArrowEncoding, unknown][] = [
+    ['geoarrow.linestring', {not: 'children'}],
+    ['geoarrow.linestring', [[1]]],
+    ['geoarrow.polygon', [{not: 'a ring'}]],
+    ['geoarrow.multipoint', [[1]]],
+    ['geoarrow.multilinestring', [{not: 'a line'}]],
+    ['geoarrow.multipolygon', [{not: 'a polygon'}]]
+  ];
+  for (const [encoding, value] of malformedCases) {
+    expect(encodeGeoArrowWKTVector(makeValueVector([value]), encoding)).toBeNull();
+  }
+  expect(encodeGeoArrowWKTVector(makeValueVector(['POINT (1 2)']), 'geoarrow.wkt')).toBeNull();
+  expect(encodeGeoArrowWKTVector(makeValueVector([null]), 'geoarrow.point')?.get(0)).toBeNull();
+});
+
+test('native geometry reader covers every concrete family and malformed rows', () => {
+  const cases: [GeoArrowEncoding, unknown, string][] = [
+    ['geoarrow.point', {x: 1, y: 2, z: 3, m: 4}, 'Point'],
+    [
+      'geoarrow.linestring',
+      makeVectorValue([
+        [0, 0],
+        [1, 1]
+      ]),
+      'LineString'
+    ],
+    [
+      'geoarrow.polygon',
+      [
+        [
+          [0, 0],
+          [1, 0],
+          [0, 0]
+        ]
+      ],
+      'Polygon'
+    ],
+    ['geoarrow.multipoint', [Float64Array.of(1, 2), [3, 4]], 'MultiPoint'],
+    [
+      'geoarrow.multilinestring',
+      [
+        [
+          [0, 0],
+          [1, 1]
+        ]
+      ],
+      'MultiLineString'
+    ],
+    [
+      'geoarrow.multipolygon',
+      [
+        [
+          [
+            [0, 0],
+            [1, 0],
+            [0, 0]
+          ]
+        ]
+      ],
+      'MultiPolygon'
+    ]
+  ];
+  for (const [encoding, value, expectedType] of cases) {
+    expect(getGeoArrowNativeGeometry(makeValueVector([value]), 0, encoding)?.type).toBe(
+      expectedType
+    );
+  }
+
+  const point = makeValueVector([{toArray: () => Float32Array.of(7, 8)}]);
+  expect(getGeoArrowNativeGeometry(point, 0, 'geoarrow.point')).toEqual({
+    type: 'Point',
+    coordinates: [7, 8]
+  });
+  expect(getGeoArrowNativeGeometry(makeValueVector([[1, 'bad']]), 0, 'geoarrow.point')).toBeNull();
+  expect(
+    getGeoArrowNativeGeometry(makeValueVector([{x: 1, y: 'bad'}]), 0, 'geoarrow.point')
+  ).toBeNull();
+  expect(getGeoArrowNativeGeometry(point, -1, 'geoarrow.point')).toBeNull();
+  expect(getGeoArrowNativeGeometry(point, 1, 'geoarrow.point')).toBeNull();
+  expect(getGeoArrowNativeGeometry(point, 0, 'geoarrow.box')).toBeNull();
+  expect(getGeoArrowNativeGeometry(point, 0, 'geoarrow.wkb')).toBeNull();
+});
+
+test('union and collection readers inspect, bound, and decode all native geometry families', () => {
+  const features: any[] = [
+    {type: 'Feature', properties: {}, geometry: {type: 'Point', coordinates: [1, 2]}},
+    {
+      type: 'Feature',
+      properties: {},
+      geometry: {
+        type: 'LineString',
+        coordinates: [
+          [-1, 4],
+          [8, -3]
+        ]
+      }
+    },
+    {
+      type: 'Feature',
+      properties: {},
+      geometry: {
+        type: 'Polygon',
+        coordinates: [
+          [
+            [0, 0],
+            [2, 0],
+            [0, 0]
+          ]
+        ]
+      }
+    },
+    {type: 'Feature', properties: {}, geometry: {type: 'MultiPoint', coordinates: [[3, 4]]}},
+    {
+      type: 'Feature',
+      properties: {},
+      geometry: {
+        type: 'MultiLineString',
+        coordinates: [
+          [
+            [5, 6],
+            [7, 8]
+          ]
+        ]
+      }
+    },
+    {
+      type: 'Feature',
+      properties: {},
+      geometry: {
+        type: 'MultiPolygon',
+        coordinates: [
+          [
+            [
+              [9, 9],
+              [10, 9],
+              [9, 9]
+            ]
+          ]
+        ]
+      }
+    },
+    {type: 'Feature', properties: {}, geometry: null}
+  ];
+  const source = convertFeaturesToGeoArrowTable(features).data;
+  const union = convertGeoArrowGeometry(source, 'geoarrow.geometry').getChild('geometry')!;
+  const inspection = inspectGeoArrowVector(union, 'geoarrow.geometry');
+  expect(inspection.geometryTypes).toEqual([
+    'Point',
+    'LineString',
+    'Polygon',
+    'MultiPoint',
+    'MultiLineString',
+    'MultiPolygon'
+  ]);
+  expect(getGeoArrowRowBounds(union, 'geoarrow.geometry')).toHaveLength(features.length);
+  expect(getGeoArrowNativeGeometry(union, 5, 'geoarrow.geometry')?.type).toBe('MultiPolygon');
+
+  const collectionSource = convertFeaturesToGeoArrowTable([
+    {
+      type: 'Feature',
+      properties: {},
+      geometry: {
+        type: 'GeometryCollection',
+        geometries: [features[0].geometry, features[1].geometry]
+      }
+    },
+    {type: 'Feature', properties: {}, geometry: null}
+  ] as any).data;
+  const collection = convertGeoArrowGeometry(
+    collectionSource,
+    'geoarrow.geometrycollection'
+  ).getChild('geometry')!;
+  expect(inspectGeoArrowVector(collection, 'geoarrow.geometrycollection')).toMatchObject({
+    rowCount: 2,
+    nullCount: 1,
+    geometryTypes: ['GeometryCollection']
+  });
+  expect(getGeoArrowNativeGeometry(collection, 0, 'geoarrow.geometrycollection')).toMatchObject({
+    type: 'GeometryCollection',
+    geometries: [{type: 'Point'}, {type: 'LineString'}]
+  });
+  expect(getGeoArrowNativeGeometry(collection, 1, 'geoarrow.geometrycollection')).toBeNull();
+});
+
+test('vector inspection covers malformed serialized and native dimension variants', () => {
+  const wkt = makeValueVector(
+    [null, 'POINT (1 2)', 'POINT Z (1 2 3)', 'POINT M (1 2 3)', 'POINT ZM (1 2 3 4)', 'bad'],
+    new arrow.Utf8()
+  );
+  expect(inspectGeoArrowVector(wkt, 'geoarrow.wkt')).toMatchObject({
+    nullCount: 1,
+    malformedRowCount: 1,
+    dimensions: ['xy', 'xyz', 'xym', 'xyzm']
+  });
+
+  const malformedWKB = makeValueVector(
+    [null, new Uint8Array(), Uint8Array.of(2, 1, 0)],
+    new arrow.Binary()
+  );
+  expect(inspectGeoArrowVector(malformedWKB, 'geoarrow.wkb')).toMatchObject({
+    nullCount: 1,
+    malformedRowCount: 2
+  });
+
+  const types = [
+    new arrow.FixedSizeList(2, new arrow.Field('item', new arrow.Float64(), true)),
+    new arrow.FixedSizeList(3, new arrow.Field('item', new arrow.Float64(), true)),
+    new arrow.FixedSizeList(4, new arrow.Field('item', new arrow.Float64(), true)),
+    new arrow.Struct([
+      new arrow.Field('x', new arrow.Float64(), true),
+      new arrow.Field('y', new arrow.Float64(), true),
+      new arrow.Field('m', new arrow.Float64(), true)
+    ]),
+    new arrow.List(
+      new arrow.Field(
+        'item',
+        new arrow.FixedSizeList(2, new arrow.Field('item', new arrow.Float64(), true)),
+        true
+      )
+    )
+  ];
+  const encodings: GeoArrowEncoding[] = [
+    'geoarrow.point',
+    'geoarrow.point',
+    'geoarrow.point',
+    'geoarrow.point',
+    'geoarrow.linestring'
+  ];
+  expect(
+    types.map(
+      (type, index) =>
+        inspectGeoArrowVector(makeValueVector([[1, 2]], type), encodings[index]).dimensions
+    )
+  ).toEqual([['xy'], ['xyz'], ['xyzm'], ['xym'], ['xy']]);
+});

--- a/modules/geoarrow/test/geoarrow-layout-wkt-boundaries.spec.ts
+++ b/modules/geoarrow/test/geoarrow-layout-wkt-boundaries.spec.ts
@@ -1,0 +1,324 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import * as arrow from 'apache-arrow';
+import {expect, test} from 'vitest';
+import {inspectGeoArrowLayout} from '@loaders.gl/geoarrow';
+import type {GeoArrowEncoding} from '@loaders.gl/schema';
+import {
+  decodeWKTGeometryCollectionVector,
+  decodeWKTNativeVector,
+  decodeWKTUnionVector
+} from '../src/lib/kernels/decode-wkt-native';
+
+/** Creates GeoArrow extension metadata for a field. */
+function extensionMetadata(encoding?: GeoArrowEncoding): Map<string, string> {
+  return encoding ? new Map([['ARROW:extension:name', encoding]]) : new Map();
+}
+
+/** Creates an interleaved coordinate type. */
+function coordinateType(
+  size: number,
+  scalar: arrow.DataType = new arrow.Float64()
+): arrow.FixedSizeList {
+  return new arrow.FixedSizeList(size, new arrow.Field('item', scalar, true));
+}
+
+/** Creates the minimum row-oriented Arrow vector needed by WKT kernels. */
+function wktVector(values: unknown[]): arrow.Vector {
+  return {
+    type: new arrow.Utf8(),
+    length: values.length,
+    data: [],
+    get: (index: number) => values[index]
+  } as unknown as arrow.Vector;
+}
+
+test('layout oracle classifies all serialized storage families and missing metadata', () => {
+  const cases: [arrow.DataType, GeoArrowEncoding, string][] = [
+    [new arrow.Binary(), 'geoarrow.wkb', 'binary'],
+    [new arrow.LargeBinary(), 'geoarrow.wkb', 'large-binary'],
+    [new arrow.BinaryView(), 'geoarrow.wkb', 'binary-view'],
+    [new arrow.Utf8(), 'geoarrow.wkt', 'utf8'],
+    [new arrow.LargeUtf8(), 'geoarrow.wkt', 'large-utf8'],
+    [new arrow.Utf8View(), 'geoarrow.wkt', 'utf8-view']
+  ];
+  for (const [type, encoding, storage] of cases) {
+    expect(
+      inspectGeoArrowLayout(new arrow.Field('geometry', type, true, extensionMetadata(encoding)))
+    ).toMatchObject({valid: true, layout: {encoding, storage}});
+  }
+
+  const missing = inspectGeoArrowLayout(
+    new arrow.Field('geometry', coordinateType(2), true, extensionMetadata())
+  );
+  expect(missing.valid).toBe(false);
+  expect(missing.layout).toMatchObject({kind: 'point', dimension: 'xy'});
+  expect(missing.issues.map(issue => issue.code)).toEqual(['missing-extension']);
+});
+
+test.each([
+  ['geoarrow.wkb', new arrow.Utf8()],
+  ['geoarrow.wkt', new arrow.Binary()],
+  ['geoarrow.geometry', coordinateType(2)],
+  ['geoarrow.geometrycollection', coordinateType(2)],
+  ['geoarrow.box', coordinateType(2)],
+  ['geoarrow.point', new arrow.Int32()]
+] as const)('layout oracle rejects %s on incompatible physical storage', (encoding, type) => {
+  const result = inspectGeoArrowLayout(
+    new arrow.Field('geometry', type, true, extensionMetadata(encoding))
+  );
+  expect(result.valid).toBe(false);
+  expect(
+    result.issues.some(issue => ['wrong-physical-type', 'unsupported-type'].includes(issue.code))
+  ).toBe(true);
+});
+
+test('layout oracle diagnoses native depth, dimension, names, and precision boundaries', () => {
+  const malformedFields = [
+    new arrow.Field('geometry', coordinateType(2), true, extensionMetadata('geoarrow.linestring')),
+    new arrow.Field(
+      'geometry',
+      new arrow.List(new arrow.Field('item', coordinateType(2), true)),
+      true,
+      extensionMetadata('geoarrow.polygon')
+    ),
+    new arrow.Field('geometry', coordinateType(1), true, extensionMetadata('geoarrow.point')),
+    new arrow.Field('geometry', coordinateType(5), true, extensionMetadata('geoarrow.point')),
+    new arrow.Field(
+      'geometry',
+      coordinateType(2, new arrow.Int32()),
+      true,
+      extensionMetadata('geoarrow.point')
+    ),
+    new arrow.Field(
+      'geometry',
+      coordinateType(2, new arrow.Float16()),
+      true,
+      extensionMetadata('geoarrow.point')
+    ),
+    new arrow.Field(
+      'geometry',
+      new arrow.Struct([new arrow.Field('x', new arrow.Float64(), true)]),
+      true,
+      extensionMetadata('geoarrow.point')
+    ),
+    new arrow.Field(
+      'geometry',
+      new arrow.Struct([
+        new arrow.Field('x', new arrow.Float32(), true),
+        new arrow.Field('y', new arrow.Float64(), false),
+        new arrow.Field('measure', new arrow.Float64(), true),
+        new arrow.Field('extra', new arrow.Float64(), true),
+        new arrow.Field('overflow', new arrow.Float64(), true)
+      ]),
+      true,
+      extensionMetadata('geoarrow.point')
+    )
+  ];
+  const codes = new Set(
+    malformedFields.flatMap(field => inspectGeoArrowLayout(field).issues.map(issue => issue.code))
+  );
+  expect(codes).toEqual(
+    new Set([
+      'wrong-child-count',
+      'wrong-coordinate-dimension',
+      'wrong-coordinate-precision',
+      'wrong-child-name'
+    ])
+  );
+});
+
+test('layout oracle reports mixed offsets and exact separated Box dimensions', () => {
+  const mixedOffsets = new arrow.LargeList(
+    new arrow.Field(
+      'outer',
+      new arrow.List(new arrow.Field('inner', coordinateType(2), true)),
+      true
+    )
+  );
+  const mixed = inspectGeoArrowLayout(
+    new arrow.Field('geometry', mixedOffsets, true, extensionMetadata('geoarrow.polygon'))
+  );
+  expect(mixed.issues.some(issue => issue.code === 'mixed-offset-width')).toBe(true);
+  expect(mixed.layout.offsetTypes).toEqual(['int64', 'int32']);
+
+  const boxCases: [string[], string][] = [
+    [['xmin', 'ymin', 'xmax', 'ymax'], 'xy'],
+    [['xmin', 'ymin', 'zmin', 'xmax', 'ymax', 'zmax'], 'xyz'],
+    [['xmin', 'ymin', 'mmin', 'xmax', 'ymax', 'mmax'], 'xym'],
+    [['xmin', 'ymin', 'zmin', 'mmin', 'xmax', 'ymax', 'zmax', 'mmax'], 'xyzm']
+  ];
+  for (const [names, dimension] of boxCases) {
+    const field = new arrow.Field(
+      'geometry',
+      new arrow.Struct(
+        names.map(
+          (name, index) =>
+            new arrow.Field(name, index % 2 ? new arrow.Float32() : new arrow.Float64(), true)
+        )
+      ),
+      true,
+      extensionMetadata('geoarrow.box')
+    );
+    expect(inspectGeoArrowLayout(field)).toMatchObject({
+      valid: true,
+      layout: {kind: 'box', dimension, coordinates: 'separated'}
+    });
+  }
+});
+
+test('layout oracle diagnoses dense-union IDs, unknown children, and collection structure', () => {
+  const invalidIds = new arrow.DenseUnion(
+    [1, 99, 200],
+    [
+      new arrow.Field('Point', coordinateType(2), true),
+      new arrow.Field('Mystery', coordinateType(2), true),
+      new arrow.Field('LineString', coordinateType(2), true)
+    ]
+  );
+  const invalid = inspectGeoArrowLayout(
+    new arrow.Field('geometry', invalidIds, true, extensionMetadata('geoarrow.geometry'))
+  );
+  expect(invalid.issues.some(issue => issue.code === 'invalid-union')).toBe(true);
+  expect(invalid.issues.some(issue => issue.code === 'unknown-union-child')).toBe(true);
+
+  const collectionChild = new arrow.List(
+    new arrow.Field(
+      'geometries',
+      new arrow.DenseUnion([1], [new arrow.Field('Point', coordinateType(2), true)]),
+      true
+    )
+  );
+  const union = new arrow.DenseUnion(
+    [7],
+    [new arrow.Field('GeometryCollection', collectionChild, true)]
+  );
+  expect(
+    inspectGeoArrowLayout(
+      new arrow.Field('geometry', union, true, extensionMetadata('geoarrow.geometrycollection'))
+    ).issues.some(issue => issue.message.includes('requires a list'))
+  ).toBe(true);
+
+  const malformedCollectionUnion = new arrow.DenseUnion(
+    [7],
+    [new arrow.Field('GeometryCollection', coordinateType(2), true)]
+  );
+  expect(
+    inspectGeoArrowLayout(
+      new arrow.Field(
+        'geometry',
+        malformedCollectionUnion,
+        true,
+        extensionMetadata('geoarrow.geometry')
+      )
+    ).issues.some(issue => issue.message.includes('list of dense union'))
+  ).toBe(true);
+});
+
+test.each([
+  'SRID 4326;POINT (1 2)',
+  'SRID=bad;POINT (1 2)',
+  'SRID=4326 POINT (1 2)',
+  'UNKNOWN (1 2)',
+  'POINT 1 2',
+  'POINT (1)',
+  'POINT Z (1 2)',
+  'POINT (1 2) trailing',
+  'LINESTRING (0 0, bad)',
+  'POLYGON (0 0, 1 1)',
+  'POLYGON ((0 0, 1 1)',
+  'MULTIPOINT ((1 2), bad)',
+  'MULTILINESTRING ((0 0), bad)',
+  'MULTIPOLYGON (((0 0)), bad)',
+  'GEOMETRYCOLLECTION (POINT (1 2), bad)'
+])('direct WKT decoders reject malformed grammar: %s', wkt => {
+  const vector = wktVector([wkt]);
+  expect(decodeWKTNativeVector(vector, 'geoarrow.point')).toBeNull();
+  expect(decodeWKTUnionVector(vector)).toBeNull();
+  expect(decodeWKTGeometryCollectionVector(vector)).toBeNull();
+});
+
+test('direct WKT native decoder covers nulls, empty geometries, number syntax, and mixed dimensions', () => {
+  const emptyCases: [GeoArrowEncoding, string][] = [
+    ['geoarrow.point', 'POINT EMPTY'],
+    ['geoarrow.linestring', 'LINESTRING EMPTY'],
+    ['geoarrow.polygon', 'POLYGON EMPTY'],
+    ['geoarrow.multipoint', 'MULTIPOINT EMPTY'],
+    ['geoarrow.multilinestring', 'MULTILINESTRING EMPTY'],
+    ['geoarrow.multipolygon', 'MULTIPOLYGON EMPTY']
+  ];
+  for (const [encoding, wkt] of emptyCases) {
+    const result = decodeWKTNativeVector(
+      wktVector([null, wkt]),
+      encoding as Exclude<
+        GeoArrowEncoding,
+        | 'geoarrow.box'
+        | 'geoarrow.geometry'
+        | 'geoarrow.geometrycollection'
+        | 'geoarrow.wkb'
+        | 'geoarrow.wkt'
+      >
+    );
+    expect(result?.length).toBe(2);
+  }
+
+  expect(
+    decodeWKTNativeVector(wktVector(['POINT (+1.5 -2.5e1)', 'POINT (.5 2.)']), 'geoarrow.point')
+      ?.length
+  ).toBe(2);
+  expect(
+    decodeWKTNativeVector(wktVector(['POINT (1 2)', 'POINT Z (1 2 3)']), 'geoarrow.point')
+  ).toBeNull();
+  expect(decodeWKTNativeVector(wktVector([42]), 'geoarrow.point')).toBeNull();
+  expect(
+    decodeWKTNativeVector(wktVector([null]), 'geoarrow.point', undefined, 'separated', 'int64')
+      ?.length
+  ).toBe(1);
+});
+
+test('direct WKT union and collection kernels cover null-only, seeded, and recursive cases', () => {
+  const nullUnion = decodeWKTUnionVector(wktVector([null, null]), undefined, 'separated', 'int64');
+  expect(nullUnion?.length).toBe(2);
+  expect((nullUnion?.type as arrow.DenseUnion).children[0].name).toBe('Point');
+
+  const seeded = decodeWKTUnionVector(
+    wktVector(['POINT M (1 2 3)', null]),
+    undefined,
+    'interleaved',
+    'int32',
+    ['LineString Z', 'Point M', 'GeometryCollection']
+  );
+  expect((seeded?.type as arrow.DenseUnion).children.map(field => field.name)).toEqual([
+    'GeometryCollection',
+    'LineString Z',
+    'Point M'
+  ]);
+
+  const nullCollection = decodeWKTGeometryCollectionVector(
+    wktVector([null, 'GEOMETRYCOLLECTION EMPTY']),
+    undefined,
+    'separated',
+    'int64',
+    ['GeometryCollection', 'Point']
+  );
+  expect(nullCollection?.type).toBeInstanceOf(arrow.LargeList);
+  expect(nullCollection?.nullCount).toBe(1);
+
+  expect(
+    decodeWKTGeometryCollectionVector(
+      wktVector(['GEOMETRYCOLLECTION (GEOMETRYCOLLECTION (POINT (1 2)))'])
+    )
+  ).toBeNull();
+  expect(
+    decodeWKTUnionVector(
+      wktVector(['GEOMETRYCOLLECTION (POINT (1 2))']),
+      undefined,
+      'interleaved',
+      'int32',
+      undefined,
+      0
+    )
+  ).toBeNull();
+});

--- a/modules/geoarrow/test/geoarrow-validation-boundaries.spec.ts
+++ b/modules/geoarrow/test/geoarrow-validation-boundaries.spec.ts
@@ -1,0 +1,342 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import * as arrow from 'apache-arrow';
+import {expect, test} from 'vitest';
+import {
+  convertFeaturesToGeoArrowTable,
+  convertGeoArrowGeometry,
+  getGeoArrowFieldInfo,
+  negotiateGeoArrowEncoding,
+  validateGeoArrowField,
+  validateGeoArrowVector
+} from '@loaders.gl/geoarrow';
+import type {GeoArrowEncoding} from '@loaders.gl/schema';
+
+/** Creates a minimal Arrow vector around hand-authored physical data. */
+function makeDataVector(type: arrow.DataType, data: Record<string, unknown>): arrow.Vector {
+  const physicalData = {
+    type,
+    length: 1,
+    offset: 0,
+    nullCount: 0,
+    children: [],
+    ...data
+  };
+  return {
+    type,
+    length: Number(physicalData.length),
+    data: [physicalData],
+    get: () => null
+  } as unknown as arrow.Vector;
+}
+
+/** Creates a row-oriented vector for serialized validation branches. */
+function makeValueVector(values: unknown[], type: arrow.DataType): arrow.Vector {
+  return {
+    type,
+    length: values.length,
+    data: [],
+    get: (index: number) => values[index]
+  } as unknown as arrow.Vector;
+}
+
+/** Creates scalar child data for hand-authored Struct and list layouts. */
+function makeScalarData(
+  type: arrow.DataType,
+  values: ArrayLike<number>,
+  length = values.length,
+  offset = 0
+): Record<string, unknown> {
+  return {type, values, length, offset, nullCount: 0, children: []};
+}
+
+test('serialized validation reports null, wrong-type, malformed, and valid rows', () => {
+  const wkb = validateGeoArrowVector(
+    makeValueVector(
+      [null, 'not bytes', new Uint8Array(), Uint8Array.of(1, 1, 0, 0, 0)],
+      new arrow.Binary()
+    ),
+    'geoarrow.wkb'
+  );
+  expect(wkb.valid).toBe(false);
+  expect(wkb.issues).toHaveLength(3);
+  expect(wkb.issues.map(issue => issue.path)).toEqual(['row[1]', 'row[2]', 'row[3]']);
+
+  const wkt = validateGeoArrowVector(
+    makeValueVector([null, 42, 'not wkt', 'POINT (1 2)'], new arrow.Utf8()),
+    'geoarrow.wkt'
+  );
+  expect(wkt.valid).toBe(false);
+  expect(wkt.issues.map(issue => issue.path)).toEqual(['row[1]', 'row[2]']);
+
+  expect(
+    validateGeoArrowVector(
+      makeValueVector([], new arrow.Null()),
+      'geoarrow.unknown' as GeoArrowEncoding
+    )
+  ).toEqual({valid: true, issues: []});
+});
+
+test('native list validation covers missing, short, negative, non-monotonic, and oversized offsets', () => {
+  const coordinateType = new arrow.FixedSizeList(
+    2,
+    new arrow.Field('item', new arrow.Float64(), true)
+  );
+  const listType = new arrow.List(new arrow.Field('item', coordinateType, true));
+  const coordinateChild = {
+    type: coordinateType,
+    length: 1,
+    offset: 0,
+    nullCount: 0,
+    children: [makeScalarData(new arrow.Float64(), Float64Array.of(1, 2))]
+  };
+
+  const cases: [string, Record<string, unknown>][] = [
+    ['missing', {valueOffsets: undefined, children: []}],
+    ['short', {valueOffsets: new Int32Array(), children: [coordinateChild]}],
+    ['negative', {valueOffsets: Float64Array.of(-1, 0), children: [coordinateChild]}],
+    ['non-monotonic', {valueOffsets: Int32Array.of(1, 0), children: [coordinateChild]}],
+    ['oversized', {valueOffsets: Int32Array.of(0, 2), children: [coordinateChild]}]
+  ];
+  for (const [name, data] of cases) {
+    const result = validateGeoArrowVector(makeDataVector(listType, data), 'geoarrow.linestring');
+    expect(result.valid, name).toBe(false);
+    expect(result.issues.length, name).toBeGreaterThan(0);
+  }
+
+  const unsupportedChild = makeDataVector(listType, {
+    valueOffsets: Int32Array.of(0, 1),
+    children: [makeScalarData(new arrow.Int32(), Int32Array.of(1))]
+  });
+  expect(
+    validateGeoArrowVector(unsupportedChild, 'geoarrow.linestring').issues[0].message
+  ).toContain('Unsupported native Arrow physical type');
+});
+
+test('native coordinate validation covers list size, precision, and child length diagnostics', () => {
+  const invalidSizeType = new arrow.FixedSizeList(
+    1,
+    new arrow.Field('item', new arrow.Float64(), true)
+  );
+  expect(
+    validateGeoArrowVector(makeDataVector(invalidSizeType, {children: []}), 'geoarrow.point')
+      .issues[0].message
+  ).toContain('two to four values');
+
+  const coordinateType = new arrow.FixedSizeList(
+    2,
+    new arrow.Field('item', new arrow.Int32(), true)
+  );
+  const result = validateGeoArrowVector(
+    makeDataVector(coordinateType, {
+      length: 2,
+      children: [makeScalarData(new arrow.Int32(), Int32Array.of(1), 1)]
+    }),
+    'geoarrow.point'
+  );
+  expect(result.issues.map(issue => issue.message)).toEqual([
+    'Native coordinates must use a floating-point child.',
+    'Native coordinate buffer is shorter than its list.'
+  ]);
+});
+
+test('native Struct validation covers names, precision, lengths, nulls, and Box extents', () => {
+  const malformedType = new arrow.Struct([
+    new arrow.Field('longitude', new arrow.Int32(), true),
+    new arrow.Field('latitude', new arrow.Int32(), true)
+  ]);
+  expect(
+    validateGeoArrowVector(
+      makeDataVector(malformedType, {
+        children: [
+          makeScalarData(new arrow.Int32(), Int32Array.of(1)),
+          makeScalarData(new arrow.Int32(), Int32Array.of(2))
+        ]
+      }),
+      'geoarrow.point'
+    ).issues[0].message
+  ).toContain('non-canonical');
+
+  const pointType = new arrow.Struct([
+    new arrow.Field('x', new arrow.Int32(), true),
+    new arrow.Field('y', new arrow.Float64(), true)
+  ]);
+  const pointResult = validateGeoArrowVector(
+    makeDataVector(pointType, {
+      length: 2,
+      children: [
+        makeScalarData(new arrow.Int32(), Int32Array.of(1), 1),
+        makeScalarData(new arrow.Float64(), Float64Array.of(2), 1)
+      ]
+    }),
+    'geoarrow.point'
+  );
+  expect(pointResult.issues.map(issue => issue.message)).toEqual([
+    'Native struct children must be floating-point.',
+    'Native struct child is shorter than its parent.',
+    'Native struct child is shorter than its parent.'
+  ]);
+
+  const boxType = new arrow.Struct(
+    ['xmin', 'ymin', 'xmax', 'ymax'].map(name => new arrow.Field(name, new arrow.Float64(), true))
+  );
+  const box = makeDataVector(boxType, {
+    length: 3,
+    nullCount: 1,
+    nullBitmap: Uint8Array.of(0b00000101),
+    children: [
+      makeScalarData(new arrow.Float64(), Float64Array.of(5, 0, Number.NaN), 3),
+      makeScalarData(new arrow.Float64(), Float64Array.of(2, 0, 1), 3),
+      makeScalarData(new arrow.Float64(), Float64Array.of(4, 0, 3), 3),
+      makeScalarData(new arrow.Float64(), Float64Array.of(6, 0, 4), 3)
+    ]
+  });
+  const boxResult = validateGeoArrowVector(box, 'geoarrow.box');
+  expect(boxResult.issues.map(issue => issue.message)).toEqual([
+    'GeoArrow Box xmin must not exceed xmax.',
+    'GeoArrow Box xmin/xmax values must be finite.'
+  ]);
+});
+
+test('dense-union validation covers absent buffers, unknown IDs, invalid offsets, and child recursion', () => {
+  const pointType = new arrow.FixedSizeList(2, new arrow.Field('item', new arrow.Float64(), true));
+  const unionType = new arrow.DenseUnion([1], [new arrow.Field('Point', pointType, true)]);
+  const pointChild = {
+    type: pointType,
+    length: 1,
+    offset: 0,
+    nullCount: 0,
+    children: [makeScalarData(new arrow.Float64(), Float64Array.of(1, 2))]
+  };
+
+  const missing = validateGeoArrowVector(
+    makeDataVector(unionType, {typeIds: undefined, valueOffsets: undefined}),
+    'geoarrow.geometry'
+  );
+  expect(missing.issues[0].message).toContain('missing type IDs');
+
+  const malformed = validateGeoArrowVector(
+    makeDataVector(unionType, {
+      length: 3,
+      typeIds: Int8Array.of(9, 1, 1),
+      valueOffsets: Int32Array.of(0, -1, 2),
+      children: [pointChild]
+    }),
+    'geoarrow.geometry'
+  );
+  expect(malformed.issues.map(issue => issue.message)).toEqual([
+    'Unknown dense union type id 9.',
+    'Dense union value offset -1 is outside child 0.',
+    'Dense union value offset 2 is outside child 0.'
+  ]);
+
+  const unsupportedChild = validateGeoArrowVector(
+    makeDataVector(new arrow.DenseUnion([1], [new arrow.Field('Point', new arrow.Int32(), true)]), {
+      typeIds: Int8Array.of(1),
+      valueOffsets: Int32Array.of(0),
+      children: [makeScalarData(new arrow.Int32(), Int32Array.of(1))]
+    }),
+    'geoarrow.geometry'
+  );
+  expect(unsupportedChild.issues.some(issue => issue.message.includes('Unsupported native'))).toBe(
+    true
+  );
+
+  expect(
+    validateGeoArrowVector(makeValueVector([], pointType), 'geoarrow.geometrycollection')
+  ).toMatchObject({
+    valid: false,
+    issues: [{path: 'type'}]
+  });
+});
+
+test('field capabilities and negotiation cover metadata, native selection, conversion, and mismatches', () => {
+  const source = convertFeaturesToGeoArrowTable([
+    {type: 'Feature', properties: {}, geometry: {type: 'Point', coordinates: [1, 2, 3]}}
+  ]).data;
+  const native = convertGeoArrowGeometry(source, 'geoarrow.point', {
+    coordinates: 'separated',
+    dimension: 'xyz'
+  });
+  const nativeField = native.schema.fields[0];
+  const info = getGeoArrowFieldInfo(nativeField);
+  expect(info).toMatchObject({
+    encoding: 'geoarrow.point',
+    dimension: 'xyz',
+    coordinates: 'separated'
+  });
+  expect(negotiateGeoArrowEncoding(nativeField)).toBe('geoarrow.point');
+  expect(negotiateGeoArrowEncoding(nativeField, {encoding: 'native'})).toBe('geoarrow.point');
+  expect(
+    negotiateGeoArrowEncoding(nativeField, {encoding: 'geoarrow.wkb', allowConversion: true})
+  ).toBe('geoarrow.wkb');
+  expect(() => negotiateGeoArrowEncoding(nativeField, {encoding: 'geoarrow.wkb'})).toThrow(
+    'without allowing conversion'
+  );
+  expect(() => negotiateGeoArrowEncoding(nativeField, {coordinates: 'interleaved'})).toThrow(
+    'does not use interleaved'
+  );
+  expect(() => negotiateGeoArrowEncoding(nativeField, {dimension: 'xy'})).toThrow(
+    'does not use xy'
+  );
+
+  const lines = convertGeoArrowGeometry(
+    convertFeaturesToGeoArrowTable([
+      {
+        type: 'Feature',
+        properties: {},
+        geometry: {
+          type: 'LineString',
+          coordinates: [
+            [0, 0],
+            [1, 1]
+          ]
+        }
+      }
+    ]).data,
+    'geoarrow.linestring',
+    {offsetType: 'int64'}
+  );
+  const lineField = lines.schema.fields[0];
+  expect(getGeoArrowFieldInfo(lineField)?.offsetType).toBe('int64');
+  expect(() => negotiateGeoArrowEncoding(lineField, {offsetType: 'int32'})).toThrow(
+    'does not use int32 offsets'
+  );
+
+  const wkbField = source.schema.fields[0];
+  expect(negotiateGeoArrowEncoding(wkbField, {encoding: 'native'})).toBe('native');
+
+  const plainField = new arrow.Field('value', new arrow.Int32(), true);
+  expect(getGeoArrowFieldInfo(plainField)).toBeNull();
+  expect(validateGeoArrowField(plainField)).toMatchObject({valid: false, info: null});
+  expect(() => negotiateGeoArrowEncoding(plainField)).toThrow('not a recognized GeoArrow field');
+});
+
+test('field validation reports empty geometry metadata and incompatible physical layouts', () => {
+  const emptyGeometryTypes = new arrow.Field(
+    'geometry',
+    new arrow.Binary(),
+    true,
+    new Map([
+      ['ARROW:extension:name', 'geoarrow.wkb'],
+      ['ARROW:extension:metadata', JSON.stringify({geometry_types: []})]
+    ])
+  );
+  expect(
+    validateGeoArrowField(emptyGeometryTypes).issues.some(issue =>
+      issue.path.endsWith('geometry_types')
+    )
+  ).toBe(true);
+
+  const incompatible = new arrow.Field(
+    'geometry',
+    new arrow.Int32(),
+    true,
+    new Map([['ARROW:extension:name', 'geoarrow.point']])
+  );
+  const result = validateGeoArrowField(incompatible);
+  expect(result.valid).toBe(false);
+  expect(result.issues.some(issue => issue.message.includes('physical Arrow layout'))).toBe(true);
+});


### PR DESCRIPTION
## Goals

- Make a substantial advance toward the long-term 90% combined coverage target.
- Target the largest remaining high-impact GeoArrow coverage bank and FlatGeobuf geometry internals.
- Keep required CI fast and hermetic while increasing branch coverage aggressively.

## Changes

- Add comprehensive native Vitest coverage for GeoArrow adapters, conversion fallbacks, kernels, validation, layout inspection, WKT/WKB handling, dimensionality, unions, collections, nulls, and malformed inputs.
- Add FlatGeobuf coverage for every core geometry family, nested geometries, Z coordinates, bounds, direct GeoArrow writing, WKB writing, absent geometry, and failure paths.
- Reject malformed nested WKT GeometryCollections instead of accepting a null child as an empty collection.
- Add 92 focused tests with approximately 0.3 seconds of test execution time.

## Coverage impact

The focused browser coverage map merged with the preceding CI artifact projects:

- Combined line + branch coverage: **85.97% → 86.91%** (**+0.94 points**)
- Covered lines: **+565**
- Covered branches: **+669**
- Covered functions: **+95**
- Covered statements: **+717**

## Validation

- `yarn lint fix`
- `yarn test-audit` — 743 files, 0 Tape, 0 violations
- `yarn build`
- `yarn build-workers`
- `yarn test-node` — 424 passed, 6 skipped
- `yarn test-headless` — 4,685 passed, 39 skipped
- Focused Chromium suites — 92 passed
- Focused instrumented Chromium suites — 92 passed
