### PR TITLE
fix(textures): make texture-compressor optional on 4.5

### DIFF
--- a/docs/modules/textures/README.md
+++ b/docs/modules/textures/README.md
@@ -92,4 +92,4 @@ They return schema `Texture` objects rather than raw image trees.
 ## Attributions
 
 - The `CompressedTextureLoader` was forked from [PicoGL](https://github.com/tsherif/picogl.js/blob/master/examples/utils/utils.js), Copyright (c) 2017 Tarek Sherif, The MIT License (MIT)
-- The `CompressedTextureWriter` is a wrapper around @TimvanScherpenzeel's [`texture-compressor`](https://github.com/TimvanScherpenzeel/texture-compressor) utility (MIT licensed).
+- The `CompressedTextureWriter` is a wrapper around @TimvanScherpenzeel's [`texture-compressor`](https://github.com/TimvanScherpenzeel/texture-compressor) utility (MIT licensed). That utility is an optional peer rather than a dependency of `@loaders.gl/textures`; applications that use the writer must install it separately.

--- a/docs/modules/textures/api-reference/compressed-texture-writer.md
+++ b/docs/modules/textures/api-reference/compressed-texture-writer.md
@@ -7,6 +7,16 @@
 
 > The experimental `CompressedTextureWriter` class can encode a binary encoded image into a compressed texture.
 
+:::caution
+This writer works by spawning the [`texture-compressor`](https://github.com/TimvanScherpenzeel/texture-compressor) command line utility via `npx`. That utility is an optional peer and is **not** installed by `@loaders.gl/textures`. Applications that use this writer must install it themselves:
+
+```bash
+npm install --save-dev texture-compressor
+```
+
+The utility is invoked with `npx --no`, so it is never downloaded on demand. If it cannot be resolved locally, `encodeURLtoURL()` rejects.
+:::
+
 | Loader         | Characteristic                                         |
 | -------------- | ------------------------------------------------------ |
 | File Extension |                                                        |
@@ -42,4 +52,6 @@ TBA
 
 ## Remarks
 
+- Requires the `texture-compressor` CLI to be installed by the application, see the note above.
+- Output is currently hardcoded to the S3TC/DXT1 compression format, and the CLI only writes `.ktx` containers, so `outputUrl` must end in `.ktx` despite the writer being registered under the `dds` id.
 - For more information, see [`texture-compressor`](https://github.com/TimvanScherpenzeel/texture-compressor).

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -2,7 +2,7 @@
 
 ## Upgrading to v4.5
 
-v4.5 is additive. Existing loaders and defaults continue to work unchanged.
+Aside from the experimental writer prerequisite noted below, v4.5 is additive. Existing loaders and defaults continue to work unchanged.
 
 **@loaders.gl/splats**
 
@@ -17,6 +17,10 @@ v4.5 is additive. Existing loaders and defaults continue to work unchanged.
 **@loaders.gl/gltf**
 
 - No migration is required. `GLTFLoader` now handles per-texture UV transforms and selects AVIF texture sources when the active image decoder supports them.
+
+**@loaders.gl/textures**
+
+- `@loaders.gl/textures` no longer installs the deprecated `texture-compressor` package for every consumer. Applications that use the experimental `CompressedTextureWriter` must install `texture-compressor` explicitly. The CLI is invoked with `npx --no`, so it is never downloaded on demand; all other loaders and writers are unaffected.
 
 ## Upgrading to v4.4
 

--- a/modules/textures/package.json
+++ b/modules/textures/package.json
@@ -80,11 +80,16 @@
     "@loaders.gl/schema": "4.5.0-alpha.1",
     "@loaders.gl/worker-utils": "4.5.0-alpha.1",
     "@math.gl/types": "^4.1.0",
-    "ktx-parse": "^0.7.0",
-    "texture-compressor": "^1.0.2"
+    "ktx-parse": "^0.7.0"
   },
   "peerDependencies": {
-    "@loaders.gl/core": "~4.4.0"
+    "@loaders.gl/core": "~4.4.0",
+    "texture-compressor": "^1.0.2"
+  },
+  "peerDependenciesMeta": {
+    "texture-compressor": {
+      "optional": true
+    }
   },
   "gitHead": "8a9e77743ea90a7be4ebec572416bb50ca9d73c3"
 }

--- a/modules/textures/src/lib/encoders/encode-texture.ts
+++ b/modules/textures/src/lib/encoders/encode-texture.ts
@@ -5,7 +5,19 @@
 import {ChildProcessProxy} from '@loaders.gl/worker-utils';
 import {CompressedTextureWriterOptions} from '../../compressed-texture-writer';
 
-/*
+/**
+ * Compresses an image file into an S3TC/DXT1 compressed texture file, under Node.js only.
+ *
+ * Note: despite the writer being named `CompressedTextureWriter` / "DDS Texture Container",
+ * the `texture-compressor` CLI only writes `.ktx` containers - the `outputUrl` must end
+ * in `.ktx` or the CLI rejects it.
+ *
+ * Note: This is an experimental encoder that shells out to the `texture-compressor` CLI.
+ * That CLI is an optional peer rather than a dependency of `@loaders.gl/textures`;
+ * applications that use this writer must install it themselves
+ * (`npm install --save-dev texture-compressor`). It is never downloaded on demand - if it
+ * cannot be resolved locally, this function rejects.
+ *
  * @see https://github.com/TimvanScherpenzeel/texture-compressor
  */
 export async function encodeImageURLToCompressedTextureURL(
@@ -15,7 +27,13 @@ export async function encodeImageURLToCompressedTextureURL(
 ): Promise<string> {
   // prettier-ignore
   const args = [
-    // Note: our actual executable is `npx`, so `texture-compressor` is an argument
+    // Note: our actual executable is `npx`, so `texture-compressor` is an argument.
+    // `--no` prevents npx from silently downloading the CLI at runtime: it must already
+    // be installed by the application.
+    '--no',
+    // `--` is required: without it npm parses the flags below as its own config
+    // instead of forwarding them to the CLI.
+    '--',
     'texture-compressor',
     '--type', 's3tc',
     '--compression', 'DXT1',

--- a/modules/textures/test/compressed-texture-writer.spec.ts
+++ b/modules/textures/test/compressed-texture-writer.spec.ts
@@ -14,17 +14,16 @@ test('CompressedTextureWriter#write-and-read-image', async (t) => {
     t.end();
     return;
   }
+  // The `texture-compressor` CLI is an optional, application-supplied prerequisite,
+  // so skip (rather than fail) when it is not installed in this environment.
+  let outputFilename: string | undefined;
   try {
-    const outputFilename = await encodeURLtoURL(
-      IMAGE_URL,
-      '/tmp/test.ktx',
-      CompressedTextureWriter,
-      {}
-    );
-    t.ok(outputFilename, 'a filename was returned');
+    outputFilename = await encodeURLtoURL(IMAGE_URL, '/tmp/test.ktx', CompressedTextureWriter, {});
   } catch (error) {
-    // @ts-ignore
-    // t.comment(error);
+    t.comment(`texture-compressor CLI not available, skipping: ${(error as Error).message}`);
+    t.end();
+    return;
   }
+  t.ok(outputFilename, 'a filename was returned');
   t.end();
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5316,9 +5316,12 @@ __metadata:
     "@loaders.gl/worker-utils": "npm:4.5.0-alpha.1"
     "@math.gl/types": "npm:^4.1.0"
     ktx-parse: "npm:^0.7.0"
-    texture-compressor: "npm:^1.0.2"
   peerDependencies:
     "@loaders.gl/core": ~4.4.0
+    texture-compressor: ^1.0.2
+  peerDependenciesMeta:
+    texture-compressor:
+      optional: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Summary

- move `texture-compressor` from a normal dependency to an optional peer dependency
- invoke the experimental writer with `npx --no -- texture-compressor` so it never downloads the CLI on demand
- document the explicit install requirement and keep the existing `ChildProcessProxy` / `options.spawn` behavior

## Why

`@loaders.gl/textures` currently installs the Node-only `texture-compressor` CLI for every consumer, even when they only use texture loaders. That CLI brings in the unpatched `image-size@0.7.5` advisory chain. The compressor is only used by the experimental `CompressedTextureWriter`, so making it optional removes the unused audit surface for ordinary consumers.

## Compatibility

Normal texture loaders are unchanged. Applications using `CompressedTextureWriter` must install `texture-compressor` explicitly. The existing custom spawn path is preserved.

## Validation

- `yarn install --immutable`
- `yarn lint fix` (existing warnings only)
- `yarn test node` (8,046 passing)
- `yarn workspace @loaders.gl/textures run pre-build`
- packed-package consumer smoke: no `texture-compressor` / `image-size` installed and `npm audit --omit=dev` reports 0 vulnerabilities

Companion 4.4-release backport: https://github.com/visgl/loaders.gl/pull/3960
