### PR TITLE
feat: prepare stateful batched loader workers

### DIFF
--- a/docs/developer-guide/using-worker-loaders.md
+++ b/docs/developer-guide/using-worker-loaders.md
@@ -77,6 +77,30 @@ Most worker-enabled loaders use the same `load` and `parse` APIs as their main-t
 counterparts. The loader reference identifies whether a loader has a worker bundle and
 whether it needs additional codec assets.
 
+### Stateful batched parsing
+
+When a loader supports worker batching, `parseInBatches` keeps one worker leased for the
+life of the returned iterator. Input fragments are requested only as the worker needs them,
+and output batches are produced only as the application advances the iterator. This keeps
+both queues bounded while allowing parsers to retain state across record and UTF-8 boundaries.
+
+The worker is returned to the pool after normal completion, so `core.reuseWorkers` still
+controls whether its runtime can be reused by later jobs. Aborting, propagating a parse error,
+or closing the iterator early terminates that worker and the pool creates a clean replacement.
+Applications should therefore close abandoned iterators (for example with `return()`) and
+should not assume that parser state survives an interrupted session.
+
+Binary fragments are transferred to the worker when possible; transfer gives the worker
+ownership and can detach the source `ArrayBuffer`. Loader-specific batch serializers can
+restore richer values after the boundary. For example, CSV Arrow batches use the Arrow
+transport helpers so the application receives real Arrow tables with methods such as
+`getChild()` rather than structured-cloned plain objects.
+
+The current 5.0 pilot is CSV with `csv.shape: 'arrow-table'`. Other loaders continue to use
+their existing main-thread or atomic-worker paths until they opt into the same stateful
+batch contract. If a loader or runtime cannot provide a compatible worker, `parseInBatches`
+falls back to the loader's main-thread parser without changing its batch ordering.
+
 ## Loading files in parallel
 
 `DracoLoader` is a worker-enabled loader that parses Draco-compressed meshes away from

--- a/docs/whats-new.mdx
+++ b/docs/whats-new.mdx
@@ -172,6 +172,13 @@ Release Date: 2026
 - Worker cancellation preserves `AbortSignal.reason`; closing a batch iterator terminates its
   leased worker so later jobs receive a clean replacement.
 
+**@loaders.gl/core and @loaders.gl/csv**
+
+- Browser `parseInBatches()` can route the CSV Arrow-table pilot through a stateful worker
+  session. One worker retains parser state across fragmented input, Arrow batches are hydrated
+  on the calling thread, and unsupported loaders retain their existing main-thread or atomic
+  worker fallbacks.
+
 **@loaders.gl/terrain**
 
 - [`QuantizedMeshWriter`](/docs/modules/terrain/api-reference/quantized-mesh-writer) NEW - writes quantized mesh terrain data.

--- a/modules/core/src/lib/api/parse-in-batches.ts
+++ b/modules/core/src/lib/api/parse-in-batches.ts
@@ -19,7 +19,12 @@ import type {
   LoaderArrayBatchType,
   TransformBatches
 } from '@loaders.gl/loader-utils';
-import {concatenateArrayBuffersAsync} from '@loaders.gl/loader-utils';
+import {
+  canParseWithWorker,
+  concatenateArrayBuffersAsync,
+  isBrowser,
+  parseWithWorkerInBatches
+} from '@loaders.gl/loader-utils';
 import {isLoaderObject} from '../loader-utils/normalize-loader';
 import {normalizeOptions} from '../loader-utils/option-utils';
 import {getLoaderContext} from '../loader-utils/loader-context';
@@ -177,8 +182,12 @@ async function parseToOutputIterator(
     options?.core?.transforms || []
   );
 
-  // If loader supports parseInBatches, we are done
+  // Stream supported browser batch parsers through one stateful worker session.
   if (loader.parseInBatches) {
+    // The loader-level adapter is intentionally piloted with CSV Arrow batches first.
+    if (loader.id === 'csv' && isBrowser && canParseWithWorker(loader, options)) {
+      return parseWithWorkerInBatches(loader, transformedIterator, options, context, parse);
+    }
     return loader.parseInBatches(transformedIterator, options, context);
   }
 

--- a/modules/csv/src/csv-loader-with-parser.ts
+++ b/modules/csv/src/csv-loader-with-parser.ts
@@ -38,7 +38,12 @@ import {
   shouldFinalizeGeometryDetection
 } from './lib/csv-geometry';
 import {CSVLoader as CSVLoaderMetadata, type CSVLoaderOptions} from './csv-loader';
