### PR TITLE
test(coverage): exercise parser and stream boundary banks

### DIFF
--- a/modules/compression/test/compress-utils-binding.spec.ts
+++ b/modules/compression/test/compress-utils-binding.spec.ts
@@ -14,6 +14,7 @@ const INPUT = new Uint8Array([1, 2, 3]);
 
 test('compress-utils direction-specific bindings copy atomic and streaming output', async () => {
   let destroyedStreams = 0;
+  const codecBuffer = new Uint8Array([255, ...INPUT, 255]);
   const createStream = async () => ({
     write: (input: Uint8Array) => input,
     finish: () => new Uint8Array([9]),
@@ -22,7 +23,7 @@ test('compress-utils direction-specific bindings copy atomic and streaming outpu
     }
   });
   const module = {
-    compress: async (input: Uint8Array) => input,
+    compress: async () => codecBuffer.subarray(1, 4),
     createCompressStream: createStream,
     decompress: async (input: Uint8Array) => input,
     createDecompressStream: createStream
@@ -34,6 +35,8 @@ test('compress-utils direction-specific bindings copy atomic and streaming outpu
 
   const compressed = await compressor.compress(INPUT.buffer);
   expect(new Uint8Array(compressed)).toEqual(INPUT);
+  expect(compressed.byteLength).toBe(INPUT.byteLength);
+  expect(compressed).not.toBe(codecBuffer.buffer);
   const compressedBatches = await collect(compressor.compressBatches([INPUT.buffer]));
   expect(compressedBatches.map(batch => Array.from(new Uint8Array(batch)))).toEqual([
     [1, 2, 3],
@@ -68,6 +71,10 @@ test('compress-utils combined binding supports both atomic directions', async ()
   expect(new Uint8Array(await compression.decompress(INPUT.buffer))).toEqual(
     new Uint8Array([0, 1, 2])
   );
+  const compressedBatches = await collect(compression.compressBatches([INPUT.buffer]));
+  const decompressedBatches = await collect(compression.decompressBatches([INPUT.buffer]));
+  expect(compressedBatches.map(batch => Array.from(new Uint8Array(batch)))).toEqual([[1, 2, 3]]);
+  expect(decompressedBatches.map(batch => Array.from(new Uint8Array(batch)))).toEqual([[1, 2, 3]]);
   expect(compression.options.compressUtils).toEqual({mode: 'test'});
 });
 

--- a/modules/csv/test/csv-arrow-dynamic-boundaries.spec.ts
+++ b/modules/csv/test/csv-arrow-dynamic-boundaries.spec.ts
@@ -1,0 +1,105 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {expect, test} from 'vitest';
+import {parseCSVArrayBufferAsArrow, parseCSVTextAsArrow} from '../src/csv-arrow-table-parser';
+
+const encoder = new TextEncoder();
+
+/** Returns one Arrow column as ordinary values. */
+function values(table: any, name: string): unknown[] {
+  const column = table.data.getChild(name);
+  return Array.from({length: table.data.numRows}, (_, index) => column.get(index));
+}
+
+test('ArrayBuffer Arrow parsing covers geometry and untyped fallback paths', async () => {
+  const geometry = await parseCSVArrayBufferAsArrow(
+    encoder.encode('name,geometry\npoint,POINT (1 2)').buffer,
+    {csv: {header: true, detectGeometryColumns: true}}
+  );
+  expect(geometry.data.getChild('geometry')!.get(0)).toBeInstanceOf(Uint8Array);
+
+  const untyped = await parseCSVArrayBufferAsArrow(encoder.encode('a,b\n1,2').buffer, {
+    csv: {header: true, dynamicTyping: false}
+  });
+  expect(values(untyped, 'a')).toEqual(['1']);
+
+  const typedQuoted = await parseCSVArrayBufferAsArrow(
+    encoder.encode('number,boolean\n"1.5","false"').buffer,
+    {csv: {header: true, dynamicTyping: true}}
+  );
+  expect(values(typedQuoted, 'number')).toEqual([1.5]);
+  expect(values(typedQuoted, 'boolean')).toEqual([false]);
+});
+
+test('quoted dynamic conversion covers nullable booleans, numbers, and dates', async () => {
+  const table = await parseCSVTextAsArrow(
+    [
+      'boolean,number,date',
+      '"true"," -1.25e+3 ","2025-01-02T03:04:05Z"',
+      ',,"2026-02-03T04:05:06Z"',
+      '"FALSE",".5",'
+    ].join('\n'),
+    {csv: {header: true, dynamicTyping: true}}
+  );
+  expect(values(table, 'boolean')).toEqual([true, null, false]);
+  expect(values(table, 'number')).toEqual([-1250, null, 0.5]);
+  expect(values(table, 'date')).toEqual([
+    Date.parse('2025-01-02T03:04:05Z'),
+    Date.parse('2026-02-03T04:05:06Z'),
+    null
+  ]);
+});
+
+test.each([
+  ['1e', '1e'],
+  ['1e+', '1e+'],
+  ['1e-x', '1e-x'],
+  ['-.', '-.'],
+  ['1.2.3', '1.2.3'],
+  ['   ', '   ']
+])('quoted dynamic conversion preserves invalid numeric grammar %s', async (input, output) => {
+  const table = await parseCSVTextAsArrow(`value\n"${input}"`, {
+    csv: {header: true, dynamicTyping: true}
+  });
+  expect(values(table, 'value')).toEqual([output]);
+});
+
+test('direct numeric parser covers duplicate headers and malformed speculative rows', async () => {
+  const duplicate = await parseCSVTextAsArrow('value,value\n1,2\n3,4', {
+    csv: {header: true, dynamicTyping: true}
+  });
+  expect(duplicate.schema.fields.map(field => field.name)).toEqual(['value', 'value.1']);
+  expect(values(duplicate, 'value.1')).toEqual([2, 4]);
+
+  const malformedWidth = await parseCSVTextAsArrow('a,b\n1\n2,3', {
+    csv: {header: true, dynamicTyping: true}
+  });
+  expect(malformedWidth.data.numRows).toBe(2);
+
+  const headerOnly = await parseCSVTextAsArrow('a,b', {
+    csv: {header: true, dynamicTyping: true}
+  });
+  expect(headerOnly.data.numRows).toBe(0);
+});
+
+test('direct parser rejects incompatible delimiter candidates before safe fallback', async () => {
+  const table = await parseCSVTextAsArrow('a§b\n1§2', {
+    csv: {
+      header: true,
+      dynamicTyping: true,
+      delimiter: '§'
+    }
+  });
+  expect(values(table, 'a')).toEqual([1]);
+
+  const guessed = await parseCSVTextAsArrow('a|b\n1|2', {
+    csv: {
+      header: true,
+      dynamicTyping: true,
+      delimitersToGuess: ['§', '||', '|']
+    }
+  });
+  expect(values(guessed, 'b')).toEqual([2]);
+});

--- a/modules/lance/test/manifest-coverage.spec.ts
+++ b/modules/lance/test/manifest-coverage.spec.ts
@@ -3,6 +3,7 @@ import {parseLanceManifest} from '../src/lance-manifest';
 import {LanceSourceLoader} from '../src/lance-source-loader';
 import {LanceDecoderUnavailableError} from '../src/lance-errors';
 
+/** Encodes an unsigned integer as protobuf varint bytes. */
 function varint(value: number): number[] {
   const bytes: number[] = [];
   do {
@@ -14,19 +15,23 @@ function varint(value: number): number[] {
   return bytes;
 }
 
+/** Encodes a protobuf varint field. */
 function field(number: number, value: number | number[]): number[] {
   const bytes = varint(number << 3);
   return [...bytes, ...(Array.isArray(value) ? value : varint(value))];
 }
 
+/** Encodes a length-delimited protobuf byte field. */
 function bytesField(number: number, value: number[]): number[] {
   return [...varint((number << 3) | 2), ...varint(value.length), ...value];
 }
 
+/** Encodes a UTF-8 protobuf string field. */
 function stringField(number: number, value: string): number[] {
   return bytesField(number, Array.from(new TextEncoder().encode(value)));
 }
 
+/** Creates a compact Lance manifest containing optional and packed fields. */
 function createManifest(): Uint8Array {
   const fieldMessage = [
     ...field(1, 2),

--- a/modules/las/test/typescript-las-format-matrix.spec.ts
+++ b/modules/las/test/typescript-las-format-matrix.spec.ts
@@ -202,6 +202,85 @@ test.each([
   expect(header.metadata?.maxGpsTime).toBeUndefined();
 });
 
+test.each([
+  ['major version', (bytes: Uint8Array) => (bytes[24] = 2), 'unsupported LAS version 2.5'],
+  [
+    'short header',
+    (_bytes: Uint8Array, view: DataView) => view.setUint16(94, 375, true),
+    'at least 393'
+  ],
+  [
+    'legacy point format',
+    (bytes: Uint8Array) => (bytes[104] = 5),
+    'requires point data record formats 6-10'
+  ],
+  [
+    'missing WKT flag',
+    (_bytes: Uint8Array, view: DataView) => view.setUint16(6, 0, true),
+    'requires the WKT'
+  ],
+  [
+    'reserved encoding bit',
+    (_bytes: Uint8Array, view: DataView) => view.setUint16(6, 0x30, true),
+    'reserved bits'
+  ],
+  [
+    'time offset without GPS type',
+    (_bytes: Uint8Array, view: DataView) => view.setUint16(6, 0x50, true),
+    'requires GPS Time Type'
+  ],
+  [
+    'non-finite GPS maximum',
+    (_bytes: Uint8Array, view: DataView) => view.setFloat64(375, Number.NaN, true),
+    'GPS time range'
+  ],
+  [
+    'reversed GPS range',
+    (_bytes: Uint8Array, view: DataView) => {
+      view.setFloat64(375, 1, true);
+      view.setFloat64(383, 2, true);
+    },
+    'GPS time range'
+  ]
+] as const)('TypeScript LAS 1.5 rejects %s', (_name, mutate, message) => {
+  const source = createLAS15Header();
+  mutate(new Uint8Array(source), new DataView(source));
+  expect(() => parseLASHeader(source)).toThrow(message);
+});
+
+test('TypeScript LAS 1.5 accepts its boundary header and GPS metadata', () => {
+  const source = createLAS15Header();
+  const view = new DataView(source);
+  view.setFloat64(375, 20, true);
+  view.setFloat64(383, 10, true);
+  const header = parseLASHeader(source);
+  expect(header.versionAsString).toBe('1.5');
+  expect(header.pointsFormatId).toBe(6);
+  expect(header.metadata?.maxGpsTime).toBe(20);
+  expect(header.metadata?.minGpsTime).toBe(10);
+});
+
+test('TypeScript LAS metadata tolerates truncated VLR and EVLR records', () => {
+  const truncatedHeader = createLASFixture(0, false).slice(0, 390);
+  const truncatedView = new DataView(truncatedHeader);
+  truncatedView.setUint32(100, 1, true);
+  expect(parseLASHeader(truncatedHeader).metadata?.variableLengthRecords).toBeUndefined();
+
+  const truncatedPayload = createLASFixture(0, false).slice(0, 430);
+  const payloadView = new DataView(truncatedPayload);
+  payloadView.setUint32(100, 1, true);
+  payloadView.setUint16(375 + 20, 1000, true);
+  expect(parseLASHeader(truncatedPayload).metadata?.variableLengthRecords).toBeUndefined();
+
+  const truncatedExtendedHeader = createLASFixture(0, false);
+  const extendedHeaderView = new DataView(truncatedExtendedHeader);
+  extendedHeaderView.setBigUint64(235, 430n, true);
+  extendedHeaderView.setUint32(243, 1, true);
+  expect(
+    parseLASHeader(truncatedExtendedHeader).metadata?.extendedVariableLengthRecords
+  ).toBeUndefined();
+});
+
 /** Collects all batches from the TypeScript streaming parser. */
 async function collectLASBatches(
   chunks: Iterable<ArrayBuffer | ArrayBufferView>
@@ -285,6 +364,22 @@ function createLASFixture(pointDataRecordFormat: number, highColor: boolean): Ar
     bytes[pointOffset + baseRecordLength] = pointIndex;
     bytes[pointOffset + baseRecordLength + 1] = 255 - pointIndex;
   }
+  return arrayBuffer;
+}
+
+/** Creates a valid empty LAS 1.5 header for mutation-based validation tests. */
+function createLAS15Header(): ArrayBuffer {
+  const arrayBuffer = new ArrayBuffer(393);
+  const bytes = new Uint8Array(arrayBuffer);
+  const view = new DataView(arrayBuffer);
+  bytes.set(new TextEncoder().encode('LASF'));
+  bytes[24] = 1;
+  bytes[25] = 5;
+  view.setUint16(6, 0x11, true);
+  view.setUint16(94, 393, true);
+  view.setUint32(96, 393, true);
+  bytes[104] = 6;
+  view.setUint16(105, POINT_FORMAT_LENGTHS[6], true);
   return arrayBuffer;
 }
 

--- a/modules/las/test/typescript-las-format-matrix.spec.ts
+++ b/modules/las/test/typescript-las-format-matrix.spec.ts
@@ -264,21 +264,25 @@ test('TypeScript LAS metadata tolerates truncated VLR and EVLR records', () => {
   const truncatedHeader = createLASFixture(0, false).slice(0, 390);
   const truncatedView = new DataView(truncatedHeader);
   truncatedView.setUint32(100, 1, true);
-  expect(parseLASHeader(truncatedHeader).metadata?.variableLengthRecords).toBeUndefined();
+  expect(parseLASHeader(truncatedHeader).metadata).toBeUndefined();
 
   const truncatedPayload = createLASFixture(0, false).slice(0, 430);
   const payloadView = new DataView(truncatedPayload);
   payloadView.setUint32(100, 1, true);
   payloadView.setUint16(375 + 20, 1000, true);
-  expect(parseLASHeader(truncatedPayload).metadata?.variableLengthRecords).toBeUndefined();
+  const truncatedPayloadMetadata = parseLASHeader(truncatedPayload).metadata;
+  expect(truncatedPayloadMetadata).toBeDefined();
+  expect(truncatedPayloadMetadata?.vlrCount).toBe(1);
+  expect(truncatedPayloadMetadata?.vlrs).toEqual([]);
 
   const truncatedExtendedHeader = createLASFixture(0, false);
   const extendedHeaderView = new DataView(truncatedExtendedHeader);
   extendedHeaderView.setBigUint64(235, 430n, true);
   extendedHeaderView.setUint32(243, 1, true);
-  expect(
-    parseLASHeader(truncatedExtendedHeader).metadata?.extendedVariableLengthRecords
-  ).toBeUndefined();
+  const truncatedExtendedMetadata = parseLASHeader(truncatedExtendedHeader).metadata;
+  expect(truncatedExtendedMetadata).toBeDefined();
+  expect(truncatedExtendedMetadata?.evlrCount).toBe(1);
+  expect(truncatedExtendedMetadata?.evlrs).toEqual([]);
 });
 
 /** Collects all batches from the TypeScript streaming parser. */

--- a/modules/loader-utils/test/lib/laz/laz-chunk-encoder.spec.ts
+++ b/modules/loader-utils/test/lib/laz/laz-chunk-encoder.spec.ts
@@ -125,39 +125,24 @@ test.each([
     dataView.setInt32(offset + 4, -200 - pointIndex, true);
     dataView.setInt32(offset + 8, 300 + pointIndex, true);
     dataView.setUint16(offset + 12, 50 + pointIndex, true);
-    dataView.setUint8(offset + 14, 0x20 | pointIndex);
+    dataView.setUint8(offset + 14, 0x18 | (pointIndex + 1));
     dataView.setUint8(offset + 15, 4 + pointIndex);
     dataView.setInt8(offset + 16, -2 - pointIndex);
     dataView.setUint8(offset + 17, 9 + pointIndex);
     dataView.setUint16(offset + 18, 1000 + pointIndex, true);
     if (pointDataRecordFormat === 1 || pointDataRecordFormat === 3) {
-      dataView.setFloat64(offset + 20, 123.5 + pointIndex, true);
+      dataView.setFloat64(offset + 20, 123.5, true);
     }
-    if (pointDataRecordFormat === 3) {
-      dataView.setUint16(offset + 28, 100 + pointIndex, true);
-      dataView.setUint16(offset + 30, 200 + pointIndex, true);
-      dataView.setUint16(offset + 32, 300 + pointIndex, true);
+    if (pointDataRecordFormat === 2 || pointDataRecordFormat === 3) {
+      const colorOffset = pointDataRecordFormat === 2 ? offset + 20 : offset + 28;
+      dataView.setUint16(colorOffset, 100 + pointIndex, true);
+      dataView.setUint16(colorOffset + 2, 200 + pointIndex, true);
+      dataView.setUint16(colorOffset + 4, 300 + pointIndex, true);
     }
   }
   const metadata = {pointCount, pointDataRecordFormat, pointDataRecordLength: recordLength};
   const decoded = decodeLAZChunk(encodeLAZChunk(rawPointData, metadata), metadata);
-  const decodedDataView = new DataView(decoded.buffer, decoded.byteOffset, decoded.byteLength);
-  expect(decoded.byteLength).toBe(rawPointData.byteLength);
-  for (let pointIndex = 0; pointIndex < pointCount; pointIndex++) {
-    const offset = pointIndex * recordLength;
-    expect(
-      Math.abs(decodedDataView.getInt32(offset, true) - (100 + pointIndex))
-    ).toBeLessThanOrEqual(1);
-    expect(
-      Math.abs(decodedDataView.getInt32(offset + 4, true) + 200 + pointIndex)
-    ).toBeLessThanOrEqual(1);
-    expect(
-      Math.abs(decodedDataView.getInt32(offset + 8, true) - (300 + pointIndex))
-    ).toBeLessThanOrEqual(1);
-    expect(
-      Math.abs(decodedDataView.getUint16(offset + 12, true) - (50 + pointIndex))
-    ).toBeLessThanOrEqual(1);
-  }
+  expect(decoded).toEqual(rawPointData);
 });
 test('LAZChunkDecoder#decodes modern Extra Bytes directly into point-data targets', () => {
   for (const pointDataRecordFormat of [6, 7, 8]) {

--- a/modules/parquet/test/make-stream-iterator.node.spec.ts
+++ b/modules/parquet/test/make-stream-iterator.node.spec.ts
@@ -1,0 +1,90 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {Readable} from 'stream';
+import {expect, test, vi} from 'vitest';
+import {makeStreamIterator} from '../src/lib/utils/make-stream-iterator';
+
+/** Collects an asynchronous stream adapter into an array. */
+async function collect<T>(values: AsyncIterable<T>): Promise<T[]> {
+  const result: T[] = [];
+  for await (const value of values) result.push(value);
+  return result;
+}
+
+/** Creates a minimal Node-style async iterable with an observable return hook. */
+function createNodeStream<T>(results: IteratorResult<T>[], returnError?: Error): Readable {
+  const iterator = {
+    next: vi.fn(async () => results.shift() || ({done: true, value: undefined} as IteratorResult<T>)),
+    return: vi.fn(async () => {
+      if (returnError) throw returnError;
+      return {done: true, value: undefined} as IteratorResult<T>;
+    })
+  };
+  return {
+    [Symbol.asyncIterator]: () => iterator,
+    iterator
+  } as unknown as Readable;
+}
+
+test('Node stream adapter yields values and finishes without cancellation', async () => {
+  const stream = createNodeStream<number>([
+    {done: false, value: 1},
+    {done: false, value: 2},
+    {done: true, value: undefined as never}
+  ]) as Readable & {iterator: {return: ReturnType<typeof vi.fn>}};
+  await expect(collect(makeStreamIterator(stream))).resolves.toEqual([1, 2]);
+  expect(stream.iterator.return).not.toHaveBeenCalled();
+});
+
+test('Node stream adapter invokes return when its consumer stops early', async () => {
+  const stream = createNodeStream<number>([{done: false, value: 1}]) as Readable & {
+    iterator: {return: ReturnType<typeof vi.fn>};
+  };
+  for await (const value of makeStreamIterator(stream)) {
+    expect(value).toBe(1);
+    break;
+  }
+  expect(stream.iterator.return).toHaveBeenCalledOnce();
+});
+
+test('Node stream adapter reports cleanup failures after an early stop', async () => {
+  const error = new Error('return failed');
+  const stream = createNodeStream([{done: false, value: 1}], error);
+  const consumeOne = async () => {
+    for await (const _value of makeStreamIterator(stream)) break;
+  };
+  await expect(consumeOne()).rejects.toThrow(error);
+});
+
+test('Node stream adapter preserves iteration failures over cleanup failures', async () => {
+  const readError = new Error('read failed');
+  const returnError = new Error('return failed');
+  const iterator = {
+    next: vi.fn(async () => {
+      throw readError;
+    }),
+    return: vi.fn(async () => {
+      throw returnError;
+    })
+  };
+  const stream = {[Symbol.asyncIterator]: () => iterator} as unknown as Readable;
+  await expect(collect(makeStreamIterator(stream))).rejects.toThrow(readError);
+  expect(iterator.return).toHaveBeenCalledOnce();
+});
+
+test('Node stream adapter aborts pending reads and invokes return', async () => {
+  const abortController = new AbortController();
+  let settleRead!: (value: IteratorResult<number>) => void;
+  const iterator = {
+    next: vi.fn(() => new Promise<IteratorResult<number>>(resolve => (settleRead = resolve))),
+    return: vi.fn(async () => ({done: true, value: undefined as never}))
+  };
+  const stream = {[Symbol.asyncIterator]: () => iterator} as unknown as Readable;
+  const result = collect(makeStreamIterator(stream, {signal: abortController.signal}));
+  abortController.abort(new Error('stop now'));
+  await expect(result).rejects.toThrow('stop now');
+  expect(iterator.return).toHaveBeenCalledOnce();
+  settleRead({done: true, value: undefined as never});
+});

--- a/modules/parquet/test/parquet-reader-boundaries.spec.ts
+++ b/modules/parquet/test/parquet-reader-boundaries.spec.ts
@@ -1,0 +1,371 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {ReadableFile} from '@loaders.gl/loader-utils';
+import {expect, test, vi} from 'vitest';
+import {ParquetReader} from '../src/parquetjs/parser/parquet-reader';
+import {ParquetSchema} from '../src/parquetjs/schema/schema';
+import {
+  CompressionCodec,
+  FieldRepetitionType,
+  Type
+} from '../src/parquetjs/parquet-thrift/index';
+
+/** Minimal random-access file used to exercise reader control flow without fixture I/O. */
+class MemoryFile implements ReadableFile {
+  readonly handle: unknown;
+  readonly size: number;
+  readonly bigsize: bigint;
+  readonly url = 'memory.parquet';
+  readonly close = vi.fn(async () => {});
+
+  constructor(readonly bytes: Uint8Array, exposeArrayBuffer = true) {
+    this.handle = exposeArrayBuffer ? bytes.buffer : {};
+    this.size = bytes.byteLength;
+    this.bigsize = BigInt(bytes.byteLength);
+  }
+
+  async read(start: number | bigint = 0, length = this.size): Promise<ArrayBuffer> {
+    const offset = Number(start);
+    return this.bytes.slice(offset, offset + length).buffer;
+  }
+}
+
+const schema = new ParquetSchema({value: {type: 'INT32'}});
+const metadata = {
+  type: Type.INT32,
+  encodings: [],
+  path_in_schema: ['value'],
+  codec: CompressionCodec.UNCOMPRESSED,
+  num_values: 0,
+  total_uncompressed_size: 0,
+  total_compressed_size: 0,
+  data_page_offset: 4
+};
+
+test('reader exposes immutable encryption snapshots and exact worker key views', async () => {
+  const backing = Uint8Array.from([9, 1, 2, 8]);
+  const reader = new ParquetReader(new MemoryFile(new Uint8Array(16)), {
+    int96AsTimestamp: true,
+    encryptionContext: {
+      algorithm: 'AES_GCM_V1',
+      aadPrefix: Uint8Array.from([3]),
+      fileUnique: Uint8Array.from([4]),
+      footerKeyMetadata: Uint8Array.from([5])
+    },
+    keyRetriever: async () => backing.subarray(1, 3)
+  });
+
+  expect(reader.encrypted).toBe(true);
+  expect(reader.int96AsTimestamp).toBe(true);
+  const context = reader.getEncryptionContextForWorker();
+  expect(context).toEqual({
+    algorithm: 'AES_GCM_V1',
+    aadPrefix: Uint8Array.from([3]),
+    fileUnique: Uint8Array.from([4]),
+    footerKeyMetadata: Uint8Array.from([5])
+  });
+  context!.fileUnique[0] = 99;
+  expect(reader.getEncryptionContextForWorker()!.fileUnique[0]).toBe(4);
+
+  const key = await reader.getColumnKeyForWorker({meta_data: metadata} as any, 2, 3);
+  expect(key.keyMaterial).toEqual(Uint8Array.from([1, 2]));
+  expect(key.keyMaterial.byteLength).toBe(2);
+});
+
+test('reader rejects worker encryption operations without required context', async () => {
+  const reader = new ParquetReader(new MemoryFile(new Uint8Array(16)));
+  expect(reader.encrypted).toBe(false);
+  expect(reader.getEncryptionContextForWorker()).toBeUndefined();
+  await expect(reader.getColumnKeyForWorker({} as any, 0, 0)).rejects.toThrow('keyRetriever');
+
+  const encryptedColumn = {crypto_metadata: {ENCRYPTION_WITH_FOOTER_KEY: {}}} as any;
+  await expect(reader.decryptIndexModule(new Uint8Array(), 'column-index', 0, 0, encryptedColumn))
+    .rejects.toThrow('keyRetriever');
+  await expect(reader.decryptBloomFilter(new Uint8Array(), 0, 0, encryptedColumn)).rejects.toThrow(
+    'keyRetriever'
+  );
+
+  const plain = Uint8Array.from([1, 2]);
+  await expect(reader.decryptIndexModule(plain, 'offset-index', 0, 0, {} as any)).resolves.toBe(
+    plain
+  );
+  await expect(reader.decryptBloomFilter(plain, 0, 0, {} as any)).resolves.toBe(plain);
+});
+
+test('header, footer, abort, and close boundaries fail before decoding payloads', async () => {
+  await expect(new ParquetReader(new MemoryFile(new TextEncoder().encode('NOPE'))).readHeader())
+    .rejects.toThrow('Invalid parquet file');
+  await expect(
+    new ParquetReader(new MemoryFile(new TextEncoder().encode('PAR1'))).readHeader(
+      AbortSignal.abort()
+    )
+  ).rejects.toThrow('Request aborted');
+
+  const badTrailer = new Uint8Array(12);
+  badTrailer.set(new TextEncoder().encode('PAR1'), 0);
+  badTrailer.set(new TextEncoder().encode('NOPE'), 8);
+  await expect(new ParquetReader(new MemoryFile(badTrailer)).readFooter()).rejects.toThrow(
+    'Not a valid parquet file'
+  );
+
+  const oversizedFooter = new Uint8Array(12);
+  new DataView(oversizedFooter.buffer).setUint32(4, 20, true);
+  oversizedFooter.set(new TextEncoder().encode('PAR1'), 8);
+  await expect(new ParquetReader(new MemoryFile(oversizedFooter)).readFooter()).rejects.toThrow(
+    'Invalid metadata size'
+  );
+
+  const file = new MemoryFile(new Uint8Array(8));
+  const reader = new ParquetReader(file);
+  reader.close();
+  expect(file.close).toHaveBeenCalledOnce();
+});
+
+test('metadata accessors cache schema and preserve key/value metadata', async () => {
+  const reader = new ParquetReader(new MemoryFile(new Uint8Array(8)));
+  const fileMetadata = {
+    version: 1,
+    schema: [
+      {name: 'schema', num_children: 1},
+      {name: 'value', type: Type.INT32, repetition_type: FieldRepetitionType.REQUIRED}
+    ],
+    num_rows: 7,
+    row_groups: [],
+    key_value_metadata: [
+      {key: 'owner', value: 'loaders.gl'},
+      {key: 'empty', value: ''}
+    ]
+  } as any;
+  reader.metadata = Promise.resolve(fileMetadata);
+
+  expect(await reader.getRowCount()).toBe(7);
+  expect(await reader.getSchemaMetadata()).toEqual({owner: 'loaders.gl', empty: ''});
+  const firstSchema = await reader.getSchema();
+  expect(firstSchema.fields.value.primitiveType).toBe('INT32');
+  expect(await reader.getSchema()).toBe(firstSchema);
+  expect(await reader.getFileMetadata()).toBe(fileMetadata);
+});
+
+test.each([-1, 1, 0.5])('row-group iterator rejects invalid index %s', async rowGroupIndex => {
+  const reader = new ParquetReader(new MemoryFile(new Uint8Array(8)));
+  reader.metadata = Promise.resolve({
+    schema: [],
+    row_groups: [{num_rows: 0, columns: []}],
+    num_rows: 0,
+    key_value_metadata: []
+  } as any);
+  (reader as any).schema = Promise.resolve(schema);
+  const iterator = reader.rowGroupIterator({rowGroups: [rowGroupIndex]});
+  await expect(iterator.next()).rejects.toThrow(`Invalid Parquet row-group index ${rowGroupIndex}`);
+});
+
+test('row, batch, and row-group iterators preserve order and column normalization', async () => {
+  const reader = new ParquetReader(new MemoryFile(new Uint8Array(8)));
+  reader.metadata = Promise.resolve({
+    schema: [],
+    row_groups: [
+      {num_rows: 1, columns: []},
+      {num_rows: 1, columns: []}
+    ],
+    num_rows: 2,
+    key_value_metadata: []
+  } as any);
+  (reader as any).schema = Promise.resolve(schema);
+  const readRowGroup = vi
+    .spyOn(reader, 'readRowGroup')
+    .mockImplementation(async (_schema, _group, columns, _signal, ordinal) => ({
+      rowCount: 1,
+      columnData: {
+        value: {values: [ordinal! + 10], rlevels: [0], dlevels: [0], count: 1}
+      },
+      columns
+    }) as any);
+
+  const rows: any[] = [];
+  for await (const row of reader.rowIterator({columnList: ['value'], rowGroups: [1, 0]})) {
+    rows.push(row);
+  }
+  expect(rows).toEqual([{value: 11}, {value: 10}]);
+  expect(readRowGroup.mock.calls[0][2]).toEqual([['value']]);
+});
+
+test('column and row-range planners reject malformed plans without reading bytes', async () => {
+  const reader = new ParquetReader(new MemoryFile(new Uint8Array(32)));
+  const chunk = {meta_data: metadata} as any;
+
+  await expect(
+    reader.readColumnChunkEncodedPages(schema, {...chunk, file_path: 'external'} as any, new Set())
+  ).rejects.toThrow('external references');
+  await expect(reader.readColumnChunkEncodedPages(schema, {} as any, new Set())).rejects.toThrow(
+    'metadata is missing'
+  );
+  await expect(
+    reader.readColumnChunkEncodedPages(
+      schema,
+      {meta_data: {...metadata, type: Type.BOOLEAN}} as any,
+      new Set()
+    )
+  ).rejects.toThrow('chunk type not matching schema');
+
+  await expect(
+    reader.readColumnChunkRange(schema, {...chunk, file_path: 'external'} as any, {start: 0, end: 1}, [])
+  ).rejects.toThrow('external references');
+  await expect(
+    reader.readColumnChunkRange(schema, {} as any, {start: 0, end: 1}, [])
+  ).rejects.toThrow('metadata is missing');
+  await expect(
+    reader.readColumnChunkRange(
+      schema,
+      {meta_data: {...metadata, type: Type.BOOLEAN}} as any,
+      {start: 0, end: 1},
+      []
+    )
+  ).rejects.toThrow('chunk type not matching schema');
+  await expect(
+    reader.readColumnChunkRange(schema, chunk, {start: 10, end: 11}, [
+      {offset: 4, compressedByteLength: 0, firstRowIndex: 0, endRowIndex: 2}
+    ])
+  ).rejects.toThrow('does not overlap');
+
+  await expect(
+    reader.readRowGroupRange(
+      schema,
+      {num_rows: 1, columns: [chunk]} as any,
+      [],
+      {start: 0, end: 1},
+      {}
+    )
+  ).rejects.toThrow('offset index missing for value');
+  await expect(reader.getDictionary(0, {} as any, 4)).resolves.toEqual([]);
+});
+
+test('row-group encoded planner filters columns and freezes its result', async () => {
+  const reader = new ParquetReader(new MemoryFile(new Uint8Array(32)));
+  const first = {meta_data: metadata} as any;
+  const second = {meta_data: {...metadata, path_in_schema: ['ignored']}} as any;
+  const encoded = {path: ['value'], pages: []} as any;
+  const read = vi.spyOn(reader, 'readColumnChunkEncodedPages').mockResolvedValue(encoded);
+
+  const result = await reader.readRowGroupEncodedPages(
+    schema,
+    {num_rows: 0, columns: [first, second]} as any,
+    [['value']],
+    new Set(['UNCOMPRESSED'])
+  );
+  expect(result).toEqual([encoded]);
+  expect(Object.isFrozen(result)).toBe(true);
+  expect(read).toHaveBeenCalledOnce();
+});
+
+test('column metadata resolution reports every incomplete encryption shape', async () => {
+  const plainReader = new ParquetReader(new MemoryFile(new Uint8Array(32)));
+  await expect(
+    (plainReader as any).getColumnMetadata({}, 0, 0)
+  ).rejects.toThrow('metadata is missing');
+
+  const encryptedBytes = Uint8Array.from([1]);
+  const encryptedColumn = {
+    encrypted_column_metadata: encryptedBytes,
+    crypto_metadata: {ENCRYPTION_WITH_COLUMN_KEY: {path_in_schema: ['value']}}
+  } as any;
+  await expect(
+    plainReader.resolveColumnMetadata({num_rows: 0, columns: [encryptedColumn]} as any, 0)
+  ).rejects.toThrow('requires parquet.keyRetriever');
+
+  const keyReader = new ParquetReader(new MemoryFile(new Uint8Array(32)), {
+    keyRetriever: async () => new Uint8Array(16)
+  });
+  await expect(
+    keyReader.resolveColumnMetadata({num_rows: 0, columns: [encryptedColumn]} as any, 0)
+  ).rejects.toThrow('has no file encryption context');
+
+  const contextReader = new ParquetReader(new MemoryFile(new Uint8Array(32)), {
+    keyRetriever: async () => new Uint8Array(16),
+    encryptionContext: {algorithm: 'AES_GCM_V1', fileUnique: Uint8Array.from([1])}
+  });
+  await expect(
+    contextReader.resolveColumnMetadata(
+      {
+        num_rows: 0,
+        columns: [
+          {
+            encrypted_column_metadata: encryptedBytes,
+            crypto_metadata: {},
+            parquetColumnOrdinal: 7
+          }
+        ]
+      } as any,
+      0
+    )
+  ).rejects.toThrow('has no key reference');
+});
+
+test('encrypted page reads require a worker encryption context', async () => {
+  const reader = new ParquetReader(new MemoryFile(new Uint8Array(32)), {
+    keyRetriever: async () => new Uint8Array(16)
+  });
+  await expect(
+    reader.readColumnChunkEncodedPages(
+      schema,
+      {meta_data: metadata, crypto_metadata: {ENCRYPTION_WITH_FOOTER_KEY: {}}} as any,
+      new Set()
+    )
+  ).rejects.toThrow('Encrypted Parquet pages require parquet.keyRetriever');
+});
+
+test('row-group planners resolve encrypted metadata only for selected columns', async () => {
+  const reader = new ParquetReader(new MemoryFile(new Uint8Array(32), false));
+  const selected = {
+    encrypted_column_metadata: Uint8Array.from([1]),
+    crypto_metadata: {ENCRYPTION_WITH_COLUMN_KEY: {path_in_schema: ['value']}}
+  } as any;
+  const ignored = {
+    encrypted_column_metadata: Uint8Array.from([2]),
+    crypto_metadata: {ENCRYPTION_WITH_COLUMN_KEY: {path_in_schema: ['ignored']}}
+  } as any;
+  const getColumnMetadata = vi
+    .spyOn(reader as any, 'getColumnMetadata')
+    .mockResolvedValue(metadata);
+  vi.spyOn(reader, 'readColumnChunkEncodedPages').mockResolvedValue({path: ['value']} as any);
+  vi.spyOn(reader, 'readColumnChunkRange').mockResolvedValue({
+    values: [],
+    rlevels: [],
+    dlevels: [],
+    count: 0
+  } as any);
+
+  await reader.readRowGroupEncodedPages(
+    schema,
+    {num_rows: 0, columns: [selected, ignored]} as any,
+    [['value']],
+    new Set()
+  );
+  expect(getColumnMetadata).toHaveBeenCalledOnce();
+
+  selected.meta_data = undefined;
+  await reader.readRowGroupRange(
+    schema,
+    {num_rows: 1, columns: [selected, ignored]} as any,
+    [['value']],
+    {start: 0, end: 1},
+    {'["value"]': [{offset: 4, compressedByteLength: 0, firstRowIndex: 0, endRowIndex: 1}]}
+  );
+  expect(getColumnMetadata).toHaveBeenCalledTimes(2);
+});
+
+test('synchronous column path validates backing storage and physical type', () => {
+  const remoteReader = new ParquetReader(new MemoryFile(new Uint8Array(32), false));
+  expect(() =>
+    (remoteReader as any).readUncompressedColumnChunkFromMemory(schema, {}, metadata)
+  ).toThrow('require an in-memory ArrayBuffer');
+
+  const memoryReader = new ParquetReader(new MemoryFile(new Uint8Array(32)));
+  expect(() =>
+    (memoryReader as any).readUncompressedColumnChunkFromMemory(schema, {}, {
+      ...metadata,
+      type: Type.BOOLEAN
+    })
+  ).toThrow('chunk type not matching schema');
+});

--- a/modules/sql/test/compile-table-query.spec.ts
+++ b/modules/sql/test/compile-table-query.spec.ts
@@ -190,7 +190,10 @@ describe('compileSQLTableQuery', () => {
         join: {
           child: {
             source: 'other',
-            query: {columns: ['value'], orderBy: [{column: 'value', direction: 'asc'}]}
+            query: {
+              columns: ['value', 'measurement_id'],
+              orderBy: [{column: 'value', direction: 'asc'}]
+            }
           },
           left: 'id',
           right: 'measurement_id'
@@ -199,11 +202,13 @@ describe('compileSQLTableQuery', () => {
       {dialect: 'snowflake'}
     );
 
-    expect(compiled.sql).toContain('("a" + "b") AS "sumValue"');
-    expect(compiled.sql).toContain('("a" - "b") AS "difference"');
-    expect(compiled.sql).toContain('("a" * "b") AS "product"');
-    expect(compiled.sql).toContain('("a" / NULLIF("b", 0)) AS "ratio"');
-    expect(compiled.sql).toContain('JOIN (SELECT "value"');
-    expect(compiled.sql).toContain('ORDER BY "value" ASC');
+    expect(compiled.sql).toBe(
+      [
+        'SELECT ("a" + "b") AS "sumValue", ("a" - "b") AS "difference", ("a" * "b") AS "product", ("a" / NULLIF("b", 0)) AS "ratio", "other"."value"',
+        'FROM "measurements" JOIN (SELECT "value", "measurement_id"',
+        'FROM "other"',
+        'ORDER BY "value" ASC) AS "other" ON "measurements"."id" = "other"."measurement_id"'
+      ].join('\n')
+    );
   });
 });

--- a/modules/wms/test/service-runtime.spec.ts
+++ b/modules/wms/test/service-runtime.spec.ts
@@ -166,12 +166,14 @@ describe('ServiceRuntime', () => {
     const first = runtime.getSource('https://example.com/one.service');
     expect(runtime.getSource('https://example.com/one.service')).toBe(first);
     runtime.clearCache('https://example.com/one.service');
-    expect(runtime.getSource('https://example.com/one.service')).not.toBe(first);
+    const second = runtime.getSource('https://example.com/one.service');
+    expect(second).not.toBe(first);
     runtime.clearCache();
+    expect(runtime.getSource('https://example.com/one.service')).not.toBe(second);
     expect(() => runtime.getSource('https://example.com/other.json')).toThrow(
       'No geospatial service loader recognized URL'
     );
-    expect(created).toBe(2);
+    expect(created).toBe(3);
   });
 
   test('retries explicitly enabled non-idempotent requests', async () => {


### PR DESCRIPTION
## Goals

- Make a substantial, runtime-conscious advance toward 90% repository coverage.
- Exercise high-impact parser, stream, and error-handling branches without adding expensive fixtures or network-dependent tests.
- Incorporate fixes requested in outstanding review threads from earlier coverage pull requests.

## Changes

- Expand CSV Arrow coverage for typed values, quoted fields, malformed numeric input, duplicate headers, delimiters, and fallback parsing.
- Add LAS 1.5 validation and metadata boundary coverage, including malformed VLR and EVLR inputs.
- Add focused Parquet reader coverage for encryption, lifecycle, caching, row groups, range planning, selected columns, and synchronous in-memory paths.
- Test Node stream iterator completion, cancellation, cleanup failures, read failures, and aborted pending reads.
- Strengthen coverage in compression, SQL, WMS, Lance, and LAZ while addressing historical review feedback.
- Keep the new cases synthetic, hermetic, and fast; the focused additions execute in milliseconds.

## Coverage

- Authoritative merged CI result: **86.9176% → 87.0728%** (`+0.1552` percentage points).
- Remaining gap to 90%: **3,397** covered line/branch units at the current denominator.
- The top 10 remaining files contain 1,816 uncovered units, or 53.5% of that gap; the next tranche can therefore target the report's largest absolute debt banks directly.

## Validation

- `yarn lint fix`
- `yarn test-audit`
- `yarn build`
- `yarn build-workers`
- `yarn test-node`
- `yarn test-headless`
