### PR TITLE
fix(textures): make texture-compressor optional on 4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## v4.4
 
+### v4.4.6
+
+- fix(textures): make texture-compressor an optional peer dependency; applications using the experimental `CompressedTextureWriter` must install it explicitly
+
 ### v4.4.5
 
 - feat(gltf): support KHR_meshopt_compression (#3617)

--- a/docs/modules/textures/README.md
+++ b/docs/modules/textures/README.md
@@ -92,4 +92,4 @@ They return schema `Texture` objects rather than raw image trees.
 ## Attributions
 
 - The `CompressedTextureLoader` was forked from [PicoGL](https://github.com/tsherif/picogl.js/blob/master/examples/utils/utils.js), Copyright (c) 2017 Tarek Sherif, The MIT License (MIT)
-- The `CompressedTextureWriter` is a wrapper around @TimvanScherpenzeel's [`texture-compressor`](https://github.com/TimvanScherpenzeel/texture-compressor) utility (MIT licensed).
+- The `CompressedTextureWriter` is a wrapper around @TimvanScherpenzeel's [`texture-compressor`](https://github.com/TimvanScherpenzeel/texture-compressor) utility (MIT licensed). Install `texture-compressor` separately when using this optional Node.js-only writer.

--- a/docs/modules/textures/api-reference/compressed-texture-writer.md
+++ b/docs/modules/textures/api-reference/compressed-texture-writer.md
@@ -7,6 +7,17 @@
 
 > The experimental `CompressedTextureWriter` class can encode a binary encoded image into a compressed texture.
 
+The writer delegates compression to the optional
+[`texture-compressor`](https://github.com/TimvanScherpenzeel/texture-compressor) command-line
+tool. Install it alongside `@loaders.gl/textures` before using this Node.js-only writer:
+
+```sh
+npm install --save-dev texture-compressor
+```
+
+The CLI is invoked with `npx --no`, so it is never downloaded on demand. If it cannot be
+resolved locally, `encodeURLtoURL()` rejects.
+
 | Loader         | Characteristic                                         |
 | -------------- | ------------------------------------------------------ |
 | File Extension |                                                        |

--- a/docs/modules/textures/formats/compressed-textures.md
+++ b/docs/modules/textures/formats/compressed-textures.md
@@ -166,7 +166,7 @@ At the time of writing, only S3 texture compression has been specified:
 
 Texture compression code is usually not readily available, particulary not in JavaScript. Compression is typically done by binary programs, e.g. [PVRTexTool](https://www.imaginationtech.com/developers/powervr-sdk-tools/pvrtextool/).
 
-The loaders.gl `CompressedTextureWriter` can compress textures (under Node.js only) by executing a binary with the appropriate command line, and then loading back the output.
+The loaders.gl `CompressedTextureWriter` can compress textures (under Node.js only) by executing a binary with the appropriate command line, and then loading back the output. The binary is not installed by loaders.gl; applications that use this writer must install `texture-compressor` separately.
 
 ## IP and Patent Considerations
 

--- a/modules/textures/package.json
+++ b/modules/textures/package.json
@@ -80,11 +80,16 @@
     "@loaders.gl/schema": "4.4.5",
     "@loaders.gl/worker-utils": "4.4.5",
     "@math.gl/types": "^4.1.0",
-    "ktx-parse": "^0.7.0",
-    "texture-compressor": "^1.0.2"
+    "ktx-parse": "^0.7.0"
   },
   "peerDependencies": {
-    "@loaders.gl/core": "~4.4.0"
+    "@loaders.gl/core": "~4.4.0",
+    "texture-compressor": "^1.0.2"
+  },
+  "peerDependenciesMeta": {
+    "texture-compressor": {
+      "optional": true
+    }
   },
   "gitHead": "8a9e77743ea90a7be4ebec572416bb50ca9d73c3"
 }

--- a/modules/textures/src/lib/encoders/encode-texture.ts
+++ b/modules/textures/src/lib/encoders/encode-texture.ts
@@ -5,7 +5,19 @@
 import {ChildProcessProxy} from '@loaders.gl/worker-utils';
 import {CompressedTextureWriterOptions} from '../../compressed-texture-writer';
 
-/*
+/**
+ * Compresses an image file into an S3TC/DXT1 compressed texture file, under Node.js only.
+ *
+ * Note: despite the writer being named `CompressedTextureWriter` / "DDS Texture Container",
+ * the `texture-compressor` CLI only writes `.ktx` containers - the `outputUrl` must end
+ * in `.ktx` or the CLI rejects it.
+ *
+ * Note: This is an experimental encoder that shells out to the `texture-compressor` CLI.
+ * That CLI is an optional peer rather than a dependency of `@loaders.gl/textures`;
+ * applications that use this writer must install it themselves
+ * (`npm install --save-dev texture-compressor`). It is never downloaded on demand - if it
+ * cannot be resolved locally, this function rejects.
+ *
  * @see https://github.com/TimvanScherpenzeel/texture-compressor
  */
 export async function encodeImageURLToCompressedTextureURL(
@@ -15,7 +27,11 @@ export async function encodeImageURLToCompressedTextureURL(
 ): Promise<string> {
   // prettier-ignore
   const args = [
-    // Note: our actual executable is `npx`, so `texture-compressor` is an argument
+    // Note: our actual executable is `npx`, so `texture-compressor` is an argument.
+    // `--no` prevents npx from silently downloading the optional CLI at runtime.
+    '--no',
+    // `--` keeps npm from parsing the compressor flags as its own config.
+    '--',
     'texture-compressor',
     '--type', 's3tc',
     '--compression', 'DXT1',

--- a/modules/textures/test/compressed-texture-writer.spec.ts
+++ b/modules/textures/test/compressed-texture-writer.spec.ts
@@ -14,17 +14,16 @@ test('CompressedTextureWriter#write-and-read-image', async (t) => {
     t.end();
     return;
   }
+  // The `texture-compressor` CLI is an optional, application-supplied prerequisite,
+  // so skip (rather than fail) when it is not installed in this environment.
+  let outputFilename: string | undefined;
   try {
-    const outputFilename = await encodeURLtoURL(
-      IMAGE_URL,
-      '/tmp/test.ktx',
-      CompressedTextureWriter,
-      {}
-    );
-    t.ok(outputFilename, 'a filename was returned');
+    outputFilename = await encodeURLtoURL(IMAGE_URL, '/tmp/test.ktx', CompressedTextureWriter, {});
   } catch (error) {
-    // @ts-ignore
-    // t.comment(error);
+    t.comment(`texture-compressor CLI not available, skipping: ${(error as Error).message}`);
+    t.end();
+    return;
   }
+  t.ok(outputFilename, 'a filename was returned');
   t.end();
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4972,9 +4972,12 @@ __metadata:
     "@loaders.gl/worker-utils": "npm:4.4.5"
     "@math.gl/types": "npm:^4.1.0"
     ktx-parse: "npm:^0.7.0"
-    texture-compressor: "npm:^1.0.2"
   peerDependencies:
     "@loaders.gl/core": ~4.4.0
+    texture-compressor: ^1.0.2
+  peerDependenciesMeta:
+    texture-compressor:
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -10304,7 +10307,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"argparse@npm:^1.0.10, argparse@npm:^1.0.7":
+"argparse@npm:^1.0.7":
   version: 1.0.10
   resolution: "argparse@npm:1.0.10"
   dependencies:
@@ -17422,15 +17425,6 @@ __metadata:
   version: 5.3.2
   resolution: "ignore@npm:5.3.2"
   checksum: 10c0/f9f652c957983634ded1e7f02da3b559a0d4cc210fca3792cb67f1b153623c9c42efdc1c4121af171e295444459fc4a9201101fb041b1104a3c000bccb188337
-  languageName: node
-  linkType: hard
-
-"image-size@npm:^0.7.4":
-  version: 0.7.5
-  resolution: "image-size@npm:0.7.5"
-  bin:
-    image-size: bin/image-size.js
-  checksum: 10c0/74e978c525e7d777df145bc66cfc4a4a7aa56de8e5daead3a69b0872082dbe385deb4a3b80799810df9e34b2031467412ae28810f2f65ec2e5fe08b895aa3491
   languageName: node
   linkType: hard
 
@@ -27057,18 +27051,6 @@ __metadata:
   version: 0.2.0
   resolution: "text-table@npm:0.2.0"
   checksum: 10c0/02805740c12851ea5982686810702e2f14369a5f4c5c40a836821e3eefc65ffeec3131ba324692a37608294b0fd8c1e55a2dd571ffed4909822787668ddbee5c
-  languageName: node
-  linkType: hard
-
-"texture-compressor@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "texture-compressor@npm:1.0.2"
-  dependencies:
-    argparse: "npm:^1.0.10"
-    image-size: "npm:^0.7.4"
-  bin:
-    texture-compressor: ./bin/texture-compressor.js
-  checksum: 10c0/ea0bce1cbda3a64f826867e97ee2a1f17a7219d21d97d7625a6370792afddc697e6832a9b3b39bf2eef0978af7bc0d1dcefaf7fd91d719213658b0a010a83c44
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- move `texture-compressor` from a normal dependency to an optional peer dependency
- invoke the experimental writer with `npx --no -- texture-compressor` so it never downloads the CLI on demand
- document the explicit install requirement and keep the existing `ChildProcessProxy` / `options.spawn` behavior

## Why

`@loaders.gl/textures` currently installs the Node-only `texture-compressor` CLI for every consumer, even when they only use texture loaders. That CLI brings in the unpatched `image-size@0.7.5` advisory chain. The compressor is only used by the experimental `CompressedTextureWriter`, so making it optional removes the unused audit surface for ordinary consumers.

## Compatibility

Normal texture loaders are unchanged. Applications using `CompressedTextureWriter` must install `texture-compressor` explicitly. The existing custom spawn path is preserved.

## Validation

- `yarn install --immutable`
- `yarn workspace @loaders.gl/textures run pre-build`
- `./node_modules/.bin/tsc -b modules/textures`
- focused compressed-writer spec
- `yarn lint fix` (existing warnings only)
- `yarn test node` (6,594 passing)
- packed-package consumer smoke: no `texture-compressor` / `image-size` installed and `npm audit --omit=dev` reports 0 vulnerabilities

Companion 4.5-release backport: https://github.com/visgl/loaders.gl/pull/3959
