### PR TITLE
test: add broad high-impact coverage tranche

### DIFF
--- a/modules/avro/test/avro-boundary-coverage.spec.ts
+++ b/modules/avro/test/avro-boundary-coverage.spec.ts
@@ -404,6 +404,102 @@ describe('Avro boundary coverage', () => {
     ).rejects.toThrow('no compatible branch');
   });
 
+  test.each([
+    ['null', true],
+    ['boolean', 'false'],
+    ['string', 1],
+    ['bytes', 1],
+    ['int', '1'],
+    [{type: ['string', 'null']}, null],
+    [{type: {type: 'boolean'}}, 'false'],
+    [{type: 'fixed', size: 1}, 1],
+    [{type: 'enum', symbols: ['A']}, 'B'],
+    [{type: 'array', items: 'int'}, {}],
+    [{type: 'map', values: 'int'}, []],
+    [{type: 'record', fields: []}, []]
+  ] as const)('rejects incompatible reader defaults for %j', async (fieldType, defaultValue) => {
+    const writerSchema = {type: 'record', name: 'Writer', fields: []};
+    const encoded = await encodeRaw(writerSchema, {});
+    await expect(
+      parseAvro(encoded, {
+        encoding: 'raw',
+        schema: writerSchema,
+        readerSchema: {
+          type: 'record',
+          name: 'Writer',
+          fields: [{name: 'added', type: fieldType as any, default: defaultValue}]
+        }
+      })
+    ).rejects.toThrow('default');
+  });
+
+  test('rejects reader enum, fixed, and primitive incompatibilities', async () => {
+    const writerSchema = {
+      type: 'record',
+      name: 'Writer',
+      fields: [
+        {name: 'kind', type: {type: 'enum', symbols: ['A', 'B']}},
+        {name: 'token', type: {type: 'fixed', size: 2}},
+        {name: 'count', type: 'int'}
+      ]
+    };
+    const encoded = await encodeRaw(writerSchema, {
+      kind: 'B',
+      token: new Uint8Array([1, 2]),
+      count: 3
+    });
+
+    await expect(
+      parseAvro(encoded, {
+        encoding: 'raw',
+        schema: writerSchema,
+        readerSchema: {
+          type: 'record',
+          name: 'Writer',
+          fields: [{name: 'kind', type: {type: 'enum', symbols: ['A']}}]
+        }
+      })
+    ).rejects.toThrow('not present in the reader schema');
+    await expect(
+      parseAvro(encoded, {
+        encoding: 'raw',
+        schema: writerSchema,
+        readerSchema: {
+          type: 'record',
+          name: 'Writer',
+          fields: [{name: 'token', type: {type: 'fixed', size: 3}}]
+        }
+      })
+    ).rejects.toThrow('incompatible sizes');
+    await expect(
+      parseAvro(encoded, {
+        encoding: 'raw',
+        schema: writerSchema,
+        readerSchema: {
+          type: 'record',
+          name: 'Writer',
+          fields: [{name: 'count', type: 'boolean'}]
+        }
+      })
+    ).rejects.toThrow('cannot promote');
+  });
+
+  test.each([
+    [[2, 1], 'unscaled value'],
+    [[6, 2, 1, 1], 'scale'],
+    [[8, 2, 1, 0, 0], 'scale']
+  ] as const)('rejects malformed big-decimal payload %j', async (bytes, message) => {
+    await expect(
+      parseAvro(Uint8Array.from(bytes).buffer, {
+        encoding: 'raw',
+        schema: {
+          type: 'record',
+          fields: [{name: 'value', type: {type: 'bytes', logicalType: 'big-decimal'}}]
+        }
+      })
+    ).rejects.toThrow(message);
+  });
+
   test('supports automatic single-object detection and optional fingerprint validation', async () => {
     const schema = {
       type: 'record',

--- a/modules/core/test/lib/fetch/fetch-error-boundaries.spec.ts
+++ b/modules/core/test/lib/fetch/fetch-error-boundaries.spec.ts
@@ -1,0 +1,48 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {expect, test} from 'vitest';
+import {
+  getErrorMessageFromResponse,
+  getErrorMessageFromResponseSync
+} from '../../../src/lib/fetch/fetch-error-message';
+import {
+  checkFetchResponseStatus,
+  checkFetchResponseStatusSync
+} from '../../../src/lib/loader-utils/check-errors';
+
+test('fetch error helpers format JSON, text, HTML, and unreadable responses', async () => {
+  const jsonResponse = new Response('{"error":"bad"}', {
+    status: 400,
+    statusText: 'Bad Request',
+    headers: {'Content-Type': 'application/json'}
+  });
+  expect(await getErrorMessageFromResponse(jsonResponse)).toContain('{"error":"bad"}');
+  expect(getErrorMessageFromResponseSync(jsonResponse)).toContain('400');
+
+  const textResponse = new Response('plain failure', {status: 500, statusText: 'Server Error'});
+  expect(await getErrorMessageFromResponse(textResponse)).toContain('Server Error');
+  await expect(checkFetchResponseStatus(textResponse)).rejects.toThrow(/plain fail/);
+
+  const htmlResponse = new Response('<pre>precise failure</pre>', {status: 503});
+  await expect(checkFetchResponseStatus(htmlResponse)).rejects.toThrow('precise failure');
+  expect(() => checkFetchResponseStatusSync(new Response(null, {status: 404}))).toThrow(
+    'fetch failed 404'
+  );
+  await expect(
+    checkFetchResponseStatus(new Response(null, {status: 204}))
+  ).resolves.toBeUndefined();
+  expect(() => checkFetchResponseStatusSync(new Response(null, {status: 204}))).not.toThrow();
+
+  const unreadableResponse = {
+    url: 'memory://error',
+    status: 500,
+    statusText: 'Unreadable',
+    headers: new Headers({'Content-Type': 'application/json'}),
+    text: async () => {
+      throw new Error('body unavailable');
+    }
+  } as Response;
+  expect(await getErrorMessageFromResponse(unreadableResponse)).toContain('memory://error');
+});

--- a/modules/core/test/lib/fetch/read-array-buffer.spec.ts
+++ b/modules/core/test/lib/fetch/read-array-buffer.spec.ts
@@ -1,0 +1,16 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {expect, test} from 'vitest';
+import {readArrayBuffer, readBlob} from '../../../src/lib/fetch/read-array-buffer';
+
+test('readArrayBuffer slices blobs, buffers, and strings', async () => {
+  const bytes = new Uint8Array([0, 1, 2, 3, 4]);
+  await expect(readArrayBuffer(new Blob([bytes]), 1, 3)).resolves.toEqual(
+    new Uint8Array([1, 2, 3]).buffer
+  );
+  await expect(readArrayBuffer(bytes.buffer, 2, 2)).resolves.toEqual(new Uint8Array([2, 3]).buffer);
+  expect(new TextDecoder().decode(await readArrayBuffer('abcdef', 2, 3))).toBe('cde');
+  await expect(readBlob(new Blob([]))).resolves.toEqual(new ArrayBuffer(0));
+});

--- a/modules/deck-layers/test/raster-source-layer.spec.ts
+++ b/modules/deck-layers/test/raster-source-layer.spec.ts
@@ -5,6 +5,7 @@
 import {COORDINATE_SYSTEM} from '@deck.gl/core';
 import {describe, expect, test, vi} from 'vitest';
 import type {RasterData, RasterSourceMetadata} from '@loaders.gl/loader-utils';
+import {RasterSet} from '@loaders.gl/tiles';
 import {
   RasterSourceLayer,
   colorizeRasterData,
@@ -320,6 +321,125 @@ describe('RasterSourceLayer lifecycle', () => {
     expect(layer.state.metadata).toBe(GEOGRAPHIC_METADATA);
     expect(layer.state.rasterSet).toBeTruthy();
     layer.releaseRasterSet();
+  });
+
+  test('forwards every RasterSet event and finalizes an owned source', async () => {
+    const callbacks = {
+      onLoadingStateChange: vi.fn(),
+      onMetadataLoad: vi.fn(),
+      onMetadataLoadError: vi.fn(),
+      onRasterLoadStart: vi.fn(),
+      onRasterLoad: vi.fn(),
+      onRasterLoadError: vi.fn()
+    };
+    const close = vi.fn(async () => {});
+    const source = {
+      async getMetadata() {
+        return GEOGRAPHIC_METADATA;
+      },
+      async getRaster() {
+        return createRaster(new Float32Array([0, 1, 2, 3]));
+      },
+      close
+    };
+    const sourceLoader = {
+      id: 'raster-source',
+      name: 'Raster source',
+      module: 'test',
+      version: '1',
+      extensions: ['raster'],
+      mimeTypes: [],
+      type: 'raster',
+      fromUrl: true,
+      fromBlob: false,
+      testURL: () => true,
+      createDataSource: () => source
+    };
+    let subscriber: any;
+    const rasterSet = {
+      metadata: null,
+      subscribe(value: any) {
+        subscriber = value;
+        return vi.fn();
+      },
+      loadMetadata: vi.fn(async () => {}),
+      requestRaster: vi.fn(),
+      finalize: vi.fn()
+    };
+    const fromRasterSource = vi
+      .spyOn(RasterSet, 'fromRasterSource')
+      .mockReturnValue(rasterSet as any);
+    const layer = createRasterLayer({
+      data: 'memory.raster',
+      sources: [sourceLoader],
+      ...callbacks
+    });
+    layer.context = {viewport: createViewport([-10, -5, 20, 15])};
+    layer.setState = (update: any) => Object.assign(layer.state, update);
+    layer.setNeedsUpdate = vi.fn();
+    layer.raiseError = vi.fn();
+    layer.initializeState();
+
+    await layer.resolveSource(layer.props);
+    subscriber.onLoadingStateChange(true);
+    subscriber.onMetadataLoadError(new Error('metadata'));
+    subscriber.onRasterLoadStart(7);
+    subscriber.onRasterLoadError(7, new Error('raster'));
+    subscriber.onUpdate();
+    subscriber.onMetadataLoad(GEOGRAPHIC_METADATA);
+    subscriber.onRasterLoad({
+      requestId: 7,
+      raster: createRaster(new Float32Array([0, 1, 2, 3])),
+      parameters: {viewport: createRasterViewport(layer.context.viewport, GEOGRAPHIC_METADATA)}
+    });
+
+    expect(callbacks.onLoadingStateChange).toHaveBeenCalledWith(true);
+    expect(callbacks.onMetadataLoadError).toHaveBeenCalledOnce();
+    expect(callbacks.onRasterLoadStart).toHaveBeenCalledWith(7);
+    expect(callbacks.onRasterLoadError).toHaveBeenCalledOnce();
+    expect(callbacks.onMetadataLoad).toHaveBeenCalledWith(GEOGRAPHIC_METADATA);
+    expect(callbacks.onRasterLoad).toHaveBeenCalledOnce();
+    expect(layer.setNeedsUpdate).toHaveBeenCalledOnce();
+
+    layer.context = null;
+    layer.finalizeState({} as any);
+    await Promise.resolve();
+    expect(close).toHaveBeenCalledOnce();
+    fromRasterSource.mockRestore();
+  });
+
+  test('reports incompatible sources and covers raster placement fallbacks', async () => {
+    const onSourceError = vi.fn();
+    const layer = createRasterLayer({
+      data: {
+        async getMetadata() {
+          return {layers: []};
+        },
+        async getSchema() {
+          return {fields: []};
+        },
+        async getFeatures() {
+          return {shape: 'geojson-table', type: 'FeatureCollection', features: []};
+        }
+      },
+      onSourceError
+    });
+    layer.initializeState();
+    layer.raiseError = vi.fn();
+    await layer.resolveSource(layer.props);
+    expect(onSourceError).toHaveBeenCalledOnce();
+
+    const metadata = {...GEOGRAPHIC_METADATA, boundingBox: undefined};
+    const viewport = createRasterViewport(createViewport([-1, -1, 1, 1]), metadata);
+    const result = createDefaultRasterRenderResult(
+      createRaster(new Float32Array([Number.NaN, Number.POSITIVE_INFINITY, 1, 1]), {
+        boundingBox: undefined
+      }),
+      {viewport: {...viewport, bounds: undefined}, bands: [0]},
+      metadata
+    );
+    expect(result.bounds).toEqual([0, 2, 2, 0]);
+    expect(Array.from((result.image as any).data)).toHaveLength(16);
   });
 });
 

--- a/modules/deck-layers/test/shared-tile-2d-view.spec.ts
+++ b/modules/deck-layers/test/shared-tile-2d-view.spec.ts
@@ -3,7 +3,14 @@
 // Copyright (c) vis.gl contributors
 
 import {expect, test} from 'vitest';
-import {Tileset2D, type Tileset2DAdapter} from '@loaders.gl/tiles';
+import {Matrix4} from '@math.gl/core';
+import {
+  STRATEGY_DEFAULT,
+  STRATEGY_NEVER,
+  STRATEGY_REPLACE,
+  Tileset2D,
+  type Tileset2DAdapter
+} from '@loaders.gl/tiles';
 import {SharedTile2DView} from '../src/shared-tile-2d/shared-tile-2d-view';
 const TEST_ADAPTER: Tileset2DAdapter<any> = {
   getTileIndices: () => [
@@ -69,3 +76,82 @@ test('SharedTile2DView#same-viewport updates reload only stale selected tiles', 
   view.finalize();
   tileset.finalize();
 });
+
+test.each([
+  [STRATEGY_DEFAULT, true],
+  [STRATEGY_REPLACE, true],
+  [STRATEGY_NEVER, false]
+] as const)('SharedTile2DView exercises %s refinement across a tile hierarchy', (strategy, ancestorVisible) => {
+  const root = createTile('root', 0);
+  const child = createTile('child', 1, root);
+  const grandchild = createTile('grandchild', 2, child);
+  root.children = [child];
+  child.children = [grandchild];
+  root.isLoaded = true;
+  const tiles = [root, child, grandchild];
+  const tileset = createStructuralTileset(tiles, strategy);
+  const view = new SharedTile2DView(tileset as any) as any;
+  view._selectedTiles = [grandchild];
+
+  expect(view._updateTileStates()).toBe(true);
+  expect(view.isTileVisible(root)).toBe(ancestorVisible);
+  expect(view.isTileVisible(grandchild)).toBe(!ancestorVisible || strategy === STRATEGY_NEVER);
+  expect(view._getVisibleTiles()).toEqual(tiles.filter(tile => view._state.get(tile)?.isVisible));
+  expect(view._updateTileStates()).toBe(false);
+  view.finalize();
+});
+
+test('SharedTile2DView traverses unloaded descendants and culls geographic and cartesian boxes', () => {
+  const root = createTile('root', 0);
+  const child = createTile('child', 1, root);
+  const grandchild = createTile('grandchild', 2, child);
+  root.children = [child];
+  child.children = [grandchild];
+  grandchild.isLoaded = true;
+  const view = new SharedTile2DView(
+    createStructuralTileset([root, child, grandchild], STRATEGY_DEFAULT) as any
+  ) as any;
+  view._selectedTiles = [root];
+  view._updateTileStates();
+
+  expect(view.isTileVisible(root)).toBe(true);
+  expect(view.isTileVisible(grandchild)).toBe(true);
+  expect(view._tileOverlapsBounds(root, [-0.5, -0.5, 0.5, 0.5])).toBe(true);
+  expect(view._tileOverlapsBounds(root, [2, 2, 3, 3])).toBe(false);
+
+  const cartesianTile = {
+    ...createTile('cartesian', 0),
+    bbox: {left: 0, top: 2, right: 2, bottom: 0}
+  };
+  expect(view._tileOverlapsBounds(cartesianTile, [1, 1, 3, 3])).toBe(true);
+  expect(view._tileOverlapsBounds(cartesianTile, [3, 3, 4, 4])).toBe(false);
+  expect(view._getTileBoundingBox(cartesianTile, Matrix4.IDENTITY)).toEqual(cartesianTile.bbox);
+  expect(
+    view._getTileBoundingBox(cartesianTile, new Matrix4().translate([10, 20, 0]))
+  ).toMatchObject({left: 10, right: 12, top: 20, bottom: 22});
+  view.finalize();
+});
+
+function createTile(id: string, zoom: number, parent: any = null): any {
+  return {
+    id,
+    zoom,
+    index: {x: 0, y: 0, z: zoom},
+    parent,
+    children: null,
+    isLoaded: false,
+    content: null,
+    needsReload: false,
+    bbox: {west: 0, south: 0, east: 1, north: 1}
+  };
+}
+
+function createStructuralTileset(tiles: any[], refinementStrategy: string): any {
+  return {
+    tiles,
+    refinementStrategy,
+    attachConsumer() {},
+    detachConsumer() {},
+    updateConsumer() {}
+  };
+}

--- a/modules/deck-layers/test/tile-2d-source-layer.spec.ts
+++ b/modules/deck-layers/test/tile-2d-source-layer.spec.ts
@@ -328,6 +328,97 @@ test('Tile2DSourceLayer updates existing tilesets and viewport callbacks', () =>
   expect(view.isTileVisible).toHaveBeenCalled();
 });
 
+test('Tile2DSourceLayer asynchronously resolves direct sources and reports invalid inputs', async () => {
+  const layer = createLayer({id: 'resolve', data: TEST_TILE_SOURCE as any});
+  layer.context = {viewport: {id: 'main'}, device: createDevice()} as any;
+  layer.initializeState();
+  layer.setState = (update: any) => Object.assign(layer.state, update);
+  layer.updateTilesetForProps = vi.fn();
+
+  layer.updateState({
+    props: layer.props,
+    oldProps: {...layer.props, data: null},
+    changeFlags: {dataChanged: true}
+  });
+  await Promise.resolve();
+  await Promise.resolve();
+
+  expect(layer.state.resolvedData).toBe(TEST_TILE_SOURCE);
+  expect(layer.updateTilesetForProps).toHaveBeenCalledWith(
+    TEST_TILE_SOURCE,
+    true,
+    expect.objectContaining({propsOrDataChanged: true})
+  );
+
+  const onSourceError = vi.fn();
+  const invalidLayer = createLayer({id: 'invalid', data: 42 as any, onSourceError});
+  invalidLayer.context = {} as any;
+  invalidLayer.initializeState();
+  invalidLayer.raiseError = vi.fn();
+  await invalidLayer.resolveTileSource(invalidLayer.props);
+  expect(onSourceError).toHaveBeenCalledWith(expect.any(Error));
+  expect(invalidLayer.raiseError).toHaveBeenCalledWith(
+    expect.any(Error),
+    'resolving 2D tile source'
+  );
+});
+
+test('Tile2DSourceLayer finalizes owned sources and rejects incompatible source types', async () => {
+  const close = vi.fn(async () => {});
+  const source = {...TEST_TILE_SOURCE, close};
+  const sourceLoader = {
+    ...TEST_SOURCE_FACTORY,
+    createDataSource: () => source
+  };
+  const layer = createLayer({
+    id: 'owned-tile-source',
+    data: 'memory.test',
+    sources: [sourceLoader as any]
+  });
+  layer.context = {device: createDevice()} as any;
+  layer.initializeState();
+  layer.setState = (update: any) => Object.assign(layer.state, update);
+  layer.updateTilesetForProps = vi.fn();
+  await layer.resolveTileSource(layer.props);
+  layer.context = null;
+  layer.finalizeState({} as any);
+  await Promise.resolve();
+  expect(close).toHaveBeenCalledOnce();
+
+  const onSourceError = vi.fn();
+  const incompatibleLayer = createLayer({
+    id: 'incompatible-tile-source',
+    data: {
+      async getMetadata() {
+        return {width: 1, height: 1, bandCount: 1, dtype: 'uint8'};
+      },
+      async getRaster() {
+        return {data: new Uint8Array([1]), width: 1, height: 1, bandCount: 1, dtype: 'uint8'};
+      }
+    } as any,
+    onSourceError
+  });
+  incompatibleLayer.context = {} as any;
+  incompatibleLayer.initializeState();
+  incompatibleLayer.raiseError = vi.fn();
+  await incompatibleLayer.resolveTileSource(incompatibleLayer.props);
+  expect(onSourceError).toHaveBeenCalledOnce();
+});
+
+test('Tile2DSourceLayer tracks changed and equivalent activated viewports', () => {
+  const layer = createLayer();
+  layer.context = {viewport: {id: 'main'}, device: createDevice()} as any;
+  layer.initializeState();
+  layer.setNeedsUpdate = vi.fn();
+  const firstViewport = {id: 'secondary', equals: vi.fn(() => false)};
+  layer.activateViewport(firstViewport);
+  expect(layer.setNeedsUpdate).toHaveBeenCalledOnce();
+  const equivalentViewport = {id: 'secondary', equals: vi.fn(() => true)};
+  layer._knownViewports.set('secondary', equivalentViewport);
+  layer.activateViewport(equivalentViewport);
+  expect(layer.setNeedsUpdate).toHaveBeenCalledOnce();
+});
+
 function createDevice(devicePixelRatio = 1) {
   return {
     getCanvasContext: () => ({getDevicePixelRatio: () => devicePixelRatio})

--- a/modules/deck-layers/test/vector-source-layer.spec.ts
+++ b/modules/deck-layers/test/vector-source-layer.spec.ts
@@ -546,6 +546,87 @@ test('VectorSourceLayer metadata subscription covers automatic layer discovery a
   expect(vectorSet.updateViewport).toHaveBeenCalledOnce();
   fromVectorSource.mockRestore();
 });
+
+test('VectorSourceLayer reports incompatible sources and finalizes owned URL sources', async () => {
+  const onSourceError = vi.fn();
+  const incompatibleLayer = createLayer({
+    id: 'incompatible-vector-source',
+    data: {
+      async getMetadata() {
+        return {width: 1, height: 1, bandCount: 1, dtype: 'uint8'};
+      },
+      async getRaster() {
+        return {data: new Uint8Array([1]), width: 1, height: 1, bandCount: 1, dtype: 'uint8'};
+      }
+    } as any,
+    onSourceError
+  });
+  incompatibleLayer.initializeState();
+  incompatibleLayer.raiseError = vi.fn();
+  await incompatibleLayer.resolveVectorSource(incompatibleLayer.props);
+  expect(onSourceError).toHaveBeenCalledOnce();
+  expect(incompatibleLayer.raiseError).toHaveBeenCalledOnce();
+
+  const close = vi.fn(async () => {});
+  const source = {...TEST_VECTOR_SOURCE, close};
+  const sourceLoader = {
+    id: 'vector-source',
+    name: 'Vector source',
+    module: 'test',
+    version: '1',
+    extensions: ['vector'],
+    mimeTypes: [],
+    type: 'vector',
+    fromUrl: true,
+    fromBlob: false,
+    testURL: () => true,
+    createDataSource: () => source
+  };
+  const layer = createLayer({
+    id: 'owned-vector-source',
+    data: 'memory.vector',
+    sources: [sourceLoader] as any,
+    layers: []
+  });
+  layer.initializeState();
+  layer.setState = (update: Record<string, unknown>) => Object.assign(layer.state, update);
+  layer.context = {viewport: createViewport([0, 1, 2, 3])};
+  layer.raiseError = vi.fn();
+  await layer.resolveVectorSource(layer.props);
+  layer.context = null;
+  layer.finalizeState({} as any);
+  await flushMicrotasks();
+  expect(close).toHaveBeenCalledOnce();
+});
+
+test('VectorSourceLayer leaves auto layers idle when metadata has no named layer', async () => {
+  const layer = createLayer({
+    id: 'empty-auto-layers',
+    data: TEST_VECTOR_SOURCE as any,
+    layers: 'auto'
+  });
+  layer.initializeState();
+  layer.setState = (update: Record<string, unknown>) => Object.assign(layer.state, update);
+  let subscriber: any;
+  const vectorSet = {
+    layers: [],
+    setOptions: vi.fn(),
+    updateViewport: vi.fn(),
+    subscribe(callbacks: any) {
+      subscriber = callbacks;
+      return vi.fn();
+    },
+    finalize: vi.fn()
+  };
+  const fromVectorSource = vi
+    .spyOn(VectorSet, 'fromVectorSource')
+    .mockReturnValue(vectorSet as any);
+  layer.state.resolvedData = TEST_VECTOR_SOURCE;
+  (layer as any)._getOrCreateVectorSet(TEST_VECTOR_SOURCE, true);
+  subscriber.onMetadataLoad({layers: []});
+  expect(vectorSet.updateViewport).not.toHaveBeenCalled();
+  fromVectorSource.mockRestore();
+});
 function createArrowTable() {
   const schema = {
     fields: [

--- a/modules/geoarrow/test/geoarrow-converter-fallback.spec.ts
+++ b/modules/geoarrow/test/geoarrow-converter-fallback.spec.ts
@@ -276,3 +276,67 @@ test('compatibility fallback selects dimension bands from declared geometry type
     expect(result.length).toBe(1);
   }
 });
+
+test('compatibility fallback extracts every dense-union family back to WKT', async () => {
+  const {convertGeoArrowVector} = await loadFallbackConverter();
+  const wkts = [
+    'POINT (1 2)',
+    'LINESTRING (0 0, 1 1)',
+    'POLYGON ((0 0, 1 0, 0 0))',
+    'MULTIPOINT ((1 2), (3 4))',
+    'MULTILINESTRING ((0 0, 1 1))',
+    'MULTIPOLYGON (((0 0, 1 0, 0 0)))',
+    'GEOMETRYCOLLECTION (POINT (9 8), LINESTRING (1 2, 3 4))',
+    null
+  ];
+  const union = convertGeoArrowVector(
+    arrow.vectorFromArray(wkts, new arrow.Utf8()),
+    'geoarrow.wkt',
+    'geoarrow.geometry',
+    {fallback: 'geojson', geometryTypes: ['Point', 'GeometryCollection']}
+  );
+  const roundTrip = convertGeoArrowVector(union, 'geoarrow.geometry', 'geoarrow.wkt', {
+    fallback: 'geojson'
+  });
+
+  expect(Array.from({length: roundTrip.length}, (_, index) => roundTrip.get(index))).toEqual(wkts);
+});
+
+test('compatibility fallback extracts nullable geometry collections to WKB and WKT', async () => {
+  const {convertGeoArrowVector, convertGeoArrowVectorCellToGeoJSON} = await loadFallbackConverter();
+  const source = arrow.vectorFromArray(
+    [
+      'GEOMETRYCOLLECTION (POINT Z (1 2 3), LINESTRING Z (0 0 0, 1 1 1))',
+      'GEOMETRYCOLLECTION EMPTY',
+      null
+    ],
+    new arrow.Utf8()
+  );
+  const collection = convertGeoArrowVector(source, 'geoarrow.wkt', 'geoarrow.geometrycollection', {
+    fallback: 'geojson',
+    coordinates: 'separated',
+    dimension: 'xyz',
+    offsetType: 'int64',
+    geometryTypes: ['GeometryCollection Z']
+  });
+  const wkb = convertGeoArrowVector(collection, 'geoarrow.geometrycollection', 'geoarrow.wkb', {
+    fallback: 'geojson',
+    dimension: 'xyz'
+  });
+  const roundTrip = convertGeoArrowVector(wkb, 'geoarrow.wkb', 'geoarrow.geometrycollection', {
+    fallback: 'geojson',
+    dimension: 'xyz',
+    geometryTypes: ['GeometryCollection Z']
+  });
+
+  expect(convertGeoArrowVectorCellToGeoJSON(roundTrip, 0, 'geoarrow.geometrycollection')).toEqual(
+    convertGeoArrowVectorCellToGeoJSON(collection, 0, 'geoarrow.geometrycollection')
+  );
+  expect(convertGeoArrowVectorCellToGeoJSON(roundTrip, 1, 'geoarrow.geometrycollection')).toEqual({
+    type: 'GeometryCollection',
+    geometries: []
+  });
+  expect(
+    convertGeoArrowVectorCellToGeoJSON(roundTrip, 2, 'geoarrow.geometrycollection')
+  ).toBeNull();
+});

--- a/modules/gis/test/convert-to-geojson.spec.ts
+++ b/modules/gis/test/convert-to-geojson.spec.ts
@@ -1,0 +1,42 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {expect, test} from 'vitest';
+import {
+  convertToBinaryGeometry,
+  convertToGeoJSON,
+  convertToWKB,
+  convertToWKT
+} from '../src/lib/geometry-converters/convert-to-geojson';
+import {writeWkbHeader} from '../src/lib/geometry-converters/wkb/helpers/write-wkb-header';
+import {BinaryWriter} from '../src/lib/utils/binary-writer';
+
+test('legacy geometry conversion helpers cover WKT and WKB inputs', () => {
+  const point = {type: 'Point', coordinates: [1, 2]} as const;
+  const wkt = convertToWKT(point);
+  const wkb = convertToWKB(point);
+
+  expect(wkt).toBe('POINT (1 2)');
+  expect(convertToGeoJSON(wkt)).toEqual(point);
+  expect(convertToGeoJSON(wkb)).toEqual(point);
+  expect(convertToBinaryGeometry(wkb).type).toBe('Point');
+  expect(() => convertToGeoJSON({} as never)).toThrow(/not implemented/);
+  expect(() => convertToBinaryGeometry(wkt)).toThrow(/not implemented/);
+  expect(() => convertToBinaryGeometry(point)).toThrow(/not implemented/);
+});
+
+test.each([
+  [{}, 1],
+  [{hasZ: true}, 1001],
+  [{hasM: true}, 2001],
+  [{hasZ: true, hasM: true}, 3001],
+  [{hasZ: true, srid: 4326}, 0x80000001],
+  [{hasM: true, srid: 4326}, 0x40000001],
+  [{hasZ: true, hasM: true, srid: 4326}, 0xc0000001]
+] as const)('writeWkbHeader encodes dimensional flags %#', (options, expectedType) => {
+  const writer = new BinaryWriter(5);
+  writeWkbHeader(writer, 1, options);
+  expect(writer.dataView.getUint8(0)).toBe(1);
+  expect(writer.dataView.getUint32(1, true)).toBe(expectedType);
+});

--- a/modules/gltf/test/gltf-constants.spec.ts
+++ b/modules/gltf/test/gltf-constants.spec.ts
@@ -1,0 +1,22 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {expect, test} from 'vitest';
+import {
+  getBytesFromComponentType,
+  getGLEnumFromSamplerParameter,
+  getSizeFromAccessorType
+} from '../src/lib/gltf-utils/gltf-constants';
+
+test('glTF constant helpers map component, accessor, and sampler values', () => {
+  expect(getBytesFromComponentType(5126)).toBe(4);
+  expect(getBytesFromComponentType(5130)).toBe(8);
+  expect(getSizeFromAccessorType('VEC3')).toBe(3);
+  expect(getSizeFromAccessorType('MAT4')).toBe(16);
+  expect(getGLEnumFromSamplerParameter('magFilter')).toBe(0x2800);
+  expect(getGLEnumFromSamplerParameter('minFilter')).toBe(0x2801);
+  expect(getGLEnumFromSamplerParameter('wrapS')).toBe(0x2802);
+  expect(getGLEnumFromSamplerParameter('wrapT')).toBe(0x2803);
+  expect(getGLEnumFromSamplerParameter('unknown')).toBeUndefined();
+});

--- a/modules/i3s/test/convert-i3s-obb-to-mbs.spec.ts
+++ b/modules/i3s/test/convert-i3s-obb-to-mbs.spec.ts
@@ -1,0 +1,13 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {expect, test} from 'vitest';
+import {convertI3SObbToMbs} from '../src/lib/utils/convert-i3s-obb-to-mbs';
+
+test('convertI3SObbToMbs preserves the cartographic center and encloses every half axis', () => {
+  const center = [-122.4, 37.8, 25];
+  const sphere = convertI3SObbToMbs({center, halfSize: [3, 4, 12]});
+  expect(sphere.slice(0, 3)).toEqual(center);
+  expect(sphere[3]).toBeCloseTo(13);
+});

--- a/modules/las/test/typescript-las-format-matrix.spec.ts
+++ b/modules/las/test/typescript-las-format-matrix.spec.ts
@@ -285,6 +285,83 @@ test('TypeScript LAS metadata tolerates truncated VLR and EVLR records', () => {
   expect(truncatedExtendedMetadata?.evlrs).toEqual([]);
 });
 
+test('TypeScript LAS resolves VLR and EVLR metadata families and GeoTIFF key values', () => {
+  const geoKeyDirectory = new Uint16Array([
+    1, 1, 0, 5, 1024, 0, 1, 4326, 2048, 34735, 2, 24, 2054, 34736, 1, 0, 3073, 34737, 5, 0, 4096,
+    999, 1, 0, 7, 8
+  ]);
+  const geoDoubleParameters = new Float64Array([12.5]);
+  const waveform = new Uint8Array(28);
+  const waveformView = new DataView(waveform.buffer);
+  waveform[2] = 16;
+  waveform[3] = 2;
+  waveformView.setUint32(4, 32, true);
+  waveformView.setUint32(8, 4, true);
+  waveformView.setFloat64(12, 1.5, true);
+  waveformView.setFloat64(20, -2.5, true);
+
+  const source = createLASMetadataFixture(
+    [
+      {userId: 'LASF_Spec', recordId: 100, data: waveform},
+      {userId: 'LASF_Projection', recordId: 2111, data: encodeLASString('TRANSFORM')},
+      {userId: 'LASF_Projection', recordId: 2112, data: encodeLASString('VLR_WKT')},
+      {
+        userId: 'LASF_Projection',
+        recordId: 34735,
+        data: new Uint8Array(geoKeyDirectory.buffer)
+      },
+      {
+        userId: 'LASF_Projection',
+        recordId: 34736,
+        data: new Uint8Array(geoDoubleParameters.buffer)
+      },
+      {userId: 'LASF_Projection', recordId: 34737, data: encodeLASString('EPSG|')}
+    ],
+    [{userId: 'LASF_Projection', recordId: 2112, data: encodeLASString('EVLR_WKT')}]
+  );
+  const metadata = parseLASHeader(source).metadata!;
+
+  expect(metadata.vlrs).toHaveLength(6);
+  expect(metadata.evlrs).toHaveLength(1);
+  expect(metadata.wktMathTransform).toBe('TRANSFORM');
+  expect(metadata.wkt).toBe('EVLR_WKT');
+  expect(metadata.waveformPacketDescriptors).toEqual([
+    {
+      recordId: 100,
+      bitsPerSample: 16,
+      compressionType: 2,
+      numberOfSamples: 32,
+      temporalSampleSpacing: 4,
+      digitizerGain: 1.5,
+      digitizerOffset: -2.5
+    }
+  ]);
+  expect(metadata.geotiff?.keyDirectory?.entries.map(entry => entry.value)).toEqual([
+    4326,
+    [7, 8],
+    12.5,
+    'EPSG',
+    undefined
+  ]);
+});
+
+test('TypeScript LAS rejects truncated waveform metadata and ignores incomplete GeoKeys', () => {
+  expect(() =>
+    parseLASHeader(
+      createLASMetadataFixture([{userId: 'LASF_Spec', recordId: 100, data: new Uint8Array(27)}])
+    )
+  ).toThrow('waveform descriptor VLR 100 is truncated');
+
+  const keys = new Uint16Array([1, 1, 0, 2, 1024, 0, 1, 4326]);
+  const metadata = parseLASHeader(
+    createLASMetadataFixture([
+      {userId: 'LASF_Projection', recordId: 34735, data: new Uint8Array(keys.buffer)}
+    ])
+  ).metadata;
+  expect(metadata?.geotiff?.keys).toEqual(keys);
+  expect(metadata?.geotiff?.keyDirectory).toBeUndefined();
+});
+
 /** Collects all batches from the TypeScript streaming parser. */
 async function collectLASBatches(
   chunks: Iterable<ArrayBuffer | ArrayBufferView>
@@ -385,6 +462,67 @@ function createLAS15Header(): ArrayBuffer {
   bytes[104] = 6;
   view.setUint16(105, POINT_FORMAT_LENGTHS[6], true);
   return arrayBuffer;
+}
+
+type TestLASMetadataRecord = {userId: string; recordId: number; data: Uint8Array};
+
+/** Creates an empty LAS 1.4 file containing caller-selected VLR and EVLR metadata records. */
+function createLASMetadataFixture(
+  vlrs: TestLASMetadataRecord[],
+  evlrs: TestLASMetadataRecord[] = []
+): ArrayBuffer {
+  const headerLength = 375;
+  const vlrByteLength = vlrs.reduce((sum, record) => sum + 54 + record.data.byteLength, 0);
+  const pointDataOffset = headerLength + vlrByteLength;
+  const evlrByteLength = evlrs.reduce((sum, record) => sum + 60 + record.data.byteLength, 0);
+  const arrayBuffer = new ArrayBuffer(pointDataOffset + evlrByteLength);
+  const bytes = new Uint8Array(arrayBuffer);
+  const view = new DataView(arrayBuffer);
+  bytes.set(new TextEncoder().encode('LASF'));
+  bytes[24] = 1;
+  bytes[25] = 4;
+  view.setUint16(94, headerLength, true);
+  view.setUint32(96, pointDataOffset, true);
+  view.setUint32(100, vlrs.length, true);
+  bytes[104] = 6;
+  view.setUint16(105, POINT_FORMAT_LENGTHS[6], true);
+  view.setBigUint64(235, evlrs.length ? BigInt(pointDataOffset) : 0n, true);
+  view.setUint32(243, evlrs.length, true);
+
+  let byteOffset = headerLength;
+  for (const record of vlrs) {
+    writeLASMetadataRecord(bytes, view, byteOffset, record, false);
+    byteOffset += 54 + record.data.byteLength;
+  }
+  for (const record of evlrs) {
+    writeLASMetadataRecord(bytes, view, byteOffset, record, true);
+    byteOffset += 60 + record.data.byteLength;
+  }
+  return arrayBuffer;
+}
+
+/** Writes one LAS metadata record header and payload. */
+function writeLASMetadataRecord(
+  bytes: Uint8Array,
+  view: DataView,
+  byteOffset: number,
+  record: TestLASMetadataRecord,
+  extended: boolean
+): void {
+  bytes.set(new TextEncoder().encode(record.userId), byteOffset + 2);
+  view.setUint16(byteOffset + 18, record.recordId, true);
+  if (extended) {
+    view.setBigUint64(byteOffset + 20, BigInt(record.data.byteLength), true);
+    bytes.set(record.data, byteOffset + 60);
+  } else {
+    view.setUint16(byteOffset + 20, record.data.byteLength, true);
+    bytes.set(record.data, byteOffset + 54);
+  }
+}
+
+/** Encodes one null-terminated LAS metadata string. */
+function encodeLASString(value: string): Uint8Array {
+  return new TextEncoder().encode(`${value}\0`);
 }
 
 /** Return the RGB field offset for a LAS point format. */

--- a/modules/loader-utils/test/lib/iterators/async-iteration-boundaries.spec.ts
+++ b/modules/loader-utils/test/lib/iterators/async-iteration-boundaries.spec.ts
@@ -1,0 +1,23 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {expect, test, vi} from 'vitest';
+import {concatenateStringsAsync, forEach} from '../../../src/lib/iterators/async-iteration';
+
+test('async iteration adapts synchronous iterator completion and errors', async () => {
+  expect(await concatenateStringsAsync(['one', '-', 'two'])).toBe('one-two');
+
+  const returnIterator = [1, 2][Symbol.iterator]();
+  returnIterator.return = vi.fn(() => ({done: true, value: undefined}));
+  const values: number[] = [];
+  await forEach(returnIterator, value => {
+    values.push(value);
+  });
+  expect(values).toEqual([1, 2]);
+  expect(returnIterator.return).toHaveBeenCalledOnce();
+
+  const earlyIterator = [1, 2, 3][Symbol.iterator]();
+  await forEach(earlyIterator, value => value === 2);
+  expect(earlyIterator.next().value).toBe(3);
+});

--- a/modules/loader-utils/test/lib/laz/laz-chunk-decoder.spec.ts
+++ b/modules/loader-utils/test/lib/laz/laz-chunk-decoder.spec.ts
@@ -4,10 +4,13 @@
 
 import {expect, test} from 'vitest';
 import {
+  createLAZChunkDecoder,
   createLAZChunkDecoderCursor,
   decodeLAZChunk,
+  decodeLAZChunkInBatches,
   decodeLAZChunkTable,
   encodeLAZChunk,
+  getLAZChunkByteLength,
   getLAZChunkDeclaredByteLength,
   getLAZChunkHeaderByteLength,
   NeedsMoreData
@@ -143,3 +146,121 @@ test('legacy LAZ cursor preserves state across appended compressed input', () =>
   expect(firstOutputByteLength).toBeLessThan(compressed.byteLength);
   expect(actual).toEqual(expected);
 });
+
+test('feedable layered decoder covers incremental lifecycle and batch exhaustion', () => {
+  const {metadata, rawPointData, compressed} = createLayeredPDRF7Chunk();
+  const decoder = createLAZChunkDecoder(metadata);
+  expect(() => decoder.decode()).toThrowError(NeedsMoreData);
+
+  const headerByteLength = getLAZChunkHeaderByteLength(metadata);
+  decoder.feed(compressed.subarray(0, headerByteLength));
+  expect(decoder.readBatch(1)).toBeNull();
+  expect(() => getLAZChunkByteLength(compressed.subarray(0, headerByteLength), metadata)).toThrow(
+    NeedsMoreData
+  );
+
+  decoder.feed(compressed.subarray(headerByteLength));
+  expect(getLAZChunkByteLength(compressed, metadata)).toBe(compressed.byteLength);
+  expect(decoder.readBatch(1)).toEqual(rawPointData.subarray(0, metadata.pointDataRecordLength));
+  expect(decoder.remainingPointCount).toBe(1);
+  expect(decoder.readBatch(10)).toEqual(rawPointData.subarray(metadata.pointDataRecordLength));
+  expect(decoder.readBatch(1)).toBeNull();
+  decoder.close();
+  expect(() => decoder.feed(new Uint8Array())).toThrow('closed');
+});
+
+test('layered decoder streams fragmented chunks through the async batch helper', async () => {
+  const {metadata, rawPointData, compressed} = createLayeredPDRF7Chunk();
+  const chunks = [compressed.subarray(0, 10), compressed.subarray(10, 40), compressed.subarray(40)];
+  const batches: Uint8Array[] = [];
+  for await (const batch of decodeLAZChunkInBatches(chunks, metadata, {batchSize: 1})) {
+    batches.push(batch);
+  }
+  expect(batches).toHaveLength(2);
+  expect(new Uint8Array([...batches[0], ...batches[1]])).toEqual(rawPointData);
+});
+
+test('direct point-data decoding validates formats and locks cursor selections', () => {
+  const {metadata, compressed} = createLayeredPDRF7Chunk();
+  const positions = new Float64Array(metadata.pointCount * 3);
+  const pointDataTarget = {
+    positions,
+    pointOffset: 0,
+    scale: [1, 1, 1] as [number, number, number],
+    offset: [0, 0, 0] as [number, number, number]
+  };
+
+  expect(() =>
+    createLAZChunkDecoder({...metadata, pointDataRecordFormat: 2}).readPointDataBatch(
+      {positions, pointOffset: 0},
+      1
+    )
+  ).toThrow('point formats 6-10');
+  expect(() =>
+    createLAZChunkDecoder({...metadata, pointDataRecordFormat: 6}).readPointDataBatch(
+      {positions, rawColors: new Uint16Array(3), pointOffset: 0},
+      1
+    )
+  ).toThrow('does not contain RGB');
+  expect(() =>
+    createLAZChunkDecoder(metadata).readPositionDataBatch(
+      {positions, colors: new Uint8Array(4), pointOffset: 0},
+      1
+    )
+  ).toThrow('cannot request color');
+  expect(() =>
+    createLAZChunkDecoder(metadata).readPointDataBatch(
+      {positions, nir: new Uint16Array(1), pointOffset: 0},
+      1
+    )
+  ).toThrow('NIR output requires');
+  expect(() =>
+    createLAZChunkDecoder({...metadata, pointDataRecordFormat: 8}).readPointDataBatch(
+      {positions, waveforms: new Uint8Array(29), pointOffset: 0},
+      1
+    )
+  ).toThrow('Waveform output requires');
+
+  const rawCursor = createLAZChunkDecoderCursor(compressed, metadata);
+  rawCursor.decodeInto(new Uint8Array(metadata.pointDataRecordLength), 0, 1);
+  expect(() => rawCursor.decodeIntoPointData(pointDataTarget, 1)).toThrow(
+    'Cannot mix raw and point-data'
+  );
+  expect(() => rawCursor.feed(compressed)).toThrow('Only legacy');
+  expect(() => rawCursor.decodeAvailableInto(new Uint8Array(1), 0, 1)).toThrow('limited to legacy');
+
+  const selectedCursor = createLAZChunkDecoderCursor(compressed, metadata);
+  selectedCursor.decodeIntoPointData(pointDataTarget, 1);
+  expect(() =>
+    selectedCursor.decodeIntoPointData(
+      {...pointDataTarget, intensities: new Uint16Array(metadata.pointCount)},
+      1
+    )
+  ).toThrow('Cannot change selected');
+});
+
+/** Creates a tiny deterministic layered LAZ chunk and its raw PDRF 7 records. */
+function createLayeredPDRF7Chunk() {
+  const metadata = {
+    pointDataRecordFormat: 7,
+    pointDataRecordLength: 36,
+    pointCount: 2,
+    point14ItemVersion: 3 as const,
+    rgb14ItemVersion: 3 as const
+  };
+  const rawPointData = new Uint8Array(metadata.pointDataRecordLength * metadata.pointCount);
+  const dataView = new DataView(rawPointData.buffer);
+  for (let pointIndex = 0; pointIndex < metadata.pointCount; pointIndex++) {
+    const pointOffset = pointIndex * metadata.pointDataRecordLength;
+    dataView.setInt32(pointOffset, 100 + pointIndex, true);
+    dataView.setInt32(pointOffset + 4, 200 + pointIndex, true);
+    dataView.setInt32(pointOffset + 8, 300 + pointIndex, true);
+    dataView.setUint16(pointOffset + 12, 400 + pointIndex, true);
+    dataView.setUint8(pointOffset + 14, 0x11);
+    dataView.setFloat64(pointOffset + 22, 500 + pointIndex, true);
+    dataView.setUint16(pointOffset + 30, 10 + pointIndex, true);
+    dataView.setUint16(pointOffset + 32, 20 + pointIndex, true);
+    dataView.setUint16(pointOffset + 34, 30 + pointIndex, true);
+  }
+  return {metadata, rawPointData, compressed: encodeLAZChunk(rawPointData, metadata)};
+}

--- a/modules/loader-utils/test/lib/node/node-utils.node.spec.ts
+++ b/modules/loader-utils/test/lib/node/node-utils.node.spec.ts
@@ -1,0 +1,35 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {expect, test} from 'vitest';
+import {toArrayBuffer, toBuffer} from '../../../src/lib/node/buffer';
+import {promisify1, promisify2, promisify3} from '../../../src/lib/node/promisify';
+
+test('Node buffer adapters preserve bytes and existing instances', () => {
+  const buffer = Buffer.from([1, 2, 3]);
+  expect(new Uint8Array(toArrayBuffer(buffer))).toEqual(new Uint8Array([1, 2, 3]));
+  expect(toArrayBuffer('unchanged')).toBe('unchanged');
+  expect(toBuffer(buffer)).toBe(buffer);
+  expect(toBuffer(new Uint8Array([4, 5]) as any)).toEqual(Buffer.from([4, 5]));
+  expect(toBuffer(new Uint8Array([6, 7]).buffer)).toEqual(Buffer.from([6, 7]));
+  expect(() => toBuffer('invalid' as any)).toThrow('toBuffer');
+});
+
+test('promisify helpers forward arguments, values, and errors', async () => {
+  const one = promisify1<number, number>((value, callback) => callback(null, value + 1));
+  const two = promisify2<number, number, number>((left, right, callback) =>
+    callback(null, left + right)
+  );
+  const three = promisify3<number, number, number, number>((one, two, three, callback) =>
+    callback(null, one + two + three)
+  );
+  const failure = promisify1<number, number>((_value, callback) =>
+    callback(new Error('failed'), 0)
+  );
+
+  await expect(one(1)).resolves.toBe(2);
+  await expect(two(2, 3)).resolves.toBe(5);
+  await expect(three(1, 2, 3)).resolves.toBe(6);
+  await expect(failure(1)).rejects.toThrow('failed');
+});

--- a/modules/loader-utils/test/lib/sources/source-utils.spec.ts
+++ b/modules/loader-utils/test/lib/sources/source-utils.spec.ts
@@ -1,0 +1,51 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {afterEach, expect, test, vi} from 'vitest';
+import {TileSourceAdapter} from '../../../src/lib/sources/tile-source-adapter';
+import {getFetchFunction, mergeImageSourceLoaderProps} from '../../../src/lib/sources/utils/utils';
+
+afterEach(() => vi.unstubAllGlobals());
+
+test('source fetch utilities cover direct, static, and default fetch configuration', async () => {
+  const globalFetch = vi.fn(async () => new Response('global'));
+  vi.stubGlobal('fetch', globalFetch);
+
+  const directFetch = vi.fn(async () => new Response('direct'));
+  await getFetchFunction({fetch: directFetch})('direct-url', {method: 'POST'});
+  expect(directFetch).toHaveBeenCalledWith('direct-url', {method: 'POST'});
+
+  await getFetchFunction({
+    fetch: {headers: {'X-Static': 'static', 'X-Override': 'old'}, method: 'POST'}
+  })('static-url', {headers: {'X-Request': 'request', 'X-Override': 'new'}});
+  const [, staticOptions] = globalFetch.mock.calls[0];
+  expect(new Headers(staticOptions?.headers).get('X-Static')).toBe('static');
+  expect(new Headers(staticOptions?.headers).get('X-Request')).toBe('request');
+  expect(new Headers(staticOptions?.headers).get('X-Override')).toBe('new');
+
+  await getFetchFunction()('default-url');
+  expect(globalFetch).toHaveBeenLastCalledWith('default-url', undefined);
+
+  const merged = mergeImageSourceLoaderProps({loadOptions: {fetch: directFetch}, marker: true});
+  expect(merged.marker).toBe(true);
+  await merged.loadOptions.fetch('merged-url');
+  expect(directFetch).toHaveBeenLastCalledWith('merged-url', undefined);
+});
+
+test('TileSourceAdapter forwards metadata and converts tile requests to image requests', async () => {
+  const metadata = {name: 'image source'};
+  const getImage = vi.fn(async parameters => parameters);
+  const adapter = new TileSourceAdapter({
+    getMetadata: async () => metadata,
+    getImage
+  } as any);
+
+  await expect(adapter.getMetadata()).resolves.toBe(metadata);
+  const tile = await adapter.getTile({x: 0, y: 0, z: 1});
+  expect(tile).toMatchObject({width: 512, height: 512, layers: []});
+  await adapter.getTileData({index: {x: 1, y: 1, z: 2}} as any);
+  expect(getImage).toHaveBeenCalledTimes(2);
+  expect(adapter.getTileLowerLeftCorner(0, 0, 0)).toHaveLength(2);
+  expect(() => adapter.getTile({x: 0, y: 0, z: 0, crs: 'EPSG:4326'})).toThrow(/SRS not ESPG3758/);
+});

--- a/modules/mvt/test/mvt-worker-transport.spec.ts
+++ b/modules/mvt/test/mvt-worker-transport.spec.ts
@@ -1,0 +1,32 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import * as arrow from 'apache-arrow';
+import {expect, test} from 'vitest';
+import {
+  deserializeMVTWorkerResult,
+  serializeMVTWorkerResult
+} from '../src/lib/mvt-worker-transport';
+
+test('MVT worker transport round-trips Arrow tables and preserves other results', () => {
+  const table = {shape: 'arrow-table', data: arrow.tableFromArrays({value: [1, 2]})} as const;
+  const serialized = serializeMVTWorkerResult(table, {
+    core: {workerTransferBufferCopy: 'slice'}
+  } as any) as any;
+  const hydrated = deserializeMVTWorkerResult(serialized) as any;
+
+  expect(serialized.data.transport).toBe('arrow-js');
+  expect(hydrated.data).toBeInstanceOf(arrow.Table);
+  expect(hydrated.data.getChild('value')?.toArray()).toEqual(new Float64Array([1, 2]));
+  expect(serializeMVTWorkerResult(null)).toBeNull();
+  expect(serializeMVTWorkerResult({shape: 'object-row-table'})).toEqual({
+    shape: 'object-row-table'
+  });
+  expect(deserializeMVTWorkerResult('unchanged')).toBe('unchanged');
+
+  const topLevelCopy = serializeMVTWorkerResult(table, {
+    workerTransferBufferCopy: 'transfer'
+  } as any) as any;
+  expect(topLevelCopy.data.transport).toBe('arrow-js');
+});

--- a/modules/parquet/test/parquet-worker-transport.spec.ts
+++ b/modules/parquet/test/parquet-worker-transport.spec.ts
@@ -1,0 +1,25 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import * as arrow from 'apache-arrow';
+import {expect, test} from 'vitest';
+import {
+  deserializeParquetWorkerResult,
+  serializeParquetWorkerResult
+} from '../src/lib/parquet-worker-transport';
+
+test('Parquet worker transport round-trips Arrow IPC and preserves row tables', () => {
+  const table = {shape: 'arrow-table', data: arrow.tableFromArrays({value: [1, 2]})} as const;
+  const serialized = serializeParquetWorkerResult(table) as any;
+  const hydrated = deserializeParquetWorkerResult(serialized) as any;
+
+  expect(serialized.data.transport).toBe('arrow-ipc');
+  expect(hydrated.data).toBeInstanceOf(arrow.Table);
+  expect(hydrated.data.getChild('value')?.toArray()).toEqual(new Float64Array([1, 2]));
+
+  const rows = {shape: 'object-row-table', data: [{value: 1}]} as any;
+  expect(serializeParquetWorkerResult(rows)).toBe(rows);
+  expect(deserializeParquetWorkerResult(rows)).toBe(rows);
+  expect(serializeParquetWorkerResult(null)).toBeNull();
+});

--- a/modules/polyfills/test/fetch-node/decode-data-uri-boundaries.node.spec.ts
+++ b/modules/polyfills/test/fetch-node/decode-data-uri-boundaries.node.spec.ts
@@ -1,0 +1,17 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {expect, test} from 'vitest';
+import {decodeDataUri} from '../../src/fetch/utils/decode-data-uri.node';
+
+test.each([
+  ['data:text/html;base64,PGh0bWw+', 'text/html', '<html>'],
+  ['data:text/plain,important%20content!', 'text/plain', 'important content!'],
+  ['data:,default', 'text/plain;charset=US-ASCII', 'default'],
+  ['data:;charset=utf-8,unicode', 'text/plain;charset=utf-8', 'unicode']
+])('decodeDataUri decodes MIME and payload variants', (uri, mimeType, text) => {
+  const decoded = decodeDataUri(uri);
+  expect(decoded.mimeType).toBe(mimeType);
+  expect(new TextDecoder().decode(decoded.arrayBuffer)).toBe(text);
+});

--- a/modules/polyfills/test/images-node/image-codecs.node.spec.ts
+++ b/modules/polyfills/test/images-node/image-codecs.node.spec.ts
@@ -1,0 +1,46 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {expect, test} from 'vitest';
+import {readFile} from 'node:fs/promises';
+import {encodeImageNode, encodeImageToStreamNode} from '../../src/images/encode-image-node';
+import {NODE_FORMAT_SUPPORT, parseImageNode} from '../../src/images/parse-image-node';
+
+const IMAGE_FIXTURES = [
+  ['@loaders.gl/images/test/data/img1-preview.png', 'image/png'],
+  ['@loaders.gl/images/test/data/img1-preview.jpeg', 'image/jpeg'],
+  ['@loaders.gl/images/test/data/img1-preview.gif', 'image/gif']
+] as const;
+
+test.each(IMAGE_FIXTURES)('parseImageNode decodes %s', async (url, mimeType) => {
+  const filename = url.replace('@loaders.gl/images/', '../../../images/');
+  const image = await parseImageNode(
+    (await readFile(new URL(filename, import.meta.url))) as any,
+    mimeType
+  );
+
+  expect(image.data).toBeInstanceOf(Uint8Array);
+  expect(image.width).toBeGreaterThan(0);
+  expect(image.height).toBeGreaterThan(0);
+  expect(image.components).toBeGreaterThanOrEqual(3);
+  expect(NODE_FORMAT_SUPPORT).toContain(mimeType);
+});
+
+test('parseImageNode requires an explicit MIME type', async () => {
+  await expect(parseImageNode(new ArrayBuffer(0), '')).rejects.toThrow(/MIMEType is required/);
+});
+
+test('encodeImageNode writes a tiny image with explicit and default formats', async () => {
+  const image = {
+    data: new Uint8Array([255, 0, 0, 255, 0, 255, 0, 255]),
+    width: 2,
+    height: 1
+  };
+  const png = (await encodeImageNode(image, {type: 'image/png'})) as ArrayBuffer;
+  const jpeg = (await encodeImageNode(image, {})) as ArrayBuffer;
+
+  expect(png.byteLength).toBeGreaterThan(0);
+  expect(jpeg.byteLength).toBeGreaterThan(0);
+  expect(encodeImageToStreamNode(image, {type: 'png'})).toBeTruthy();
+});

--- a/modules/schema-utils/test/lib/table/arrow-utility-boundaries.spec.ts
+++ b/modules/schema-utils/test/lib/table/arrow-utility-boundaries.spec.ts
@@ -1,0 +1,65 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import * as arrow from 'apache-arrow';
+import {expect, test} from 'vitest';
+import {convertMeshToColumnarTable} from '../../../src/lib/mesh/convert-mesh-to-table';
+import {getTypeInfo} from '../../../src/lib/table/arrow-api/get-type-info';
+import {convertArrowToTable} from '../../../src/lib/table/tables/convert-arrow-table';
+import {selectArrowTableRows} from '../../../src/lib/table/query-arrow-table';
+import {
+  getFixedSizeListData,
+  getFixedSizeListType,
+  getListFixedSizeListSize,
+  getListFixedSizeListVector,
+  isListFixedSizeList
+} from '../../../src/lib/arrow-utils/arrow-list-of-fixed-size-list-utils';
+
+test('Arrow utility adapters cover row selection and every table shape', () => {
+  const data = arrow.tableFromArrays({name: ['a', 'b', 'c'], value: [1, 2, 3]});
+  const wrapped = {shape: 'arrow-table', data} as const;
+  const selected = selectArrowTableRows(wrapped, [2, 0], ['value'], 1);
+  expect(selected.data.numRows).toBe(1);
+  expect(selected.data.getChild('value')?.get(0)).toBe(3);
+  expect(() => selectArrowTableRows(wrapped, [0], ['missing'])).toThrow(/could not read column/);
+
+  expect(convertArrowToTable(data, 'arrow-table').shape).toBe('arrow-table');
+  expect(convertArrowToTable(data, 'columnar-table').data.value).toBeInstanceOf(Float64Array);
+  expect(convertArrowToTable(data, 'array-row-table').data).toHaveLength(3);
+  expect(convertArrowToTable(data, 'object-row-table').data[0]).toMatchObject({name: 'a'});
+  expect(convertArrowToTable(data, 'geojson-table').features).toHaveLength(3);
+  expect(() => convertArrowToTable(data, 'invalid' as any)).toThrow('invalid');
+});
+
+test('fixed-size-list and Arrow type helpers expose native buffer metadata', () => {
+  const values = new Float32Array([1, 2, 3, 4]);
+  const data = getFixedSizeListData(values, 2);
+  const type = getFixedSizeListType(values, 2);
+  const vector = getListFixedSizeListVector(new Uint32Array([0, 1]), values, 2);
+
+  expect(data.length).toBe(2);
+  expect(type.listSize).toBe(2);
+  expect(isListFixedSizeList(vector)).toBe(true);
+  expect(getListFixedSizeListSize(vector)).toBe(2);
+  expect(getListFixedSizeListSize(arrow.vectorFromArray([1, 2]))).toBe(1);
+  expect(getTypeInfo(new arrow.Float64())).toMatchObject({typeName: 'Float64'});
+  expect(getTypeInfo(new arrow.Int32()).typeEnumName).toBeTruthy();
+});
+
+test('mesh columnar conversion preserves attributes and optional indices', () => {
+  const baseMesh = {
+    shape: 'mesh',
+    topology: 'triangle-list',
+    mode: 4,
+    schema: {fields: [], metadata: {}},
+    attributes: {POSITION: {size: 3, value: new Float32Array([0, 0, 0])}}
+  } as any;
+  const withoutIndices = convertMeshToColumnarTable({...baseMesh, indices: null});
+  const indices = {size: 1, value: new Uint16Array([0])};
+  const withIndices = convertMeshToColumnarTable({...baseMesh, indices});
+
+  expect(withoutIndices.data.POSITION).toBe(baseMesh.attributes.POSITION.value);
+  expect(withoutIndices.indices).toBeUndefined();
+  expect(withIndices.indices).toBe(indices);
+});

--- a/modules/worker-utils/test/lib/library-utils/library-utils.spec.ts
+++ b/modules/worker-utils/test/lib/library-utils/library-utils.spec.ts
@@ -45,4 +45,20 @@ test('extractLoadLibraryOptions # flattens core options and preserves modules', 
     modules
   });
 });
+test('library option normalization covers top-level overrides and invalid inputs', () => {
+  expect(
+    extractLoadLibraryOptions({
+      useLocalLibraries: false,
+      CDN: null,
+      core: {useLocalLibraries: true, CDN: 'https://legacy.example.com'}
+    })
+  ).toEqual({useLocalLibraries: false, CDN: null});
+  expect(extractLoadLibraryOptions()).toEqual({});
+  expect(() => getLibraryUrl('decoder.js', 'test', {core: {} as any} as any)).toThrow(
+    /must be pre-normalized/
+  );
+  expect(() => getLibraryUrl('decoder.js', 'test', {CDN: 42 as any})).toThrow(
+    /must be a string or null/
+  );
+});
 test('loadLibrary', () => {});

--- a/modules/worker-utils/test/lib/process-utils/process-utils.node.spec.ts
+++ b/modules/worker-utils/test/lib/process-utils/process-utils.node.spec.ts
@@ -1,0 +1,27 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import ChildProcess from 'node:child_process';
+import {afterEach, expect, test, vi} from 'vitest';
+import {getAvailablePort} from '../../../src/lib/process-utils/process-utils';
+
+afterEach(() => vi.restoreAllMocks());
+
+test('getAvailablePort selects the first free port and falls back on process errors', async () => {
+  vi.spyOn(ChildProcess, 'exec').mockImplementationOnce(((_command, callback) => {
+    callback?.(
+      null,
+      'node 1 user 1u IPv4 TCP *:3000 (LISTEN)\nnode 2 user 1u IPv4 TCP *:3001 (LISTEN)',
+      ''
+    );
+    return {} as any;
+  }) as any);
+  await expect(getAvailablePort(3000)).resolves.toBe(3002);
+
+  vi.spyOn(ChildProcess, 'exec').mockImplementationOnce(((_command, callback) => {
+    callback?.(new Error('lsof unavailable'), '', '');
+    return {} as any;
+  }) as any);
+  await expect(getAvailablePort(4000)).resolves.toBe(4000);
+});

--- a/modules/worker-utils/test/remove-nontransferable-options.spec.ts
+++ b/modules/worker-utils/test/remove-nontransferable-options.spec.ts
@@ -1,0 +1,27 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {expect, test} from 'vitest';
+import {removeNontransferableOptions} from '../src/lib/worker-utils/remove-nontransferable-options';
+
+test('removeNontransferableOptions recursively sanitizes worker options', () => {
+  const typedArray = new Uint8Array([1, 2]);
+  const options = {
+    callback: () => 1,
+    expression: /tiles/,
+    nested: {value: 7, callback: () => 2, deeper: {expression: /deep/}},
+    typedArray,
+    scalar: 'kept'
+  };
+
+  expect(removeNontransferableOptions(options)).toEqual({
+    callback: {},
+    expression: {},
+    nested: {value: 7, callback: {}, deeper: {expression: {}}},
+    typedArray,
+    scalar: 'kept'
+  });
+  expect(removeNontransferableOptions(null)).toEqual({});
+  expect(options.callback()).toBe(1);
+});

--- a/modules/zarr/test/geo-zarr-source.spec.ts
+++ b/modules/zarr/test/geo-zarr-source.spec.ts
@@ -83,6 +83,61 @@ test('GeoZarrRasterSource transposes physical x/y arrays into row-major raster o
   expect(Array.from(raster.data as Uint8Array)).toEqual([1, 4, 2, 5, 3, 6]);
 });
 
+test('GeoZarrRasterSource validates structural metadata and retries failed initialization', async () => {
+  const cases: Array<{name: string; overrides: Record<string, unknown>; message: RegExp}> = [
+    {name: 'duplicate dimensions', overrides: {dimension_names: ['x', 'x']}, message: /unique Zarr dimension_names/},
+    {
+      name: 'missing spatial dimensions',
+      overrides: {dimension_names: ['row', 'column'], attributes: {'spatial:dimensions': null}},
+      message: /could not resolve two spatial dimensions/
+    },
+    {
+      name: 'missing affine transform',
+      overrides: {attributes: {'spatial:transform': null}},
+      message: /requires spatial:transform metadata/
+    },
+    {name: 'unsupported dtype', overrides: {data_type: 'bool'}, message: /dtype bool is not currently supported/}
+  ];
+
+  for (const testCase of cases) {
+    const baseUrl = `https://example.com/${testCase.name.replaceAll(' ', '-')}.zarr`;
+    const source = new GeoZarrRasterSource(baseUrl, {
+      core: {
+        loadOptions: {
+          core: {fetch: createDirectGeoZarrFetcher(baseUrl, 'uint8', ['y', 'x'], [2, 2], undefined, testCase.overrides)}
+        }
+      },
+      zarr: {requireConsolidatedMetadata: false},
+      geozarr: {array: 'values'}
+    });
+    await expect(source.getMetadata(), testCase.name).rejects.toThrow(testCase.message);
+    await expect(source.getMetadata(), `${testCase.name} retries`).rejects.toThrow(testCase.message);
+  }
+});
+
+test('GeoZarrRasterSource applies node registration and rejects rotated reads', async () => {
+  const baseUrl = 'https://example.com/rotated-node.zarr';
+  const fetcher = createDirectGeoZarrFetcher(
+    baseUrl,
+    'uint8',
+    ['y', 'x'],
+    [2, 2],
+    new Uint8Array([1, 2, 3, 4]),
+    {attributes: {'spatial:registration': 'node', 'spatial:transform': [1, 0.25, 0, 0.5, -1, 2]}}
+  );
+  const source = new GeoZarrRasterSource(baseUrl, {
+    core: {loadOptions: {core: {fetch: fetcher}}},
+    zarr: {requireConsolidatedMetadata: false},
+    geozarr: {array: 'values'}
+  });
+  const metadata = await source.getMetadata();
+  expect(metadata.registration).toBe('node');
+  expect(metadata.transform).toEqual([1, 0.25, -0.625, 0.5, -1, 2.25]);
+  await expect(
+    source.getRaster({viewport: createViewport(metadata.boundingBox!, 'EPSG:4326')})
+  ).rejects.toThrow(/rotated affine window reads/);
+});
+
 /** Creates the minimal viewport shape accepted by raster sources. */
 function createViewport(
   bounds: RasterBoundingBox,
@@ -108,9 +163,10 @@ function createDirectGeoZarrFetcher(
   dataType: (typeof DATA_TYPES)[number],
   dimensionNames: [string, string],
   shape: [number, number],
-  data?: Uint8Array
+  data?: Uint8Array,
+  arrayMetadataOverrides: Record<string, any> = {}
 ): typeof fetch {
-  const arrayMetadata = {
+  const baseArrayMetadata = {
     zarr_format: 3,
     node_type: 'array',
     shape,
@@ -125,6 +181,14 @@ function createDirectGeoZarrFetcher(
       'spatial:transform': [1, 0, 0, 0, 1, 0],
       'spatial:bbox': [0, 0, 2, 3],
       'proj:code': 'EPSG:4326'
+    }
+  };
+  const arrayMetadata = {
+    ...baseArrayMetadata,
+    ...arrayMetadataOverrides,
+    attributes: {
+      ...baseArrayMetadata.attributes,
+      ...arrayMetadataOverrides.attributes
     }
   };
   const responses = new Map<string, BodyInit>([

--- a/modules/zarr/test/ome-zarr-source.browser.spec.ts
+++ b/modules/zarr/test/ome-zarr-source.browser.spec.ts
@@ -50,6 +50,44 @@ test('OMEZarrImageSource validates browser raster selections', async () => {
     await expect(source.getRaster({ t: 1 })).rejects.toThrow(/time index 1 is out of bounds/);
     await expect(source.getRaster({ z: -1 })).rejects.toThrow(/z index -1 is out of bounds/);
 });
+test.each([
+    ['uint16', Uint16Array],
+    ['uint32', Uint32Array],
+    ['int8', Int8Array],
+    ['int16', Int16Array],
+    ['int32', Int32Array],
+    ['float32', Float32Array],
+    ['float64', Float64Array]
+] as const)('OMEZarrImageSource normalizes %s metadata and empty raster output', async (dataType, TypedArray) => {
+    const baseUrl = `https://example.com/browser-${dataType}.zarr`;
+    const source = new OMEZarrImageSource(baseUrl, {
+        core: { loadOptions: { core: { fetch: createOMEZarrFetcher(baseUrl, dataType) } } },
+        zarr: { requireConsolidatedMetadata: false }
+    });
+    const metadata = await source.getMetadata();
+    const raster = await source.getRaster({ channels: [0] });
+    expect(metadata.dtype).toBe(dataType);
+    expect(raster.data).toBeInstanceOf(TypedArray);
+});
+test('OMEZarrImageSource retries initialization after malformed metadata', async () => {
+    const baseUrl = 'https://example.com/malformed-ome.zarr';
+    let groupRequestCount = 0;
+    const fetcher = (async (input: RequestInfo | URL) => {
+        const url = input instanceof Request ? input.url : String(input);
+        if (url === `${baseUrl}/zarr.json`) {
+            groupRequestCount++;
+            return new Response(encodeJson({zarr_format: 3, node_type: 'group', attributes: {}}));
+        }
+        return new Response(null, {status: 404});
+    }) as typeof fetch;
+    const source = new OMEZarrImageSource(baseUrl, {
+        core: {loadOptions: {core: {fetch: fetcher}}},
+        zarr: {requireConsolidatedMetadata: false}
+    });
+    await expect(source.getMetadata()).rejects.toThrow(/requires multiscales metadata/);
+    await expect(source.getMetadata()).rejects.toThrow(/requires multiscales metadata/);
+    expect(groupRequestCount).toBe(2);
+});
 /** Creates an OME-Zarr source backed by a small in-memory Zarr v3 store. */
 function createInMemoryOMEZarrSource(): OMEZarrImageSource {
     const baseUrl = 'https://example.com/browser-ome.zarr';
@@ -60,13 +98,13 @@ function createInMemoryOMEZarrSource(): OMEZarrImageSource {
     return new OMEZarrImageSource(baseUrl, options);
 }
 /** Creates an in-memory HTTP view of a small OME-Zarr v3 store. */
-function createOMEZarrFetcher(baseUrl: string): typeof fetch {
+function createOMEZarrFetcher(baseUrl: string, dataType = 'uint8'): typeof fetch {
     const responses = new Map<string, BodyInit>([
         [`${baseUrl}/zarr.json`, encodeJson(createOMEGroupMetadata())],
-        [`${baseUrl}/0/zarr.json`, encodeJson(createOMEArrayMetadata())],
-        [`${baseUrl}/0/c/0/0/0/0/0`, new Uint8Array([1, 2, 3, 4, 5, 6])],
-        [`${baseUrl}/0/c/0/1/0/0/0`, new Uint8Array([11, 12, 13, 14, 15, 16])],
-        [`${baseUrl}/0/c/0/2/0/0/0`, new Uint8Array([21, 22, 23, 24, 25, 26])]
+        [`${baseUrl}/0/zarr.json`, encodeJson(createOMEArrayMetadata(dataType))],
+        [`${baseUrl}/0/c/0/0/0/0/0`, createTypedChunk(dataType, 1)],
+        [`${baseUrl}/0/c/0/1/0/0/0`, createTypedChunk(dataType, 11)],
+        [`${baseUrl}/0/c/0/2/0/0/0`, createTypedChunk(dataType, 21)]
     ]);
     return (async (input) => {
         const url = input instanceof Request ? input.url : String(input);
@@ -108,12 +146,12 @@ function createOMEGroupMetadata(): Record<string, unknown> {
     };
 }
 /** Creates uncompressed uint8 array metadata for the in-memory image. */
-function createOMEArrayMetadata(): Record<string, unknown> {
+function createOMEArrayMetadata(dataType = 'uint8'): Record<string, unknown> {
     return {
         zarr_format: 3,
         node_type: 'array',
         shape: [1, 3, 1, 2, 3],
-        data_type: 'uint8',
+        data_type: dataType,
         chunk_grid: { name: 'regular', configuration: { chunk_shape: [1, 1, 1, 2, 3] } },
         chunk_key_encoding: { name: 'default', configuration: { separator: '/' } },
         codecs: [{ name: 'bytes', configuration: { endian: 'little' } }],
@@ -125,4 +163,19 @@ function createOMEArrayMetadata(): Record<string, unknown> {
 /** Encodes Zarr metadata as UTF-8 bytes. */
 function encodeJson(value: unknown): Uint8Array {
     return new TextEncoder().encode(JSON.stringify(value));
+}
+/** Creates six little-endian scalar values for an uncompressed Zarr chunk. */
+function createTypedChunk(dataType: string, start: number): ArrayBufferView {
+    const values = Array.from({length: 6}, (_, index) => start + index);
+    const constructors: Record<string, new (values: number[]) => ArrayBufferView> = {
+        uint8: Uint8Array,
+        uint16: Uint16Array,
+        uint32: Uint32Array,
+        int8: Int8Array,
+        int16: Int16Array,
+        int32: Int32Array,
+        float32: Float32Array,
+        float64: Float64Array
+    };
+    return new constructors[dataType](values);
 }


### PR DESCRIPTION
## Goals

- Make a substantial step toward the repository's 90% combined line-and-branch coverage goal.
- Target broad, high-impact uncovered behavior without making the required test suite materially slower.
- Keep all new coverage fast, deterministic, hermetic, and written in native Vitest syntax.

## Changes

- Adds boundary and error-path coverage across Avro, LAS/LAZ, GeoArrow, Zarr, core fetch helpers, GIS, glTF, I3S, MVT, Parquet, polyfills, schema utilities, loader utilities, and worker utilities.
- Expands deck.gl source-layer lifecycle and tile-view coverage across raster, vector, and tile source layers.
- Exercises worker transports, option sanitization, process helpers, Node image codecs, data URI decoding, Arrow utilities, source adapters, and iterator boundaries.
- Adds 1,429 lines across 26 focused test files, covering an estimated 1,058 additional line/branch units when merged with the existing coverage baseline.
- Keeps the normal validation runtime bounded: the complete Node suite runs in approximately 7 seconds and the complete Chromium suite in approximately 109 seconds locally.

## Validation

- `yarn build`
- `yarn build-workers`
- `yarn test-node` — 441 passed, 6 skipped
- `yarn test-headless` — 4,792 passed, 39 skipped
- `yarn test-cover` — 5,233 passed, 45 skipped
- `yarn test-audit` — 762 files, 0 Tape, 0 violations
- `yarn lint fix`

