### PR TITLE
feat(website): prototype hot-reloadable Parquet source worker

### DIFF
--- a/docs/developer-guide/dev-env.md
+++ b/docs/developer-guide/dev-env.md
@@ -58,6 +58,21 @@ yarn bootstrap
 
 Note that our primary development environment is MacOS, but it is also possible to build loaders.gl on Linux and Windows.
 
+### Website development workers
+
+The website development server can run the Parquet source worker directly from
+`modules/parquet/src/workers/parquet-source-worker.ts`. You do not need to run
+`yarn build-workers` before `cd website && yarn start`; the website-only
+development webpack configuration supplies a module-worker URL for that source
+file and watches it for changes. Editing the worker invalidates the development
+worker farm, so active jobs fail and the next request starts a fresh worker.
+
+This is intentionally a website development convenience, not a published
+package feature. Production and staging still use the generated
+`dist/parquet-source-worker.js` asset, and an explicit `parquet.workerUrl` always
+overrides the built-in target. The source-worker replacement is not enabled for
+server-side rendering, Node.js, or package builds.
+
 ### Develop on Windows
 
 It is possible to build loaders.gl on Windows 10, but not directly in the Windows command prompt. You will need to install a Linux command line environment.

--- a/modules/parquet/src/lib/parquet-source-worker-client.ts
+++ b/modules/parquet/src/lib/parquet-source-worker-client.ts
@@ -6,6 +6,7 @@ import type {Loader} from '@loaders.gl/loader-utils';
 import {canParseWithWorker, isBrowser, parseWithWorker} from '@loaders.gl/loader-utils';
 
 import {PARQUET_LOADER_BASE} from '../parquet-loader-base';
