### PR TITLE
test: deepen high-impact coverage tranche

### DIFF
--- a/modules/copc/test/copc-source.spec.ts
+++ b/modules/copc/test/copc-source.spec.ts
@@ -133,6 +133,40 @@ test('COPCSourceLoader#validates scan batch size and cancellation', async () => 
   await source.close();
 });
 
+test('COPCSourceLoader#validates progressive decoding options and unavailable nodes', async () => {
+  const source = COPCSourceLoader.createDataSource(await createEllipsoidSourceData(), {});
+  await source.initialize();
+
+  await expect(source.loadTileContentInBatches({id: '1-1-1-1'}).next()).resolves.toMatchObject({
+    done: true
+  });
+  const rootTile = await source.getRootTile();
+  for (const options of [
+    {batchSize: 0},
+    {batchSize: 1.5},
+    {rangeChunkSize: 0},
+    {rangeConcurrency: 0}
+  ]) {
+    await expect(source.loadTileContentInBatches(rootTile, options).next()).rejects.toThrow(
+      /positive integer/
+    );
+  }
+
+  await expect(
+    source.loadTileContentInBatches(rootTile, {columns: ['NIR']}).next()
+  ).rejects.toThrow('COPC NIR output requires PDRF 8');
+  await expect(
+    source.loadTileContentInBatches(rootTile, {columns: ['EXTRA_BYTES']}).next()
+  ).rejects.toThrow('typed Extra Bytes output requires an Extra Bytes VLR');
+
+  const abortController = new AbortController();
+  abortController.abort();
+  await expect(
+    source.loadTileContentInBatches(rootTile, {signal: abortController.signal}).next()
+  ).rejects.toThrow('was aborted');
+  await source.close();
+});
+
 test('COPCSourceLoader#loads normalized root and child tiles', async () => {
   const source = COPCSourceLoader.createDataSource(await createEllipsoidSourceData(), {});
   await source.initialize();

--- a/modules/geoarrow/test/geoarrow-layout.spec.ts
+++ b/modules/geoarrow/test/geoarrow-layout.spec.ts
@@ -75,9 +75,17 @@ describe('GeoArrow physical layout oracle', () => {
         coordinates: 'separated',
         offsetType: 'int64'
       });
-      expect(native.schema.fields[0].metadata?.get('ARROW:extension:name')).toContain(
+      const nativeField = native.schema.fields[0];
+      const nativeLayout = inspectGeoArrowLayout(nativeField);
+      expect(nativeLayout).toMatchObject({
+        valid: true,
+        layout: {dimension: 'xyz', coordinates: 'separated'}
+      });
+      expect(nativeField.metadata?.get('ARROW:extension:name')).toContain(
         `geoarrow.${geometry.type.toLowerCase()}`
       );
+      const nativeWkt = convertGeoArrowGeometry(native, 'geoarrow.wkt', {dimension: 'xyz'});
+      expect(nativeWkt.getChildAt(0)!.get(0)).toContain(geometry.type.toUpperCase());
 
       const wkt = convertGeoArrowGeometry(source, 'geoarrow.wkt', {dimension: 'xyzm'});
       expect(wkt.getChildAt(0)!.get(0)).toContain(geometry.type.toUpperCase());

--- a/modules/geoarrow/test/geoarrow-layout.spec.ts
+++ b/modules/geoarrow/test/geoarrow-layout.spec.ts
@@ -11,6 +11,119 @@ function extensionMetadata(encoding: string): Map<string, string> {
 }
 
 describe('GeoArrow physical layout oracle', () => {
+  test('converts every concrete geometry family through native, WKT, and WKB targets', () => {
+    const cases = [
+      {
+        type: 'Point' as const,
+        coordinates: [1, 2]
+      },
+      {
+        type: 'LineString' as const,
+        coordinates: [
+          [0, 0],
+          [1, 1]
+        ]
+      },
+      {
+        type: 'Polygon' as const,
+        coordinates: [
+          [
+            [0, 0],
+            [1, 0],
+            [1, 1],
+            [0, 0]
+          ]
+        ]
+      },
+      {
+        type: 'MultiPoint' as const,
+        coordinates: [
+          [0, 0],
+          [1, 1]
+        ]
+      },
+      {
+        type: 'MultiLineString' as const,
+        coordinates: [
+          [
+            [0, 0],
+            [1, 1]
+          ]
+        ]
+      },
+      {
+        type: 'MultiPolygon' as const,
+        coordinates: [
+          [
+            [
+              [0, 0],
+              [1, 0],
+              [1, 1],
+              [0, 0]
+            ]
+          ]
+        ]
+      }
+    ];
+
+    for (const geometry of cases) {
+      const source = convertFeaturesToGeoArrowTable([
+        {type: 'Feature', properties: {}, geometry}
+      ]).data;
+      const native = convertGeoArrowGeometry(source, 'native', {
+        dimension: 'xyz',
+        coordinates: 'separated',
+        offsetType: 'int64'
+      });
+      expect(native.schema.fields[0].metadata?.get('ARROW:extension:name')).toContain(
+        `geoarrow.${geometry.type.toLowerCase()}`
+      );
+
+      const wkt = convertGeoArrowGeometry(source, 'geoarrow.wkt', {dimension: 'xyzm'});
+      expect(wkt.getChildAt(0)!.get(0)).toContain(geometry.type.toUpperCase());
+
+      const wkb = convertGeoArrowGeometry(source, 'geoarrow.wkb');
+      expect(wkb.getChildAt(0)!.get(0)).toBeInstanceOf(Uint8Array);
+    }
+  });
+
+  test('converts and validates nested geometry collections with null members', () => {
+    const source = convertFeaturesToGeoArrowTable([
+      {
+        type: 'Feature',
+        properties: {},
+        geometry: {
+          type: 'GeometryCollection',
+          geometries: [
+            {type: 'Point', coordinates: [1, 2]},
+            {
+              type: 'LineString',
+              coordinates: [
+                [0, 0],
+                [1, 1]
+              ]
+            }
+          ]
+        }
+      },
+      {type: 'Feature', properties: {}, geometry: null}
+    ]).data;
+
+    const collection = convertGeoArrowGeometry(source, 'geoarrow.geometrycollection', {
+      offsetType: 'int64'
+    });
+    expect(collection.numRows).toBe(2);
+    expect(collection.schema.fields[0].type).toBeInstanceOf(arrow.LargeList);
+
+    const union = convertGeoArrowGeometry(source, 'geoarrow.geometry', {
+      geometryTypes: ['Point', 'LineString', 'GeometryCollection']
+    });
+    expect(union.numRows).toBe(2);
+    expect(() =>
+      convertGeoArrowGeometry(source, 'geoarrow.point', {geometryColumn: 'missing'})
+    ).toThrow('could not find geometry column');
+  });
+
   test('classifies native layouts and reports nested storage facts', () => {
     const coordinate = new arrow.FixedSizeList(
       2,

--- a/modules/las/test/typescript-las-format-matrix.spec.ts
+++ b/modules/las/test/typescript-las-format-matrix.spec.ts
@@ -4,7 +4,9 @@
 
 import {expect, test} from 'vitest';
 import type {MeshArrowTable} from '@loaders.gl/schema';
+import {encodeLAZChunk} from '@loaders.gl/loader-utils';
 import {
+  decodeLAZChunkToArrowTable,
   parseLAS,
   parseLASChunkedIterator,
   parseLASHeader,
@@ -81,6 +83,68 @@ test('TypeScript LAS color selection covers explicit and auto 8-bit paths', () =
     expect(firstColor).toHaveLength(4);
     expect(firstColor[3]).toBe(255);
   }
+});
+
+test('TypeScript LAS directly decodes a modern LAZ chunk into Arrow columns', () => {
+  const source = createLASFixture(7, true);
+  const pointDataRecordLength = 36;
+  const rawPointData = new Uint8Array(3 * pointDataRecordLength);
+  for (let pointIndex = 0; pointIndex < 3; pointIndex++) {
+    rawPointData.set(
+      new Uint8Array(source, 375 + pointIndex * 38, pointDataRecordLength),
+      pointIndex * pointDataRecordLength
+    );
+  }
+  const metadata = {
+    pointDataRecordFormat: 7,
+    pointDataRecordLength,
+    pointCount: 3,
+    point14ItemVersion: 3 as const,
+    rgb14ItemVersion: 3 as const,
+    scale: [0.5, 2, 4] as [number, number, number],
+    offset: [10, 20, 30] as [number, number, number]
+  };
+  const compressed = encodeLAZChunk(rawPointData, metadata);
+  const table = decodeLAZChunkToArrowTable(compressed, metadata, {
+    las: {
+      columns: ['POSITION', 'COLOR_0', 'GPS_TIME', 'intensity', 'classification'],
+      colorDepth: 16
+    }
+  });
+
+  expect(table.data.numRows).toBe(3);
+  expect(Array.from(table.data.getChild('POSITION')!.get(0))).toEqual([510, -3980, 230]);
+  expect(Array.from(table.data.getChild('COLOR_0')!.get(0))).toEqual([2560, 5120, 7680]);
+  expect(table.data.getChild('GPS_TIME')!.get(2)).toBe(1002.5);
+});
+
+test('TypeScript LAS standalone LAZ Arrow decoding rejects unsupported formats and columns', () => {
+  const metadata = {
+    pointDataRecordFormat: 7,
+    pointDataRecordLength: 36,
+    pointCount: 1,
+    point14ItemVersion: 3 as const,
+    rgb14ItemVersion: 3 as const,
+    scale: [1, 1, 1] as [number, number, number],
+    offset: [0, 0, 0] as [number, number, number]
+  };
+  const compressed = encodeLAZChunk(new Uint8Array(36), metadata);
+  for (const pointDataRecordFormat of [5, 9]) {
+    expect(() =>
+      decodeLAZChunkToArrowTable(
+        compressed,
+        {...metadata, pointDataRecordFormat},
+        {las: {columns: ['POSITION']}}
+      )
+    ).toThrow(/supports PDRF 6-8/);
+  }
+  expect(() =>
+    decodeLAZChunkToArrowTable(
+      compressed,
+      {...metadata, pointDataRecordLength: 38},
+      {las: {columns: ['EXTRA_BYTES']}}
+    )
+  ).toThrow('only supports direct LAZ columns');
 });
 
 test('TypeScript LAS streams fragmented modern records into exact batches', async () => {

--- a/modules/parquet/test/parquet-writer-nested.spec.ts
+++ b/modules/parquet/test/parquet-writer-nested.spec.ts
@@ -1,0 +1,112 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {encode, load} from '@loaders.gl/core';
+import {ParquetJSLoader, ParquetJSWriter} from '@loaders.gl/parquet';
+import type {ObjectRowTable} from '@loaders.gl/schema';
+import {expect, test} from 'vitest';
+
+test('ParquetJSWriter round-trips nested structs, lists, maps, and nulls', async () => {
+  const table: ObjectRowTable = {
+    shape: 'object-row-table',
+    schema: {
+      fields: [
+        {
+          name: 'profile',
+          type: {
+            type: 'struct',
+            children: [
+              {name: 'city', type: 'utf8', nullable: false},
+              {name: 'score', type: 'int32', nullable: true}
+            ]
+          },
+          nullable: true
+        },
+        {
+          name: 'tags',
+          type: {type: 'list', children: [{name: 'item', type: 'int32', nullable: false}]},
+          nullable: false
+        },
+        {
+          name: 'labels',
+          type: {
+            type: 'map',
+            children: [
+              {name: 'key', type: 'utf8', nullable: false},
+              {name: 'value', type: 'utf8', nullable: true}
+            ]
+          },
+          nullable: false
+        }
+      ],
+      metadata: {}
+    },
+    data: [
+      {
+        profile: {city: 'Paris', score: 10},
+        tags: [1, 2],
+        labels: new Map([
+          ['language', 'fr'],
+          ['optional', null]
+        ])
+      },
+      {profile: null, tags: [], labels: {language: 'en'}}
+    ]
+  };
+
+  const parquetBuffer = await encode(table, ParquetJSWriter, {worker: false});
+  const output = await load(parquetBuffer, ParquetJSLoader, {core: {worker: false}});
+
+  expect(output.shape).toBe('object-row-table');
+  if (output.shape === 'object-row-table') {
+    expect(output.data).toEqual([
+      {
+        profile: {city: 'Paris', score: 10},
+        tags: {list: [{element: 1}, {element: 2}]},
+        labels: {
+          key_value: [
+            {key: 'language', value: 'fr'},
+            {key: 'optional'}
+          ]
+        }
+      },
+      {tags: {}, labels: {key_value: [{key: 'language', value: 'en'}]}}
+    ]);
+  }
+});
+
+test('ParquetJSWriter rejects invalid nested table schemas before writing', async () => {
+  const invalidList: ObjectRowTable = {
+    shape: 'object-row-table',
+    schema: {
+      fields: [{name: 'values', type: {type: 'list', children: []}, nullable: false}],
+      metadata: {}
+    },
+    data: [{values: []}]
+  };
+  await expect(encode(invalidList, ParquetJSWriter, {worker: false})).rejects.toThrow(
+    'List field "values" has no value child'
+  );
+
+  const invalidMap: ObjectRowTable = {
+    shape: 'object-row-table',
+    schema: {
+      fields: [
+        {
+          name: 'values',
+          type: {
+            type: 'map',
+            children: [{name: 'key', type: 'utf8', nullable: true}]
+          },
+          nullable: false
+        }
+      ],
+      metadata: {}
+    },
+    data: [{values: {key: 'value'}}]
+  };
+  await expect(encode(invalidMap, ParquetJSWriter, {worker: false})).rejects.toThrow(
+    'Map field "values" needs key and value children'
+  );
+});


### PR DESCRIPTION
## Goals

- Increase meaningful loaders.gl coverage in high-impact GeoArrow, LAS/COPC, and Parquet paths.
- Exercise nested Parquet writer conversion without adding large fixtures or slow exhaustive cases.
- Keep all new coverage in native Vitest syntax and preserve fast, hermetic test execution.

## Changes

- Extend GeoArrow geometry conversion coverage across concrete geometry families and nested geometry collections.
- Add LAS/COPC boundary coverage for modern LAZ decoding, unsupported point formats, extra bytes, invalid progressive options, and cancellation.
- Add Parquet writer coverage for nested structs, lists, maps, nullable values, `Map`/object normalization, and invalid nested schemas.
- The branch is based on the merged coverage baseline from PR #3949.

## Validation

- `yarn build`
- `yarn build-workers`
- `yarn test-node` — 441 passed, 6 skipped
- `yarn test-headless`
- `yarn lint fix`
- `yarn test-audit` — 0 Tape files, 0 violations
- `git diff --check`

The full repository Coveralls result will be reported by CI; the focused local coverage file is intentionally not used as a repository-wide baseline.