-import {deserializeCSVWorkerResult, serializeCSVWorkerResult} from './lib/csv-worker-transport';
+import {
+  deserializeCSVWorkerBatch,
+  deserializeCSVWorkerResult,
+  serializeCSVWorkerBatch,
+  serializeCSVWorkerResult
+} from './lib/csv-worker-transport';
 
 const {preload: _CSVLoaderPreload, ...CSVLoaderMetadataWithoutPreload} = CSVLoaderMetadata;
 
@@ -63,7 +68,9 @@ export const CSVLoaderWithParser = {
       ? parseCSVInArrowBatches(asyncIterator, options)
       : parseCSVInBatches(asyncIterator, options),
   serializeWorkerResult: serializeCSVWorkerResult,
-  deserializeWorkerResult: deserializeCSVWorkerResult
+  deserializeWorkerResult: deserializeCSVWorkerResult,
+  serializeWorkerBatch: serializeCSVWorkerBatch,
+  deserializeWorkerBatch: deserializeCSVWorkerBatch
 } as const satisfies LoaderWithParser<
   ObjectRowTable | ArrayRowTable | ColumnarTable | ArrowTable,
   TableBatch | ColumnarTableBatch | ArrowTableBatch,

--- a/modules/csv/src/lib/csv-worker-transport.ts
+++ b/modules/csv/src/lib/csv-worker-transport.ts
@@ -4,7 +4,13 @@
 
 import type {DehydratedArrowTable, SplitArrowBuffersOptions} from '@loaders.gl/arrow/transport';
 import {dehydrateArrowTable, hydrateArrowTable} from '@loaders.gl/arrow/transport';
-import type {ArrayRowTable, ArrowTable, ColumnarTable, ObjectRowTable} from '@loaders.gl/schema';
+import type {
+  ArrayRowTable,
+  ArrowTable,
+  ArrowTableBatch,
+  ColumnarTable,
+  ObjectRowTable
+} from '@loaders.gl/schema';
 import type {CSVLoaderOptions} from '../csv-loader-options';
 
 type CSVWorkerResult = ArrowTable | ObjectRowTable | ArrayRowTable | ColumnarTable;
@@ -45,6 +51,16 @@ export function deserializeCSVWorkerResult(result: unknown): CSVWorkerResult {
   }
 
   return result as CSVWorkerResult;
