### PR TITLE
feat(i3s): decode LEPCC point clouds in workers

### DIFF
--- a/docs/modules/i3s/formats/i3s.md
+++ b/docs/modules/i3s/formats/i3s.md
@@ -174,7 +174,7 @@ those versions.
 
 | Capability | Status | Since | Notes |
 | --- | :---: | --- | --- |
-| LEPCC point-cloud attribute blobs | **Supported** | **v5.0** | `I3SLEPCCDecoder` decodes standalone `lepcc-xyz`, `lepcc-rgb`, `lepcc-intensity`, and bit-stuffed or Huffman flag-byte resources. `I3SPointCloudSource` maps them to Arrow point attributes. |
+| LEPCC point-cloud attribute blobs | **Supported** | **v5.0** | `I3SLEPCCDecoder` decodes standalone `lepcc-xyz`, `lepcc-rgb`, `lepcc-intensity`, and bit-stuffed or Huffman flag-byte resources. `I3SLEPCCLoader` exposes the same decode through a worker-capable loader, and `I3SPointCloudSource` maps the results to Arrow point attributes. |
 | Point Cloud standard attributes | **Partial** | **v5.0** | RGB, intensity, flags, and metadata-described scalar arrays are normalized. Classification, returns, and producer-defined bit fields are preserved as raw attributes when no canonical mapping is declared. |
 
 ### Point geometry and styling metadata

--- a/modules/3d-tiles/src/3d-tiles-archive-source.ts
+++ b/modules/3d-tiles/src/3d-tiles-archive-source.ts
@@ -3,7 +3,7 @@
 // Copyright vis.gl contributors
 
 import {IndexedArchiveTilesetSource, Tiles3DSource} from '@loaders.gl/tiles';
-import type {CoreAPI, Loader, LoaderOptions, LoaderWithParser} from '@loaders.gl/loader-utils';
+import type {CoreAPI, Loader, LoaderOptions} from '@loaders.gl/loader-utils';
 import {parse3DTilesArchive} from './3d-tiles-archive/3d-tiles-archive-parser';
 
 /** Constructor input for {@link Tiles3DArchiveSource}. */
