### PR TITLE
chore: update release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,18 +30,13 @@ jobs:
           fi
           echo "result=${result}" >> "$GITHUB_OUTPUT"
 
-  publish:
+  node_tests:
+    name: Node tests
     runs-on: ubuntu-22.04
-    timeout-minutes: 30
     needs: check_branch
-    permissions:
-      contents: write
+    timeout-minutes: 15
 
-    if: ${{ github.repository_owner == 'visgl' && needs.check_branch.outputs.should_build }}
-
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      NPM_ACCESS_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}
+    if: ${{ github.repository_owner == 'visgl' && needs.check_branch.outputs.should_build == 'true' }}
 
     steps:
       - name: Checkout code
@@ -58,9 +53,59 @@ jobs:
           corepack prepare "$(node -p "require('./package.json').packageManager")" --activate
           yarn -v
 
-      - name: Cache Yarn 4 artifacts
-        id: yarn-cache
-        uses: actions/cache@v4
+      - name: Restore Yarn 4 artifacts
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            .yarn/cache
+            .pnp.*
+            .yarn/install-state.gz
+          key: yarn-cache-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            yarn-cache-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Build
+        run: yarn build
+
+      - name: Build workers
+        run: yarn build-workers
+
+      - name: Run Node tests
+        run: yarn test-node
+
+  browser_tests:
+    name: Headless tests (${{ matrix.shard }}/3)
+    runs-on: ubuntu-22.04
+    needs: check_branch
+    timeout-minutes: 20
+
+    if: ${{ github.repository_owner == 'visgl' && needs.check_branch.outputs.should_build == 'true' }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node (with Corepack)
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Enable Corepack / Yarn
+        run: |
+          corepack enable
+          corepack prepare "$(node -p "require('./package.json').packageManager")" --activate
+          yarn -v
+
+      - name: Restore Yarn 4 artifacts
+        uses: actions/cache/restore@v4
         with:
           path: |
             .yarn/cache
@@ -82,21 +127,115 @@ jobs:
       - name: Build workers
         run: yarn build-workers
 
-      - name: Run Node tests
-        run: yarn test-node
-
       - name: Run headless browser tests
-        run: yarn test-headless
+        run: yarn test-headless --shard=${{ matrix.shard }}/3
+
+  slow_tests:
+    name: Hermetic slow tests
+    runs-on: ubuntu-22.04
+    needs: check_branch
+    timeout-minutes: 30
+
+    if: ${{ github.repository_owner == 'visgl' && needs.check_branch.outputs.should_build == 'true' }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node (with Corepack)
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Enable Corepack / Yarn
+        run: |
+          corepack enable
+          corepack prepare "$(node -p "require('./package.json').packageManager")" --activate
+          yarn -v
+
+      - name: Restore Yarn 4 artifacts
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            .yarn/cache
+            .pnp.*
+            .yarn/install-state.gz
+          key: yarn-cache-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            yarn-cache-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Install Playwright browsers
+        run: yarn playwright install --with-deps chromium
+
+      - name: Build
+        run: yarn build
+
+      - name: Build workers
+        run: yarn build-workers
 
       - name: Run hermetic slow tests
         env:
           VITEST_MAX_WORKERS: 1
         run: yarn test-slow
 
-      - name: Login to NPM
-        run: npm config set "//registry.npmjs.org/:_authToken=${NPM_ACCESS_TOKEN}"
+  release:
+    name: Post GitHub release and publish to NPM
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+    needs: [check_branch, node_tests, browser_tests, slow_tests]
+    permissions:
+      contents: write
+      id-token: write
 
-      - name: Publish to NPM
+    if: ${{ success() && github.repository_owner == 'visgl' && needs.check_branch.outputs.should_build == 'true' }}
+
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node (with Corepack)
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Update npm
+        run: npm install --global npm@^11.15.0
+
+      - name: Enable Corepack / Yarn
+        run: |
+          corepack enable
+          corepack prepare "$(node -p "require('./package.json').packageManager")" --activate
+          yarn -v
+
+      - name: Restore Yarn 4 artifacts
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            .yarn/cache
+            .pnp.*
+            .yarn/install-state.gz
+          key: yarn-cache-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            yarn-cache-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Build
+        run: yarn build
+
+      - name: Build workers
+        run: yarn build-workers
+
+      # ocular-publish creates the GitHub Release before publishing the tagged packages to npm.
+      - name: Post GitHub release and publish to NPM
         env:
           NPM_CONFIG_LOGLEVEL: verbose
         run: npx ocular-publish from-git


### PR DESCRIPTION
- Use trusted publishing and remove npm token
- Run pre-release testing in parallel jobs