+}
+
+/** Serializes one CSV parser batch using the same transport as an atomic result. */
+export function serializeCSVWorkerBatch(batch: unknown, options?: CSVLoaderOptions): unknown {
+  return serializeCSVWorkerResult(batch, options);
+}
+
+/** Rehydrates one CSV parser batch into a main-thread Arrow batch when needed. */
+export function deserializeCSVWorkerBatch(batch: unknown): ArrowTableBatch {
+  return deserializeCSVWorkerResult(batch) as ArrowTableBatch;
 }
 
 /**

--- a/modules/csv/test/csv-arrow-table.spec.ts
+++ b/modules/csv/test/csv-arrow-table.spec.ts
@@ -768,6 +768,53 @@ test('CSVLoader#arrow-table geometry detection supports byte and streaming input
   expect(batches.every(batch => batch.shape === 'arrow-table')).toBe(true);
 });
 
+test('CSVLoader#parseInBatches streams fragmented Arrow batches through one worker session', async () => {
+  const csvText = 'id,name\n1,Alice\n2,Bob\n3,Carol\n';
+  const bytes = new TextEncoder().encode(csvText);
+  // Copy each fragment because worker transport transfers ArrayBuffer ownership.
+  const chunks = [bytes.slice(0, 9), bytes.slice(9, 16), bytes.slice(16)];
+
+  async function collectRows(worker: boolean): Promise<{batchTypes: string[]; rows: unknown[][]}> {
+    const iterator = await parseInBatches(chunks, CSVLoader, {
+      core: {
+        worker,
+        batchSize: 1,
+        metadata: true,
+        _workerType: 'test',
+        reuseWorkers: false
+      },
+      csv: {header: true, shape: 'arrow-table', dynamicTyping: true, skipEmptyLines: false}
+    });
+    const batchTypes: string[] = [];
+    const rows: unknown[][] = [];
+    for await (const batch of iterator) {
+      batchTypes.push(batch.batchType);
+      if (batch.batchType === 'data') {
+        for (let rowIndex = 0; rowIndex < batch.data.numRows; rowIndex++) {
+          rows.push(
+            Array.from({length: batch.data.numCols}, (_, columnIndex) =>
+              batch.data.getChildAt(columnIndex)?.get(rowIndex)
+            )
+          );
+        }
+        expect(batch.data.getChild('id')?.get(0)).toEqual(expect.any(Number));
+      }
+    }
+    return {batchTypes, rows};
+  }
+
+  const mainThreadResult = await collectRows(false);
+  const workerResult = await collectRows(true);
+
+  expect(workerResult).toEqual(mainThreadResult);
+  expect(workerResult.batchTypes[0]).toBe('metadata');
+  expect(workerResult.rows).toEqual([
+    [1, 'Alice'],
+    [2, 'Bob'],
+    [3, 'Carol']
+  ]);
+});
+
 test('CSVLoader#worker transport serializes and hydrates Arrow table results', async () => {
   const table = await parse('city,population\nParis,2148000', CSVLoader, {
     core: {worker: false},

--- a/modules/loader-utils/src/index.ts
+++ b/modules/loader-utils/src/index.ts
@@ -102,8 +102,15 @@ export {registerJSModules} from './lib/module-utils/js-module-utils';
 export {checkJSModule, getJSModule, getJSModuleOrNull} from './lib/module-utils/js-module-utils';
 
 // LOADERS.GL-SPECIFIC WORKER UTILS
-export {createLoaderWorker} from './lib/worker-loader-utils/create-loader-worker';
-export {parseWithWorker, canParseWithWorker} from './lib/worker-loader-utils/parse-with-worker';
+export {
+  createLoaderWorker,
+  processLoaderWorkerBatches
+} from './lib/worker-loader-utils/create-loader-worker';
+export {
+  parseWithWorker,
+  parseWithWorkerInBatches,
+  canParseWithWorker
+} from './lib/worker-loader-utils/parse-with-worker';
 export {canEncodeWithWorker} from './lib/worker-loader-utils/encode-with-worker';
 
 // PARSER UTILS

--- a/modules/loader-utils/src/lib/worker-loader-utils/create-loader-worker.ts
+++ b/modules/loader-utils/src/lib/worker-loader-utils/create-loader-worker.ts
@@ -13,8 +13,11 @@ import {createWorker} from '@loaders.gl/worker-utils';
  * @param loader
  */
 export async function createLoaderWorker(loader: LoaderWithParser) {
-  await createWorker((input, options, workerContext, loaderContext) =>
-    processLoaderWorkerData(loader, input, options, workerContext, loaderContext)
+  await createWorker(
+    (input, options, workerContext, loaderContext) =>
+      processLoaderWorkerData(loader, input, options, workerContext, loaderContext),
+    (inputIterator, options, workerContext, loaderContext) =>
+      processLoaderWorkerBatches(loader, inputIterator, options, workerContext, loaderContext)
   );
 }
 
@@ -42,6 +45,35 @@ export async function processLoaderWorkerData(
   return loader.serializeWorkerResult
     ? loader.serializeWorkerResult(result, options, loaderContext as LoaderContext)
     : result;
+}
+
+/** Processes a complete input stream using the loader's stateful batch parser. */
+export async function* processLoaderWorkerBatches(
+  loader: LoaderWithParser,
+  inputIterator:
+    | AsyncIterable<ArrayBufferLike | ArrayBufferView>
+    | Iterable<ArrayBufferLike | ArrayBufferView>,
+  options: {[key: string]: any} = {},
+  workerContext?: {
+    process?: (data: any, options?: LoaderOptions, context?: Record<string, any>) => any;
+  },
+  loaderContext: Record<string, any> = {}
+): AsyncIterable<unknown> {
+  if (!loader.parseInBatches) {
+    throw new Error(`${loader.id} loader does not support batched parsing`);
+  }
+
+  const resultIterator = loader.parseInBatches(inputIterator, options, {
+    ...loaderContext,
+    coreApi: createWorkerCoreApi(),
+    _parse: createParseOnMainThread(workerContext?.process)
+  } as LoaderContext);
+
+  for await (const batch of resultIterator) {
+    yield loader.serializeWorkerBatch
+      ? loader.serializeWorkerBatch(batch, options, loaderContext as LoaderContext)
+      : batch;
+  }
 }
 
 /**

--- a/modules/loader-utils/src/lib/worker-loader-utils/parse-with-worker.ts
+++ b/modules/loader-utils/src/lib/worker-loader-utils/parse-with-worker.ts
@@ -2,8 +2,18 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {canProcessOnWorker, isBrowser, processOnWorker} from '@loaders.gl/worker-utils';
-import type {Loader, StrictLoaderOptions, LoaderContext} from '../../loader-types';
+import {
+  canProcessOnWorker,
+  isBrowser,
+  processOnWorker,
+  processOnWorkerInBatches
+} from '@loaders.gl/worker-utils';
+import type {
+  Loader,
+  LoaderWithParser,
+  StrictLoaderOptions,
+  LoaderContext
+} from '../../loader-types';
 
 type ParseOnMainThread = (
   arrayBuffer: ArrayBuffer,
@@ -86,6 +96,56 @@ export async function parseWithWorker(
   return isLoaderWithWorkerResultDeserializer(loader)
     ? loader.deserializeWorkerResult(result, options, context)
     : result;
+}
+
+/**
+ * Parses an input iterator through one stateful worker session.
+ * @param loader Parser-bearing loader with a batched worker implementation.
+ * @param inputIterator Input fragments to stream to the worker.
+ * @param options Loader and worker options.
+ * @param context Serializable loader context.
+ * @param parseOnMainThread Callback for worker requests that must run on the calling thread.
+ * @param signal Optional cancellation signal for this worker job.
+ */
+export async function* parseWithWorkerInBatches(
+  loader: LoaderWithParser,
+  inputIterator:
+    | AsyncIterable<ArrayBufferLike | ArrayBufferView>
+    | Iterable<ArrayBufferLike | ArrayBufferView>,
+  options?: StrictLoaderOptions,
+  context?: LoaderContext,
+  parseOnMainThread?: ParseOnMainThread,
+  signal?: AbortSignal
+): AsyncIterable<unknown> {
+  const workerSignal = signal || getWorkerAbortSignal(options);
+  const outputIterator = processOnWorkerInBatches(
+    loader,
+    inputIterator,
+    {...getWorkerOptions(options), signal: workerSignal},
+    {
+      process: async (input, processOptions, _workerContext, parseContext) => {
+        if (!parseOnMainThread) {
+          throw new Error('Worker not set up to parse on main thread');
+        }
+        const mainThreadContext = context
+          ? ({...context, ...(parseContext || {})} as LoaderContext)
+          : undefined;
+        return await callParseOnMainThread(
+          parseOnMainThread,
+          input,
+          processOptions,
+          mainThreadContext
+        );
+      }
+    },
+    getSerializableLoaderContext(context)
+  );
+
+  for await (const batch of outputIterator) {
+    yield loader.deserializeWorkerBatch
+      ? loader.deserializeWorkerBatch(batch, options, context)
+      : batch;
+  }
 }
 
 /** Returns the loader-specific abort signal used to cancel a worker job. */

--- a/modules/loader-utils/src/loader-types.ts
+++ b/modules/loader-utils/src/loader-types.ts
@@ -256,6 +256,18 @@ export type LoaderWithParser<
     options?: LoaderOptionsT,
     context?: LoaderContext
   ) => AsyncIterable<BatchT>;