@@ -47,7 +47,7 @@ export class Tiles3DArchiveSource extends Tiles3DSource {
     super(
       {
         url: archiveSource.sourceUrl,
-        loader: input.loader as LoaderWithParser,
+        loader: input.loader,
         basePath: input.basePath || archiveSource.sourceUrl,
         resolver: archiveSource,
         coreApi: input.coreApi

--- a/modules/deck-layers/src/archive-source-resolver.ts
+++ b/modules/deck-layers/src/archive-source-resolver.ts
@@ -6,7 +6,7 @@ import {fetchFile, parse} from '@loaders.gl/core';
 import {DeflateDecompressor, GZipDecompressor, NoDecompressor} from '@loaders.gl/compression';
 import {MD5Hash} from '@loaders.gl/crypto';
 import {BlobFile, HttpFile, path} from '@loaders.gl/loader-utils';
-import type {LoaderOptions, LoaderWithParser, ReadableFile} from '@loaders.gl/loader-utils';
+import type {Loader, LoaderOptions, LoaderWithParser, ReadableFile} from '@loaders.gl/loader-utils';
 import type {TilesetSourceResolver} from '@loaders.gl/tiles';
 import {
   CD_HEADER_SIGNATURE,
@@ -33,21 +33,21 @@ type ArchiveAccessor = {
  * @returns Resolver and runtime loader for the standard 3D Tiles source.
  */
 export function createTiles3DArchiveResolver(data: ArchiveSourceData): {
-  loader: LoaderWithParser;
+  loader: Loader;
   resolver: TilesetSourceResolver;
 };
 export function createTiles3DArchiveResolver(
   data: ArchiveSourceData,
-  parserLoader: LoaderWithParser
+  parserLoader: Loader
 ): {
-  loader: LoaderWithParser;
+  loader: Loader;
   resolver: TilesetSourceResolver;
 };
 export function createTiles3DArchiveResolver(
   data: ArchiveSourceData,
-  parserLoader: LoaderWithParser = TILES_3D_RUNTIME_LOADER
+  parserLoader: Loader = TILES_3D_RUNTIME_LOADER
 ): {
-  loader: LoaderWithParser;
+  loader: Loader;
   resolver: TilesetSourceResolver;
 } {
   const sourceUrl = getArchiveSourceUrl(data, 'tileset.3tz');
@@ -74,21 +74,21 @@ export function createTiles3DArchiveResolver(
  * @returns Resolver and runtime loader for the standard I3S source.
  */
 export function createSLPKArchiveResolver(data: ArchiveSourceData): {
-  loader: LoaderWithParser;
+  loader: Loader;
   resolver: TilesetSourceResolver;
 };
 export function createSLPKArchiveResolver(
   data: ArchiveSourceData,
-  parserLoader: LoaderWithParser
+  parserLoader: Loader
 ): {
-  loader: LoaderWithParser;
+  loader: Loader;
   resolver: TilesetSourceResolver;
 };
 export function createSLPKArchiveResolver(
   data: ArchiveSourceData,
-  parserLoader: LoaderWithParser = I3S_RUNTIME_LOADER
+  parserLoader: Loader = I3S_RUNTIME_LOADER
 ): {
-  loader: LoaderWithParser;
+  loader: Loader;
   resolver: TilesetSourceResolver;
 } {
   const sourceUrl = getArchiveSourceUrl(data, 'tileset.slpk');
@@ -145,7 +145,7 @@ function createArchiveResolver(
   return {
     loadRoot<DataT>(
       _url: string,
-      loader: LoaderWithParser<DataT>,
+      loader: Loader<DataT>,
       loadOptions: LoaderOptions
     ): Promise<DataT> {
       return parseArchiveResource(accessor, rootUrl, rootPath, rootMode, loader, loadOptions);
@@ -153,7 +153,7 @@ function createArchiveResolver(
 
     loadResource<DataT>(
       url: string,
-      loader: LoaderWithParser<DataT>,
+      loader: Loader<DataT>,
       loadOptions: LoaderOptions
     ): Promise<DataT> {
       const pathInArchive = resolveArchivePath(url, url, accessor.sourceUrl);
@@ -167,7 +167,7 @@ async function parseArchiveResource<DataT>(
   resourceUrl: string,
   pathInArchive: string,
   mode: ArchiveFileMode,
-  loader: LoaderWithParser<DataT>,
+  loader: Loader<DataT>,
   loadOptions: LoaderOptions
 ): Promise<DataT> {
   const data = await accessor.loadFile(pathInArchive, mode);

--- a/modules/i3s/package.json
+++ b/modules/i3s/package.json
@@ -40,11 +40,21 @@
       "types": "./dist/unbundled.d.ts",
       "import": "./dist/unbundled.js"
     },
+    "./i3s-lepcc-loader": {
+      "types": "./dist/i3s-lepcc-loader.d.ts",
+      "import": "./dist/i3s-lepcc-loader.js"
+    },
     "./i3s-content-worker.js": {
       "import": "./dist/i3s-content-worker.js"
     },
     "./i3s-content-worker-node.js": {
       "import": "./dist/i3s-content-worker-node.js"
+    },
+    "./i3s-lepcc-worker.js": {
+      "import": "./dist/i3s-lepcc-worker.js"
+    },
+    "./i3s-lepcc-worker-node.js": {
+      "import": "./dist/i3s-lepcc-worker-node.js"
     },
     "./i3s-scene-layer.schema.json": "./dist/i3s-scene-layer.schema.json",
     "./i3s-node-page.schema.json": "./dist/i3s-node-page.schema.json",
@@ -57,12 +67,14 @@
     "README.md"
   ],
   "scripts": {
-    "pre-build": "npm run generate-json-schema && npm run build-bundle && npm run build-bundle-dev && npm run build-worker && npm run build-worker-node",
+    "pre-build": "npm run generate-json-schema && npm run build-bundle && npm run build-bundle-dev && npm run build-worker && npm run build-worker-node && npm run build-lepcc-worker && npm run build-lepcc-worker-node",
     "generate-json-schema": "node ../../scripts/generate-json-schema.mjs --schema ./dist/i3s-zod-schema.js --export I3SSceneLayerSchema --output ./dist/i3s-scene-layer.schema.json --id https://unpkg.com/@loaders.gl/i3s/i3s-scene-layer.schema.json --title 'loaders.gl I3S scene layer metadata' && node ../../scripts/generate-json-schema.mjs --schema ./dist/i3s-zod-schema.js --export I3SNodePageSchema --output ./dist/i3s-node-page.schema.json --id https://unpkg.com/@loaders.gl/i3s/i3s-node-page.schema.json --title 'loaders.gl I3S node page' && node ../../scripts/generate-json-schema.mjs --schema ./dist/i3s-zod-schema.js --export I3SPointCloudSceneLayerSchema --output ./dist/i3s-point-cloud-scene-layer.schema.json --id https://unpkg.com/@loaders.gl/i3s/i3s-point-cloud-scene-layer.schema.json --title 'loaders.gl I3S Point Cloud scene layer metadata'",
     "build-bundle": "ocular-bundle ./bundle.ts --output=dist/dist.min.js",
     "build-bundle-dev": "ocular-bundle ./bundle.ts --env=dev --output=dist/dist.dev.js",
     "build-worker": "esbuild src/workers/i3s-content-worker.ts --outfile=dist/i3s-content-worker.js --target=esnext --bundle --define:__VERSION__=\\\"$npm_package_version\\\"",
-    "build-worker-node": "esbuild src/workers/i3s-content-worker-node.ts --outfile=dist/i3s-content-worker-node.js --platform=node --target=node16 --minify --bundle --sourcemap --define:__VERSION__=\\\"$npm_package_version\\\""
+    "build-worker-node": "esbuild src/workers/i3s-content-worker-node.ts --outfile=dist/i3s-content-worker-node.js --platform=node --target=node16 --minify --bundle --sourcemap --define:__VERSION__=\\\"$npm_package_version\\\"",
+    "build-lepcc-worker": "esbuild src/workers/i3s-lepcc-worker.ts --outfile=dist/i3s-lepcc-worker.js --target=esnext --bundle --define:__VERSION__=\\\"$npm_package_version\\\"",
+    "build-lepcc-worker-node": "esbuild src/workers/i3s-lepcc-worker-node.ts --outfile=dist/i3s-lepcc-worker-node.js --platform=node --target=node16 --bundle --sourcemap --define:__VERSION__=\\\"$npm_package_version\\\""
   },
   "dependencies": {
     "@loaders.gl/compression": "5.0.0-alpha.5",

--- a/modules/i3s/src/bundled.ts
+++ b/modules/i3s/src/bundled.ts
@@ -16,6 +16,8 @@ export {SLPKLoaderWithParser as SLPKLoader} from './i3s-slpk-loader-with-parser'
 export type {SLPKSourceInput} from './i3s-slpk-source';
 export {SLPKSource} from './i3s-slpk-source';
 export {I3SContentLoaderWithParser as I3SContentLoader} from './i3s-content-loader-with-parser';
+export {I3SLEPCCLoaderWithParser as I3SLEPCCLoader} from './i3s-lepcc-loader';
+export type {I3SLEPCCLoaderOptions, I3SLEPCCLoaderResult} from './i3s-lepcc-loader-types';
 export {
   I3SAttributeLoaderWithParser as I3SAttributeLoader,
   loadFeatureAttributes

--- a/modules/i3s/src/i3s-content-loader.ts
+++ b/modules/i3s/src/i3s-content-loader.ts
@@ -7,6 +7,7 @@ import type {I3SLoaderOptions} from './i3s-loader';
 import type {I3STileContent} from './types';
 
 import {I3SContentFormat} from './i3s-format';
+import {I3S_LOADER_OPTIONS} from './i3s-loader-options';
 // __VERSION__ is injected by babel-plugin-version-inline
 // @ts-ignore TS2304: Cannot find name '__VERSION__'.
 
@@ -31,6 +32,7 @@ export const I3SContentLoader = {
     (await import('./i3s-content-loader-with-parser')).I3SContentLoaderWithParser,
   extensions: ['bin'],
   options: {
+    i3s: I3S_LOADER_OPTIONS,
     'i3s-content': {}
   }
 } as const satisfies Loader<I3STileContent | null, never, I3SLoaderOptions>;

--- a/modules/i3s/src/i3s-format.ts
+++ b/modules/i3s/src/i3s-format.ts
@@ -31,6 +31,8 @@ export const I3SContentFormat = binary('I3S Content', 'i3s-content', 'i3s-conten
 export const I3SAttributeFormat = binary('I3S Attribute', 'i3s-attribute', 'i3s-attribute', [
   'bin'
 ]);
+/** Standalone LEPCC point-cloud geometry or attribute resource. */
+export const I3SLEPCCFormat = binary('I3S LEPCC', 'i3s-lepcc', 'i3s-lepcc', ['bin']);
 export const I3SNodePageFormat = json('I3S Node Page', 'i3s-node-page', 'i3s-node-page');
 export const SLPKFormat = {
   name: 'SLPK',

--- a/modules/i3s/src/i3s-lepcc-loader-types.ts
+++ b/modules/i3s/src/i3s-lepcc-loader-types.ts
@@ -1,0 +1,42 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright vis.gl contributors
+
+import type {Loader, LoaderOptions} from '@loaders.gl/loader-utils';
+import {I3SLEPCCFormat} from './i3s-format';
+import type {I3SLEPCCBlobType, I3SLEPCCDecodedValue} from './i3s-lepcc';
+
+// __VERSION__ is injected by babel-plugin-version-inline
+// @ts-ignore TS2304: Cannot find name '__VERSION__'.
+const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
+
+/** Options accepted by the standalone I3S LEPCC loader. */
+export type I3SLEPCCLoaderOptions = LoaderOptions & {
+  'i3s-lepcc'?: {
+    /** Verify Fletcher-32 checksums before decoding. Defaults to true. */
+    verifyChecksum?: boolean;
+  };
+};
+
+/** Result returned after decoding one standalone LEPCC resource. */
+export type I3SLEPCCLoaderResult = {
+  /** Attribute represented by the resource. */
+  type: I3SLEPCCBlobType;
+  /** Decoded typed values. */
+  value: I3SLEPCCDecodedValue;
+};
+
+/** Metadata-only loader for standalone I3S LEPCC resources. */
+export const I3SLEPCCLoader = {
+  ...I3SLEPCCFormat,
+  dataType: null as unknown as I3SLEPCCLoaderResult,
+  batchType: null as never,
+  version: VERSION,
+  worker: true,
+  options: {
+    'i3s-lepcc': {
+      verifyChecksum: true
+    }
+  },
+  preload: async () => (await import('@loaders.gl/i3s/i3s-lepcc-loader')).I3SLEPCCLoaderWithParser
+} as const satisfies Loader<I3SLEPCCLoaderResult, never, I3SLEPCCLoaderOptions>;

--- a/modules/i3s/src/i3s-lepcc-loader.ts
+++ b/modules/i3s/src/i3s-lepcc-loader.ts
@@ -1,0 +1,29 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {LoaderWithParser} from '@loaders.gl/loader-utils';
+import {I3SLEPCCDecoder} from './i3s-lepcc';
+import {
+  I3SLEPCCLoader,
+  type I3SLEPCCLoaderOptions,
+  type I3SLEPCCLoaderResult
+} from './i3s-lepcc-loader-types';
+
+/** Parser-bearing worker-capable I3S LEPCC loader. */
+export const I3SLEPCCLoaderWithParser = {
+  ...I3SLEPCCLoader,
+  parse: async (
+    arrayBuffer: ArrayBuffer,
+    options?: I3SLEPCCLoaderOptions
+  ): Promise<I3SLEPCCLoaderResult> => {
+    const decoder = new I3SLEPCCDecoder({
+      verifyChecksum: options?.['i3s-lepcc']?.verifyChecksum
+    });
+    const bytes = new Uint8Array(arrayBuffer);
+    return {
+      type: decoder.getBlobType(bytes),
+      value: decoder.decode(bytes)
+    };
+  }
+} as const satisfies LoaderWithParser<I3SLEPCCLoaderResult, never, I3SLEPCCLoaderOptions>;

--- a/modules/i3s/src/i3s-loader-options.ts
+++ b/modules/i3s/src/i3s-loader-options.ts
@@ -1,0 +1,20 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright vis.gl contributors
+
+import {COORDINATE_SYSTEM} from './lib/parsers/constants';
+
+/** Shared I3S defaults used by metadata and binary content loaders. */
+export const I3S_LOADER_OPTIONS = {
+  token: undefined,
+  isTileset: 'auto',
+  isTileHeader: 'auto',
+  tile: undefined,
+  tileset: undefined,
+  _tileOptions: undefined,
+  _tilesetOptions: undefined,
+  useDracoGeometry: true,
+  useCompressedTextures: true,
+  decodeTextures: true,
+  coordinateSystem: COORDINATE_SYSTEM.METER_OFFSETS
+} as const;

--- a/modules/i3s/src/i3s-loader.ts
+++ b/modules/i3s/src/i3s-loader.ts
@@ -4,10 +4,11 @@
 
 import type {Loader, StrictLoaderOptions} from '@loaders.gl/loader-utils';
 import type {I3STilesetHeader} from './types';
-import {COORDINATE_SYSTEM} from './lib/parsers/constants';
 import {I3SParseOptions} from './types';
 
 import {I3SFormat} from './i3s-format';
+import {I3SContentLoader} from './i3s-content-loader';
+import {I3S_LOADER_OPTIONS} from './i3s-loader-options';
 // __VERSION__ is injected by babel-plugin-version-inline
 // @ts-ignore TS2304: Cannot find name '__VERSION__'.
 const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
@@ -32,24 +33,16 @@ export const I3SLoader = {
   name: 'I3S (Indexed Scene Layers)',
   id: 'i3s',
   module: 'i3s',
+  /** Worker-capable loader used by I3S sources for binary tile content. */
+  contentLoader: I3SContentLoader,
   version: VERSION,
   mimeTypes: ['application/octet-stream'],
   /** Loads the parser-bearing I3S loader implementation. */
   preload: async () => (await import('./i3s-loader-with-parser')).I3SLoaderWithParser,
   extensions: ['bin'],
   options: {
-    i3s: {
-      token: undefined,
-      isTileset: 'auto',
-      isTileHeader: 'auto',
-      tile: undefined,
-      tileset: undefined,
-      _tileOptions: undefined,
-      _tilesetOptions: undefined,
-      useDracoGeometry: true,
-      useCompressedTextures: true,
-      decodeTextures: true,
-      coordinateSystem: COORDINATE_SYSTEM.METER_OFFSETS
-    }
+    i3s: I3S_LOADER_OPTIONS
   }
-} as const satisfies Loader<I3STilesetHeader, never, I3SLoaderOptions>;
+} as const satisfies Loader<I3STilesetHeader, never, I3SLoaderOptions> & {
+  contentLoader: Loader;
+};

--- a/modules/i3s/src/i3s-point-cloud-source.ts
+++ b/modules/i3s/src/i3s-point-cloud-source.ts
@@ -2,7 +2,12 @@
 // SPDX-License-Identifier: MIT
 // Copyright vis.gl contributors
 
-import type {DataSourceOptions, ReadableFile} from '@loaders.gl/loader-utils';
+import type {
+  CoreAPI,
+  DataSourceOptions,
+  ReadableFile,
+  StrictLoaderOptions
+} from '@loaders.gl/loader-utils';
 import {BlobFile, HttpFile} from '@loaders.gl/loader-utils';
 import {makeMeshArrowTable} from '@loaders.gl/schema-utils';
 import type {MeshAttributes} from '@loaders.gl/schema';
@@ -26,6 +31,9 @@ import {DataSource} from '@loaders.gl/loader-utils';
 import {parseSLPKArchive} from './lib/parsers/parse-slpk/parse-slpk';
 import type {SLPKArchive} from './lib/parsers/parse-slpk/slpk-archieve';
 import {I3SLEPCCDecoder} from './i3s-lepcc';
+import type {I3SLEPCCBlobType} from './i3s-lepcc';
+import {I3SLEPCCLoader} from './i3s-lepcc-loader-types';
+import type {I3SLEPCCLoaderResult} from './i3s-lepcc-loader-types';
 import {I3SPointCloudNodePageSchema, I3SPointCloudSceneLayerSchema} from './i3s-zod-schema';
 import type {
   I3SPointCloudAttributeInfo,
@@ -94,8 +102,8 @@ export class I3SPointCloudSource
    * @param data Layer REST URL or an SLPK Blob/URL.
    * @param options Source and loader options.
    */
-  constructor(data: string | Blob, options: I3SPointCloudSourceOptions = {}) {
-    super(data, options);
+  constructor(data: string | Blob, options: I3SPointCloudSourceOptions = {}, coreApi?: CoreAPI) {
+    super(data, options, undefined, coreApi);
     this.decoder = new I3SLEPCCDecoder({verifyChecksum: options.i3s?.verifyChecksum});
   }
 
@@ -182,7 +190,11 @@ export class I3SPointCloudSource
     const geometryBytes = await this.readBinary(
       this.resourceCandidates(`nodes/${resourceId}/geometries/${geometryResource}`)
     );
-    const positions = this.decoder.decodeXyz(new Uint8Array(geometryBytes));
+    const geometry = await this.decodeLEPCC(geometryBytes, 'xyz');
+    if (geometry.type !== 'xyz' || !(geometry.value instanceof Float64Array)) {
+      throw new Error(`I3S PointCloud geometry resource decoded as ${geometry.type}, expected xyz`);
+    }
+    const positions = geometry.value;
     const pointCount = positions.length / 3;
     if (node.vertexCount && node.vertexCount !== pointCount) {
       throw new Error(
@@ -218,7 +230,7 @@ export class I3SPointCloudSource
         if (!bytes) {
           return;
         }
-        const decoded = this.decodeAttribute(bytes, descriptor);
+        const decoded = await this.decodeAttribute(bytes, descriptor);
         if (decoded.value.length !== pointCount * decoded.size) {
           throw new Error(
             `I3S PointCloud attribute ${descriptor.name || descriptor.key || 'unknown'} count mismatch`
@@ -387,11 +399,17 @@ export class I3SPointCloudSource
   private decodeAttribute(
     bytes: ArrayBuffer,
     descriptor: I3SPointCloudAttributeInfo
-  ): {
-    value: Float32Array | Float64Array | Uint8Array | Uint16Array | Int32Array;
-    size: number;
-    kind: string;
-  } {
+  ):
+    | {
+        value: Float32Array | Float64Array | Uint8Array | Uint16Array | Int32Array;
+        size: number;
+        kind: string;
+      }
+    | Promise<{
+        value: Float32Array | Float64Array | Uint8Array | Uint16Array | Int32Array;
+        size: number;
+        kind: string;
+      }> {
     const data = new Uint8Array(bytes);
     const encoding = String(descriptor.encoding || '').toLowerCase();
     let magic = '';
@@ -402,13 +420,52 @@ export class I3SPointCloudSource
     }
     const kind = encoding || magic;
     if (magic === 'rgb' || encoding.includes('rgb')) {
-      return {value: this.decoder.decodeRgb(data), size: 3, kind: 'rgb'};
+      if (magic && this.hasCoreApi && this.loadOptions.core?.worker !== false) {
+        return this.decodeLEPCC(bytes).then(decoded => ({
+          value: decoded.value instanceof Uint8Array ? decoded.value : this.decoder.decodeRgb(data),
+          size: 3,
+          kind: 'rgb'
+        }));
+      }
+      return {
+        value: this.decoder.decodeRgb(data),
+        size: 3,
+        kind: 'rgb'
+      };
     }
     if (magic === 'intensity' || encoding.includes('intensity')) {
-      return {value: this.decoder.decodeIntensity(data), size: 1, kind: 'intensity'};
+      if (magic && this.hasCoreApi && this.loadOptions.core?.worker !== false) {
+        return this.decodeLEPCC(bytes).then(decoded => ({
+          value:
+            decoded.value instanceof Uint16Array
+              ? decoded.value
+              : this.decoder.decodeIntensity(data),
+          size: 1,
+          kind: 'intensity'
+        }));
+      }
+      return {
+        value: this.decoder.decodeIntensity(data),
+        size: 1,
+        kind: 'intensity'
+      };
     }
     if (magic === 'flagBytes' || encoding.includes('flag')) {
-      return {value: this.decoder.decodeFlagBytes(data), size: 1, kind: 'flags'};
+      if (magic && this.hasCoreApi && this.loadOptions.core?.worker !== false) {
+        return this.decodeLEPCC(bytes).then(decoded => ({
+          value:
+            decoded.value instanceof Uint8Array
+              ? decoded.value
+              : this.decoder.decodeFlagBytes(data),
+          size: 1,
+          kind: 'flags'
+        }));
+      }
+      return {
+        value: this.decoder.decodeFlagBytes(data),
+        size: 1,
+        kind: 'flags'
+      };
     }
 
     const valueType = String(
@@ -428,6 +485,37 @@ export class I3SPointCloudSource
       return {value: new Int32Array(bytes), size: valueSize, kind};
     }
     return {value: new Uint8Array(bytes), size: valueSize, kind};
+  }
+
+  /** Decode a LEPCC resource using the shared worker pool when one is available. */
+  private async decodeLEPCC(
+    bytes: ArrayBuffer,
+    expectedType?: I3SLEPCCBlobType
+  ): Promise<I3SLEPCCLoaderResult> {
+    const loaderOptions: StrictLoaderOptions = {
+      ...this.loadOptions,
+      'i3s-lepcc': {
+        verifyChecksum: this.options.i3s?.verifyChecksum
+      }
+    };
+    if (this.hasCoreApi && loaderOptions.core?.worker !== false) {
+      return (await this.coreApi.parse(bytes, I3SLEPCCLoader, {
+        ...loaderOptions
+      })) as I3SLEPCCLoaderResult;
+    }
+    const data = new Uint8Array(bytes);
+    const type = expectedType || this.decoder.getBlobType(data);
+    return {
+      type,
+      value:
+        type === 'xyz'
+          ? this.decoder.decodeXyz(data)
+          : type === 'rgb'
+            ? this.decoder.decodeRgb(data)
+            : type === 'intensity'
+              ? this.decoder.decodeIntensity(data)
+              : this.decoder.decodeFlagBytes(data)
+    };
   }
 
   private getAttributeName(descriptor: I3SPointCloudAttributeInfo, kind: string): string {

--- a/modules/i3s/src/i3s-service.ts
+++ b/modules/i3s/src/i3s-service.ts
@@ -228,7 +228,7 @@ export function createI3SLayerSource(
   coreApi?: CoreAPI
 ): I3SLayerSource {
   if (layer.layerType === 'PointCloud') {
-    return new I3SPointCloudSource(url, options);
+    return new I3SPointCloudSource(url, options, coreApi);
   }
 
   const loadOptions = {

--- a/modules/i3s/src/i3s-slpk-source.ts
+++ b/modules/i3s/src/i3s-slpk-source.ts
@@ -3,7 +3,7 @@
 // Copyright vis.gl contributors
 
 import {I3SSource, IndexedArchiveTilesetSource} from '@loaders.gl/tiles';
-import type {CoreAPI, Loader, LoaderOptions, LoaderWithParser} from '@loaders.gl/loader-utils';
+import type {CoreAPI, Loader, LoaderOptions} from '@loaders.gl/loader-utils';
 import {parseSLPKArchive} from './lib/parsers/parse-slpk/parse-slpk';
 
 /** Constructor input for {@link SLPKSource}. */
@@ -49,7 +49,7 @@ export class SLPKSource extends I3SSource {
     super(
       {
         url: archiveSource.sourceUrl,
-        loader: input.loader as LoaderWithParser,
+        loader: input.loader,
         basePath: input.basePath || archiveSource.sourceUrl,
         resolver: archiveSource,
         coreApi: input.coreApi

--- a/modules/i3s/src/index.ts
+++ b/modules/i3s/src/index.ts
@@ -67,6 +67,7 @@ export {
   I3SAttributeFormat,
   I3SBuildingSceneLayerFormat,
   I3SContentFormat,
+  I3SLEPCCFormat,
   I3SFormat,
   I3SNodePageFormat,
   SLPKFormat
@@ -77,6 +78,11 @@ export {SLPKLoader} from './i3s-slpk-loader';
 export type {SLPKSourceInput} from './i3s-slpk-source';
 export {SLPKSource} from './i3s-slpk-source';
 export {I3SContentLoader} from './i3s-content-loader';
+export {I3SLEPCCLoader} from './i3s-lepcc-loader-types';
+export type {
+  I3SLEPCCLoaderOptions,
+  I3SLEPCCLoaderResult
+} from './i3s-lepcc-loader-types';
 export {I3SAttributeLoader, loadFeatureAttributes} from './i3s-attribute-loader';
 export {I3SBuildingSceneLayerLoader} from './i3s-building-scene-layer-loader';
 export {I3SNodePageLoader} from './i3s-node-page-loader';

--- a/modules/i3s/src/unbundled.ts
+++ b/modules/i3s/src/unbundled.ts
@@ -17,6 +17,8 @@ export {SLPKLoader} from './i3s-slpk-loader';
 export type {SLPKSourceInput} from './i3s-slpk-source';
 export {SLPKSource} from './i3s-slpk-source';
 export {I3SContentLoader} from './i3s-content-loader';
+export {I3SLEPCCLoader} from './i3s-lepcc-loader-types';
+export type {I3SLEPCCLoaderOptions, I3SLEPCCLoaderResult} from './i3s-lepcc-loader-types';
 export {I3SAttributeLoader, loadFeatureAttributes} from './i3s-attribute-loader';
 export {I3SBuildingSceneLayerLoader} from './i3s-building-scene-layer-loader';
 export {I3SNodePageLoader} from './i3s-node-page-loader';

--- a/modules/i3s/src/workers/i3s-lepcc-worker-node.ts
+++ b/modules/i3s/src/workers/i3s-lepcc-worker-node.ts
@@ -1,0 +1,9 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import '@loaders.gl/polyfills';
+import {createLoaderWorker} from '@loaders.gl/loader-utils';
+import {I3SLEPCCLoaderWithParser} from '../i3s-lepcc-loader';
+
+createLoaderWorker(I3SLEPCCLoaderWithParser);

--- a/modules/i3s/src/workers/i3s-lepcc-worker.ts
+++ b/modules/i3s/src/workers/i3s-lepcc-worker.ts
@@ -1,0 +1,8 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {createLoaderWorker} from '@loaders.gl/loader-utils';
+import {I3SLEPCCLoaderWithParser} from '../i3s-lepcc-loader';
+
+createLoaderWorker(I3SLEPCCLoaderWithParser);

--- a/modules/i3s/test/i3s-lepcc.browser.spec.ts
+++ b/modules/i3s/test/i3s-lepcc.browser.spec.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {fetchFile} from '@loaders.gl/core';
-import {I3SLEPCCDecoder} from '@loaders.gl/i3s';
+import {fetchFile, parse} from '@loaders.gl/core';
+import {I3SLEPCCDecoder, I3SLEPCCLoader} from '@loaders.gl/i3s';
 import {expect, test} from 'vitest';
 
 const XYZ_FIXTURE = '@loaders.gl/i3s/test/data/point-cloud/SMALL_AUTZEN_LAS_All.pccxyz';
@@ -47,4 +47,14 @@ test('I3SLEPCCDecoder decodes LEPCC attribute blobs', async () => {
   expect(Array.from(intensity.slice(0, 6))).toEqual([0, 238, 9, 29, 1, 65]);
   expect(Array.from(rgb.slice(0, 9))).toEqual([10, 40, 60, 20, 30, 60, 20, 40, 50]);
   expect(Array.from(flags.slice(0, 12))).toEqual([7, 3, 3, 3, 3, 3, 3, 3, 3, 3, 7, 3]);
+});
+
+test('I3SLEPCCLoader decodes resources in a worker', async () => {
+  const response = await fetchFile(XYZ_FIXTURE);
+  const result = await parse(await response.arrayBuffer(), I3SLEPCCLoader, {
+    core: {worker: true, reuseWorkers: false, _workerType: 'test'}
+  });
+  expect(result.type).toBe('xyz');
+  expect(result.value).toBeInstanceOf(Float64Array);
+  expect(result.value).toHaveLength(318);
 });

--- a/modules/potree/src/lib/potree-node-source.ts
+++ b/modules/potree/src/lib/potree-node-source.ts
@@ -873,14 +873,17 @@ export class PotreeNodesSource
     }
 
     if (!Array.isArray(this.metadata.pointAttributes)) {
-      return {
-        // Preserve source-level worker/fetch settings while allowing the
-        // TypeScript LAS loader to use its packaged worker by default.
-        core: this.loadOptions.core,
+      // Preserve source-level worker/fetch settings while allowing the
+      // TypeScript LAS loader to use its packaged worker by default.
+      const loaderOptions: LoaderOptions = {
         las: {
           colorDepth: 'auto'
         }
       };
+      if (this.loadOptions.core) {
+        loaderOptions.core = this.loadOptions.core;
+      }
+      return loaderOptions;
     }
 
     const [tileMinBounds] = tileBoundingBox;

--- a/modules/potree/src/lib/potree-node-source.ts
+++ b/modules/potree/src/lib/potree-node-source.ts
@@ -874,9 +874,9 @@ export class PotreeNodesSource
 
     if (!Array.isArray(this.metadata.pointAttributes)) {
       return {
-        core: {
-          worker: false
-        },
+        // Preserve source-level worker/fetch settings while allowing the
+        // TypeScript LAS loader to use its packaged worker by default.
+        core: this.loadOptions.core,
         las: {
           colorDepth: 'auto'
         }

--- a/modules/potree/test/potree-source-boundary.spec.ts
+++ b/modules/potree/test/potree-source-boundary.spec.ts
@@ -132,6 +132,16 @@ test('Potree source covers loader fallbacks, failures, and color usability', asy
       [0, 0, 0],
       [1, 1, 1]
     ])
+  ).toEqual({las: {colorDepth: 'auto'}});
+
+  const sourceWithLoadOptions = createSource();
+  sourceWithLoadOptions.metadata = {version: '1.7', pointAttributes: 'LAZ'};
+  sourceWithLoadOptions.loadOptions = {core: {worker: false}};
+  expect(
+    sourceWithLoadOptions.getNodeContentLoaderOptions([
+      [0, 0, 0],
+      [1, 1, 1]
+    ])
   ).toMatchObject({
     core: {worker: false},
     las: {colorDepth: 'auto'}

--- a/modules/tiles/src/tileset-3d/common/indexed-archive-tileset-source.ts
+++ b/modules/tiles/src/tileset-3d/common/indexed-archive-tileset-source.ts
@@ -3,12 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import {BlobFile, HttpFile, path} from '@loaders.gl/loader-utils';
-import type {
-  CoreAPI,
-  LoaderOptions,
-  LoaderWithParser,
-  ReadableFile
-} from '@loaders.gl/loader-utils';
+import type {CoreAPI, Loader, LoaderOptions, ReadableFile} from '@loaders.gl/loader-utils';
 import type {TilesetSourceResolver} from './tileset-source';
 
 /** Options for {@link IndexedArchiveTilesetSource}. */
@@ -63,7 +58,7 @@ export class IndexedArchiveTilesetSource<ArchiveT> implements TilesetSourceResol
    */
   async loadRoot<DataT>(
     url: string,
-    loader: LoaderWithParser<DataT>,
+    loader: Loader<DataT>,
     loadOptions: LoaderOptions
   ): Promise<DataT> {
     return await this.parseArchiveResource(
@@ -83,7 +78,7 @@ export class IndexedArchiveTilesetSource<ArchiveT> implements TilesetSourceResol
    */
   async loadResource<DataT>(
     url: string,
-    loader: LoaderWithParser<DataT>,
+    loader: Loader<DataT>,
     loadOptions: LoaderOptions
   ): Promise<DataT> {
     const pathInArchive = this.resolveArchivePath(url, url);
@@ -93,7 +88,7 @@ export class IndexedArchiveTilesetSource<ArchiveT> implements TilesetSourceResol
   private async parseArchiveResource<DataT>(
     resourceUrl: string,
     pathInArchive: string,
-    loader: LoaderWithParser<DataT>,
+    loader: Loader<DataT>,
     loadOptions: LoaderOptions,
     mode?: string
   ): Promise<DataT> {

--- a/modules/tiles/src/tileset-3d/common/tileset-3d.ts
+++ b/modules/tiles/src/tileset-3d/common/tileset-3d.ts
@@ -7,7 +7,7 @@
 import {Matrix4, Vector3} from '@math.gl/core';
 import {Ellipsoid} from '@math.gl/geospatial';
 import {Stats} from '@probe.gl/stats';
-import {RequestScheduler, LoaderWithParser, LoaderOptions} from '@loaders.gl/loader-utils';
+import {RequestScheduler, Loader, LoaderOptions} from '@loaders.gl/loader-utils';
 import {TilesetCache} from './tileset-cache';
 import {calculateTransformProps} from '../helpers/transform-utils';
 import {getFrameState, limitSelectedTiles, updateCameraMotionState} from '../helpers/frame-state';
@@ -322,7 +322,7 @@ export class Tileset3D {
 
   type: TILESET_TYPE;
   tileset: TilesetJSON | null;
-  loader: LoaderWithParser;
+  loader: Loader;
   url: string;
   basePath: string;
   modelMatrix: Matrix4;

--- a/modules/tiles/src/tileset-3d/common/tileset-source.ts
+++ b/modules/tiles/src/tileset-3d/common/tileset-source.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import type {CoreAPI, LoaderOptions, LoaderWithParser} from '@loaders.gl/loader-utils';
+import type {CoreAPI, Loader, LoaderOptions} from '@loaders.gl/loader-utils';
 import type {Vector3} from '@math.gl/core';
 import type {TilesetTraverser, TilesetTraverserProps} from './tileset-traverser';
 import type {Tile3D} from './tile-3d';
@@ -24,18 +24,14 @@ export type TilesetSourceResolver = {
   /**
    * Loads and parses the root metadata resource for a source.
    */
-  loadRoot<DataT>(
-    url: string,
-    loader: LoaderWithParser<DataT>,
-    loadOptions: LoaderOptions
-  ): Promise<DataT>;
+  loadRoot<DataT>(url: string, loader: Loader<DataT>, loadOptions: LoaderOptions): Promise<DataT>;
 
   /**
    * Loads and parses an arbitrary source-relative resource.
    */
   loadResource<DataT>(
     url: string,
-    loader: LoaderWithParser<DataT>,
+    loader: Loader<DataT>,
     loadOptions: LoaderOptions
   ): Promise<DataT>;
 };
@@ -47,7 +43,7 @@ export type TilesetSourceRequest = {
   /** Absolute root metadata URL. */
   url: string;
   /** Loader used to fetch and parse the root metadata. */
-  loader: LoaderWithParser;
+  loader: Loader;
   /** Optional base path override for relative resources. */
   basePath?: string;
   /** Optional resource-loading strategy used for archive-backed datasets. */
@@ -119,8 +115,8 @@ export type TilesetSourceViewState = {
 export type TilesetSourceMetadata = {
   /** Format discriminator. */
   type: TILESET_TYPE;
-  /** Loader used for metadata and content requests. */
-  loader: LoaderWithParser;
+  /** Primary format loader used for metadata and default content requests. */
+  loader: Loader;
   /** Absolute root metadata URL. */
   url: string;
   /** Base path used for relative resource resolution. */
@@ -143,8 +139,8 @@ export type TilesetSourceMetadata = {
 export interface Tileset3DSource {
   /** Tileset format discriminator. */
   readonly type: TILESET_TYPE;
-  /** Loader used for content and metadata requests. */
-  readonly loader: LoaderWithParser;
+  /** Primary format loader used for metadata and default content requests. */
+  readonly loader: Loader;
   /** Absolute URL of the root tileset resource. */
   readonly url: string;
   /** Base directory used for relative resource resolution. */

--- a/modules/tiles/src/tileset-3d/format-3d-tiles/tiles-3d-source.ts
+++ b/modules/tiles/src/tileset-3d/format-3d-tiles/tiles-3d-source.ts
@@ -5,7 +5,7 @@
 import {path, RequestCache} from '@loaders.gl/loader-utils';
 import {Ellipsoid} from '@math.gl/geospatial';
 import {Vector3} from '@math.gl/core';
-import type {CoreAPI, LoaderOptions, LoaderWithParser} from '@loaders.gl/loader-utils';
+import type {CoreAPI, Loader, LoaderOptions} from '@loaders.gl/loader-utils';
 import type {Tile3D} from '../common/tile-3d';
 import {Tileset3DTraverser} from './tileset-3d-traverser';
 import type {Tileset3D} from '../common/tileset-3d';
@@ -65,7 +65,7 @@ export class Tiles3DSource implements Tileset3DSource {
   /** 3D Tiles format discriminator. */
   readonly type = TILESET_TYPE.TILES3D;
   /** Loader used for tile content requests. */
-  readonly loader: LoaderWithParser;
+  readonly loader: Loader;
   /** Root tileset URL. */
   readonly url: string;
   /** Base path used for relative tile resource resolution. */
@@ -487,7 +487,7 @@ export class Tiles3DSource implements Tileset3DSource {
   private async loadWithCoreApi(
     url: string,
     options: LoaderOptions,
-    loader: LoaderWithParser = this.loader
+    loader: Loader = this.loader
   ): Promise<any> {
     if (!this.coreApi) {
       throw new Error('Tiles3DSource requires an injected coreApi to load tileset data');
@@ -513,7 +513,7 @@ export class Tiles3DSource implements Tileset3DSource {
   private async loadResourceData(
     url: string,
     options: LoaderOptions,
-    loader: LoaderWithParser = this.loader
+    loader: Loader = this.loader
   ): Promise<any> {
     if (this.resolver) {
       return await this.resolver.loadResource(url, loader, options);

--- a/modules/tiles/src/tileset-3d/format-i3s/i3s-source.ts
+++ b/modules/tiles/src/tileset-3d/format-i3s/i3s-source.ts
@@ -5,7 +5,7 @@
 import {path} from '@loaders.gl/loader-utils';
 import {Ellipsoid} from '@math.gl/geospatial';
 import {Vector3} from '@math.gl/core';
-import type {CoreAPI, LoaderOptions, LoaderWithParser} from '@loaders.gl/loader-utils';
+import type {CoreAPI, Loader, LoaderOptions} from '@loaders.gl/loader-utils';
 import type {Tile3D} from '../common/tile-3d';
 import {Tile3D as Tile3DNode} from '../common/tile-3d';
 import {I3STilesetTraverser} from './i3s-tileset-traverser';
@@ -41,8 +41,10 @@ const EMPTY_CONTENT_FORMATS: TilesetContentFormats = {
 export class I3SSource implements Tileset3DSource {
   /** I3S format discriminator. */
   readonly type = TILESET_TYPE.I3S;
-  /** Loader used for tile metadata and content requests. */
-  readonly loader: LoaderWithParser;
+  /** Primary I3S loader used for root and child metadata requests. */
+  readonly loader: Loader;
+  /** Worker-capable loader used for binary tile content when supplied by the format loader. */
+  readonly contentLoader: Loader;
   /** Root I3S layer URL. */
   readonly url: string;
   /** Base path used for relative tile resource resolution. */
@@ -80,6 +82,7 @@ export class I3SSource implements Tileset3DSource {
     this.rootTileset = isTilesetRequest(input) ? null : input;
     this.tileset = this.rootTileset;
     this.loader = request.loader;
+    this.contentLoader = getI3SContentLoader(request.loader);
     this.url = request.url;
     this.basePath = request.basePath || path.dirname(request.url);
     this.resolver = request.resolver;
@@ -215,7 +218,7 @@ export class I3SSource implements Tileset3DSource {
       }
     };
 
-    tile.content = await this.loadResourceData(contentUrl, options);
+    tile.content = await this.loadResourceData(contentUrl, options, this.contentLoader);
     return {loaded: true};
   }
 
@@ -372,12 +375,16 @@ export class I3SSource implements Tileset3DSource {
   /**
    * Loads data through injected core APIs so this module stays independent from `@loaders.gl/core`.
    */
-  private async loadWithCoreApi(url: string, options: LoaderOptions): Promise<any> {
+  private async loadWithCoreApi(
+    url: string,
+    options: LoaderOptions,
+    loader: Loader = this.loader
+  ): Promise<any> {
     if (!this.coreApi) {
       throw new Error('I3SSource requires an injected coreApi to load tileset data');
     }
 
-    return await this.coreApi.load(url, this.loader, options);
+    return await this.coreApi.load(url, loader, options);
   }
 
   /**
@@ -408,12 +415,16 @@ export class I3SSource implements Tileset3DSource {
   /**
    * Loads tile metadata or content through an injected resolver when present, otherwise through the injected core API.
    */
-  private async loadResourceData(url: string, options: LoaderOptions): Promise<any> {
+  private async loadResourceData(
+    url: string,
+    options: LoaderOptions,
+    loader: Loader = this.loader
+  ): Promise<any> {
     if (this.resolver) {
-      return await this.resolver.loadResource(url, this.loader, options);
+      return await this.resolver.loadResource(url, loader, options);
     }
 
-    return await this.loadWithCoreApi(url, options);
+    return await this.loadWithCoreApi(url, options, loader);
   }
 
   /** Transform one I3S header bound after target options and elevation providers are available. */
@@ -436,6 +447,11 @@ export class I3SSource implements Tileset3DSource {
       i3sLodMbs: transformedBounds.i3sLodMbs
     };
   }
+}
+
+/** Returns the format-provided binary content loader, falling back for custom legacy loaders. */
+function getI3SContentLoader(loader: Loader): Loader {
+  return (loader as Loader & {contentLoader?: Loader}).contentLoader || loader;
 }
 
 function isTilesetRequest(input: TilesetSourceInput): input is TilesetSourceRequest {

--- a/modules/tiles/test/tileset/tileset-3d-source.spec.ts
+++ b/modules/tiles/test/tileset/tileset-3d-source.spec.ts
@@ -4,7 +4,11 @@
 
 import {expect, test} from 'vitest';
 import {coreApi} from '@loaders.gl/core';
-import {createQueryParameterCredential, type LoaderWithParser} from '@loaders.gl/loader-utils';
+import {
+  createQueryParameterCredential,
+  type Loader,
+  type LoaderWithParser
+} from '@loaders.gl/loader-utils';
 import {I3SLoader} from '@loaders.gl/i3s';
 import {Tiles3DLoader} from '@loaders.gl/3d-tiles';
 import {
@@ -260,6 +264,44 @@ test('I3SSource initializes promised roots and appends auth tokens to tile urls'
     'https://example.com/SceneServer/layers/0/nodes/1?token=secret-token'
   );
   expect(source.getTilesTotalCount()).toBe(7);
+});
+test('I3SSource routes binary tile content through the worker-capable content loader', async () => {
+  const resourceLoaders: Loader[] = [];
+  const resolver: TilesetSourceResolver = {
+    async loadRoot() {
+      throw new Error('preloaded metadata should not request a root resource');
+    },
+    async loadResource(_url, loader) {
+      resourceLoaders.push(loader);
+      return loader.id === 'i3s' ? {id: '1', refine: 'REPLACE'} : {vertexCount: 3};
+    }
+  };
+  const source = new I3SSource({
+    type: 'tileset',
+    url: 'https://example.com/SceneServer/layers/0',
+    loader: I3SLoader,
+    resolver,
+    root: {id: 'root-node', refine: 'REPLACE'},
+    lodMetricType: 'maxScreenThresholdSQ',
+    lodMetricValue: 4,
+    store: {}
+  } as any);
+  await source.initialize();
+  await source.loadChildTileHeader?.({} as Tile3D, '1', {} as any);
+
+  const tile = {
+    contentUrl: 'https://example.com/SceneServer/layers/0/nodes/1/geometries/0',
+    header: {},
+    tileset: {
+      options: {i3s: {}, spatial: {}},
+      spatialReference: {status: 'native'}
+    }
+  } as Tile3D;
+  await source.loadTileContent(tile);
+
+  expect(resourceLoaders.map(loader => loader.id)).toEqual(['i3s', 'i3s-content']);
+  expect(resourceLoaders[1].worker).toBe(true);
+  expect(tile.content).toEqual({vertexCount: 3});
 });
 test('I3SSource transforms traversal bounds and preserves a geographic view center', async () => {
   const source = new I3SSource({

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -181,6 +181,9 @@
       "@loaders.gl/i3s": [
         "modules/i3s/src"
       ],
+      "@loaders.gl/i3s/*": [
+        "modules/i3s/src/*"
+      ],
       "@loaders.gl/i3s/test": [
         "modules/i3s/test"
       ],


### PR DESCRIPTION
Goals

- Move I3S Point Cloud LEPCC geometry and attribute decoding off the renderer thread when workers are available.
- Allow Potree LAS/LAZ content to use the worker-capable TypeScript LAS loader by default.

Changes

- Add the standalone I3SLEPCCLoader metadata/parser pair with browser and Node worker bundles.
- Expose LEPCC loader options and package worker entry points.
- Route I3SPointCloudSource LEPCC resources through the injected CoreAPI, with a decoder fallback when workers are unavailable or disabled.
- Pass CoreAPI through I3S Point Cloud source creation.
- Preserve worker and fetch settings in Potree LAS/LAZ node loads instead of forcing core.worker: false.
- Keep legacy laz-perf, COPC, and laz-rs compatibility variants main-thread-only.
- Add worker/source coverage and update I3S format documentation.

Validation

- yarn build
- yarn build-workers
- yarn lint fix
- yarn test-audit
- yarn test-node
- yarn test-headless
- Targeted I3S LEPCC, I3S Point Cloud, Potree, and LAS worker tests