+import {PARQUET_SOURCE_WORKER_LOAD_WORKER} from '../parquet-source-worker-factory';
 import {PARQUET_SOURCE_WORKER_URL} from '../parquet-source-worker-url';
 import type {
   ParquetSourceWorkerInput,
@@ -18,7 +19,8 @@ const PARQUET_SOURCE_WORKER: Loader = {
   ...PARQUET_LOADER_BASE,
   id: 'parquet-source',
   name: 'ParquetSource',
-  worker: PARQUET_SOURCE_WORKER_URL
+  worker: PARQUET_SOURCE_WORKER_URL,
+  loadWorker: PARQUET_SOURCE_WORKER_LOAD_WORKER
 };
 
 /** Returns whether this runtime and option set can decode Parquet source rows on a worker. */

--- a/modules/parquet/src/parquet-source-worker-factory.ts
+++ b/modules/parquet/src/parquet-source-worker-factory.ts
@@ -1,0 +1,8 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {Loader} from '@loaders.gl/loader-utils';
+
+/** Optional browser worker factory for the private Parquet source worker. */
+export const PARQUET_SOURCE_WORKER_LOAD_WORKER: Loader['loadWorker'] = undefined;

--- a/modules/worker-utils/src/lib/worker-farm/worker-farm.ts
+++ b/modules/worker-utils/src/lib/worker-farm/worker-farm.ts
@@ -63,12 +63,13 @@ export default class WorkerFarm {
   }
 
   /**
-   * Terminate all workers in the farm
+   * Terminate all workers in the farm and abort active jobs.
+   * @param reason Optional error delivered to active jobs.
    * @note Can free up significant memory
    */
-  destroy(): void {
+  destroy(reason?: unknown): void {
     for (const workerPool of this.workerPools.values()) {
-      workerPool.destroy();
+      workerPool.destroy(reason);
     }
     this.workerPools = new Map<string, WorkerPool>();
   }

--- a/modules/worker-utils/src/lib/worker-farm/worker-pool.ts
+++ b/modules/worker-utils/src/lib/worker-farm/worker-pool.ts
@@ -70,6 +70,7 @@ export default class WorkerPool {
   private props: WorkerPoolProps = {};
   private jobQueue: QueuedJob[] = [];
   private idleQueue: WorkerThread[] = [];
+  private activeJobs = new Set<WorkerJob>();
   private count = 0;
   private isDestroyed = false;
 
@@ -91,11 +92,13 @@ export default class WorkerPool {
   }
 
   /**
-   * Terminates all workers in the pool
+   * Terminates all workers in the pool and aborts active jobs.
+   * @param reason Optional error delivered to active jobs.
    * @note Can free up significant memory
    */
-  destroy(): void {
-    // Destroy idle workers, active Workers will be destroyed on completion
+  destroy(reason: unknown = new Error('Worker pool was destroyed')): void {
+    // Abort active jobs so callers receive an error when a development worker is invalidated.
+    this.activeJobs.forEach(job => job.abort(reason));
     this.idleQueue.forEach(worker => worker.destroy());
     this.isDestroyed = true;
   }
@@ -165,6 +168,7 @@ export default class WorkerPool {
 
       // Create a worker job to let the app access thread and manage job completion
       const job = new WorkerJob(queuedJob.name, workerThread);
+      this.activeJobs.add(job);
       workerThread.ref();
 
       // Set the worker thread's message handlers
@@ -181,6 +185,7 @@ export default class WorkerPool {
         // The job result promise carries worker errors back to the caller; do not duplicate-log
         // handled rejections here.
       } finally {
+        this.activeJobs.delete(job);
         this.returnWorkerToQueue(workerThread);
       }
     }

--- a/modules/worker-utils/test/lib/worker-farm/worker-pool.spec.ts
+++ b/modules/worker-utils/test/lib/worker-farm/worker-pool.spec.ts
@@ -86,3 +86,21 @@ test('WorkerPool with reuseWorkers === true param', async () => {
   expect(workerPool.idleQueue.length).toBe(3);
   workerPool.destroy();
 });
+
+test('WorkerPool destroy aborts active jobs with its reason', async () => {
+  if (!hasWorker) {
+    console.log('Worker test is browser only');
+    return;
+  }
+  const workerPool = new WorkerPool({
+    source: testWorkerSource,
+    name: 'test-worker',
+    maxConcurrency: 1
+  });
+  const job = await workerPool.startJob('test-job');
+  job.postMessage('process', {input: 'pending'});
+  const reason = new Error('worker source invalidated');
+  workerPool.destroy(reason);
+
+  await expect(job.result).rejects.toBe(reason);
+});

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -38,6 +38,23 @@ function createBundlerPlugin() {
     name: 'loaders-gl-bundler-plugin',
     configureWebpack(_config, _isServer, {currentBundler}) {
       const bundler = currentBundler.instance;
+      const developmentWorkerReplacements = [];
+      if (process.env.NODE_ENV === 'development' && !_isServer) {
+        developmentWorkerReplacements.push(
+          new bundler.NormalModuleReplacementPlugin(
+            /parquet-source-worker-url$/,
+            resolve('./src/shims/parquet-source-worker-url.dev.js')
+          ),
+          new bundler.NormalModuleReplacementPlugin(
+            /parquet-source-worker-factory$/,
+            resolve('./src/shims/parquet-source-worker-factory.dev.js')
+          ),
+          new bundler.NormalModuleReplacementPlugin(
+            /loadersgl-worker-hmr$/,
+            resolve('./src/shims/loadersgl-worker-hmr.dev.js')
+          )
+        );
+      }
       return {
         // These modules intentionally use Node fallbacks or dynamic WASM paths that are replaced
         // in browser builds. Keep unrelated bundler warnings visible.
@@ -78,7 +95,8 @@ function createBundlerPlugin() {
             if (normalizedContext?.endsWith('/node_modules/geotiff/dist-module/compression')) {
               resource.request = resolve('./src/shims/geotiff-lerc-decoder.js');
             }
-          })
+          }),
+          ...developmentWorkerReplacements
         ]
       };
     }

--- a/website/scripts/build.sh
+++ b/website/scripts/build.sh
@@ -32,6 +32,13 @@ case $MODE in
     ;;
 esac
 
+# Development-only source-worker replacements must never enter production output.
+if rg -q 'new URL[^\n]*parquet-source-worker\.ts|parquet-source-worker-factory\.dev' "$OUTPUT_DIR" \
+  -g '*.js' -g '*.map' -g '*.json'; then
+  echo 'Development Parquet worker source leaked into website production output.' >&2
+  exit 1
+fi
+
 # # transpile workers
 # (
 #   cd ..

--- a/website/scripts/start.sh
+++ b/website/scripts/start.sh
@@ -1,12 +1,4 @@
 #!/bin/bash
 set -e
 
-# The integrated examples import this worker by module-relative URL. Build it
-# before starting Docusaurus so a fresh checkout does not crash at compile time.
-(cd ../modules/parquet && ../../node_modules/.bin/esbuild src/workers/parquet-source-worker.ts \
-  --outfile=dist/parquet-source-worker.js \
-  --target=esnext --platform=browser --bundle --sourcemap \
-  --inject:src/polyfills/process.ts --banner:js='var global=globalThis;' \
-  --define:__VERSION__=\"$npm_package_version\")
-
 exec docusaurus start "$@"

--- a/website/src/shims/loadersgl-worker-hmr.dev.js
+++ b/website/src/shims/loadersgl-worker-hmr.dev.js
@@ -1,0 +1,10 @@
+import {WorkerFarm} from '@loaders.gl/worker-utils';
+
+/** Installs worker-farm cleanup when webpack invalidates a worker source module. */
+export function installWorkerHMR() {
+  if (typeof module !== 'undefined' && module.hot) {
+    module.hot.dispose(() => {
+      WorkerFarm.getWorkerFarm().destroy(new Error('Worker source was invalidated by HMR'));
+    });
+  }
+}

--- a/website/src/shims/loadersgl-worker-hmr.ts
+++ b/website/src/shims/loadersgl-worker-hmr.ts
@@ -1,0 +1,4 @@
+// Production-safe no-op. Development builds replace this module with the HMR implementation.
+
+/** Installs the website worker HMR cleanup hook when development mode provides one. */
+export function installWorkerHMR(): void {}

--- a/website/src/shims/parquet-source-worker-factory.dev.js
+++ b/website/src/shims/parquet-source-worker-factory.dev.js
@@ -1,0 +1,8 @@
+// Development-only source worker factory. This file is injected only into browser dev builds.
+export const PARQUET_SOURCE_WORKER_LOAD_WORKER = () =>
+  typeof Worker !== 'undefined'
+    ? new Worker(
+        new URL('../../../modules/parquet/src/workers/parquet-source-worker.ts', import.meta.url),
+        {type: 'module'}
+      )
+    : null;

--- a/website/src/shims/parquet-source-worker-url.dev.js
+++ b/website/src/shims/parquet-source-worker-url.dev.js
@@ -1,0 +1,3 @@
+// Development-only replacement for the generated Parquet source-worker URL.
+// Returning true lets worker-utils select the adjacent source-backed loadWorker factory.
+export const PARQUET_SOURCE_WORKER_URL = true;

--- a/website/src/theme/Root.tsx
+++ b/website/src/theme/Root.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import {installWorkerHMR} from '../shims/loadersgl-worker-hmr';
+
+installWorkerHMR();
+
+/** Adds the website root while allowing development-only worker cleanup on HMR. */
+export default function Root({children}: {children: React.ReactNode}) {
+  return <>{children}</>;
+}


### PR DESCRIPTION
## Goals

- Let the loaders.gl website run the Parquet source worker directly from TypeScript during development.
- Make worker source edits participate in the website bundler hot-reload cycle.
- Keep production, staging, package, Node, and explicit worker URL behavior unchanged.

## Changes

- Adds a website-only development replacement for the private Parquet worker target and a static module-worker factory for `modules/parquet/src/workers/parquet-source-worker.ts`.
- Removes only the development Parquet worker prebuild from `website/scripts/start.sh`; production/staging builds retain the generated worker build.
- Adds a website root HMR disposal hook and worker-farm active-job abort reporting so invalidated workers cannot leave callers hanging.
- Keeps the published Parquet descriptor production-safe with an undefined factory slot and no source-worker import.
- Adds a production output guard that checks emitted JS/maps/JSON for development source-worker reachability.
- Documents the website development workflow and adds focused worker-pool coverage.

## Validation

- `yarn lint fix`
- `yarn build-workers`
- `yarn test-node` (441 passed, 6 skipped)
- `yarn test-headless modules/parquet/test/parquet-source-loader.spec.ts` (25 passed)
- `yarn test-headless modules/parquet/test/parquet-worker-transport.spec.ts` (1 passed)
- `yarn test-headless modules/worker-utils/test/lib/worker-farm/worker-pool.spec.ts` (4 passed)
- Production website build passes and confirms no development worker source in emitted code/assets.
- `yarn build` reaches the existing unrelated `@loaders.gl/tiles` pre-build resolution failure in this worktree.
- Development server smoke test is blocked in this sandbox because binding localhost returns `listen EPERM`; browser/compiler path is covered by the production build and focused tests.

This is intentionally a website-local POC. It does not add a public Loader preload API, change the worker protocol, convert other loaders, or alter Node worker activation.