+  /** Serializes one parser batch before returning it from a worker. */
+  serializeWorkerBatch?: (
+    batch: BatchT,
+    options?: LoaderOptionsT,
+    context?: LoaderContext
+  ) => unknown;
+  /** Deserializes one parser batch returned from a worker. */
+  deserializeWorkerBatch?: (
+    batch: unknown,
+    options?: LoaderOptionsT,
+    context?: LoaderContext
+  ) => BatchT;
   /** For random access, file like sources, source that don't integrate with fetch. */
   parseFileInBatches?: (
     file: ReadableFile,

--- a/modules/loader-utils/test/lib/worker-loader-utils/create-loader-worker.spec.ts
+++ b/modules/loader-utils/test/lib/worker-loader-utils/create-loader-worker.spec.ts
@@ -3,7 +3,10 @@
 // Copyright (c) vis.gl contributors
 
 import {describe, expect, test, vi} from 'vitest';
-import {processLoaderWorkerData} from '../../../src/lib/worker-loader-utils/create-loader-worker';
+import {
+  processLoaderWorkerBatches,
+  processLoaderWorkerData
+} from '../../../src/lib/worker-loader-utils/create-loader-worker';
 
 const BASE_LOADER = {
   id: 'test',
@@ -47,6 +50,75 @@ describe('processLoaderWorkerData', () => {
     expect(result).toEqual({parsed: true, serialized: true});
     expect(parse).toHaveBeenCalledOnce();
     expect(serializeWorkerResult).toHaveBeenCalledOnce();
+  });
+
+  test('retains parser state and serializes each output batch', async () => {
+    const parseInBatches = vi.fn(async function* (inputIterator: AsyncIterable<number>) {
+      let total = 0;
+      for await (const input of inputIterator) {
+        total += input;
+        yield {batchType: 'data', value: total};
+      }
+    });
+    const serializeWorkerBatch = vi.fn((batch: {batchType: string; value: number}) => ({
+      ...batch,
+      serialized: true
+    }));
+    const batches = [];
+
+    for await (const batch of processLoaderWorkerBatches(
+      {
+        ...BASE_LOADER,
+        parseInBatches,
+        serializeWorkerBatch
+      } as any,
+      [1, 2, 3] as any,
+      {core: {worker: false}}
+    )) {
+      batches.push(batch);
+    }
+
+    expect(batches).toEqual([
+      {batchType: 'data', value: 1, serialized: true},
+      {batchType: 'data', value: 3, serialized: true},
+      {batchType: 'data', value: 6, serialized: true}
+    ]);
+    expect(parseInBatches).toHaveBeenCalledOnce();
+    expect(serializeWorkerBatch).toHaveBeenCalledTimes(3);
+  });
+
+  test('propagates parser errors lazily and closes the parser iterator early', async () => {
+    const parserError = new Error('parser failed on second batch');
+    let parserClosed = false;
+    const parseInBatches = async function* (_inputIterator: AsyncIterable<number>) {
+      try {
+        yield {batchType: 'data', value: 1};
+        throw parserError;
+      } finally {
+        parserClosed = true;
+      }
+    };
+    const outputIterator = processLoaderWorkerBatches(
+      {...BASE_LOADER, parseInBatches} as any,
+      [1, 2] as any
+    )[Symbol.asyncIterator]();
+
+    expect(parserClosed).toBe(false);
+    await expect(outputIterator.next()).resolves.toMatchObject({
+      value: {batchType: 'data', value: 1},
+      done: false
+    });
+    await expect(outputIterator.next()).rejects.toBe(parserError);
+    expect(parserClosed).toBe(true);
+
+    parserClosed = false;
+    const closableIterator = processLoaderWorkerBatches(
+      {...BASE_LOADER, parseInBatches} as any,
+      [1, 2] as any
+    )[Symbol.asyncIterator]();
+    await closableIterator.next();
+    await closableIterator.return?.();
+    expect(parserClosed).toBe(true);
   });
 
   test('selects sync and text parsers', async () => {


### PR DESCRIPTION
## Goals

Prepare loaders.gl 5.0 for stateful batched parsing on workers and cost-aware atomic worker selection while keeping existing worker behavior compatible.

## Changes

- Add `parseWithWorkerInBatches()` and loader-worker batched processing support on top of the existing demand-driven worker session protocol.
- Add typed `serializeWorkerBatch` and `deserializeWorkerBatch` hooks for non-structured-clone-safe batches.
- Route browser CSV `csv.shape: 'arrow-table'` `parseInBatches()` through one stateful classic worker, preserving main-thread input transforms and metadata ordering.
- Hydrate CSV Arrow batches with the existing Arrow transport helpers. Other loaders and Node worker activation remain unchanged for follow-up work.
- Add `core.worker: 'auto'` and `core.workerThreshold` for atomic `parse()` calls. Loaders can provide synchronous normalized `getWorkerEstimate()` hooks using the original, unmaterialized input.
- Keep explicit `worker: true` and `worker: false` behavior unchanged. Missing, invalid, or throwing estimates conservatively retain worker-capable behavior; unknown streams are not consumed for estimation.
- Document worker session identity, backpressure, transfer ownership, Arrow hydration, cancellation, fallback behavior, and automatic worker selection guidance based on CPU work rather than bytes alone.
- Add coverage for fragmented CSV state retention, Arrow APIs, worker/main-thread equivalence, metadata ordering, per-batch serialization, lazy errors, early iterator closure, and automatic atomic worker selection for ArrayBuffer, Blob, and unknown stream inputs.

## Validation

- `yarn build`
- `yarn build-workers`
- Focused Chromium worker-selection tests: 11 passed
- `yarn test-node`: 441 passed, 6 skipped
- `yarn test-audit`: passing
- `yarn lint fix`: passing
- Full `yarn test-headless` was attempted; the browser runner exited before collecting results in this environment. Existing focused browser coverage passes.

