### PR TITLE
feat(4.5): backport Chrome Trace loaders

### DIFF
--- a/docs/modules/traces/README.md
+++ b/docs/modules/traces/README.md
@@ -1,8 +1,24 @@
-# @loaders.gl/traces
+import {TracesDocsTabs} from '@site/src/components/docs/traces-docs-tabs';
 
-The `@loaders.gl/traces` module will provide parsers for performance trace formats.
+# Traces
 
-## Scope
+<TracesDocsTabs active="overview" />
 
-- Chrome Trace Event format
-- Perfetto Trace format
+The `@loaders.gl/traces` module provides parsers for browser and system performance trace formats.
+
+## Installation
+
+```bash
+npm install @loaders.gl/core @loaders.gl/traces
+```
+
+## Loaders
+
+| Loader                                                                      | Description                                      |
+| --------------------------------------------------------------------------- | ------------------------------------------------ |
+| [`ChromeTraceLoader`](/docs/modules/traces/api-reference/chrome-trace-loader) | Loads Chrome Trace Event JSON as JSON or Arrow. |
+
+## Additional APIs
+
+`@loaders.gl/traces` also exports `parseChromeTrace(...)` and streaming helpers for logical events,
+Arrow batches, and chunked Chrome trace files.

--- a/docs/modules/traces/README.md
+++ b/docs/modules/traces/README.md
@@ -14,8 +14,8 @@ npm install @loaders.gl/core @loaders.gl/traces
 
 ## Loaders
 
-| Loader                                                                      | Description                                      |
-| --------------------------------------------------------------------------- | ------------------------------------------------ |
+| Loader                                                                        | Description                                     |
+| ----------------------------------------------------------------------------- | ----------------------------------------------- |
 | [`ChromeTraceLoader`](/docs/modules/traces/api-reference/chrome-trace-loader) | Loads Chrome Trace Event JSON as JSON or Arrow. |
 
 ## Additional APIs

--- a/docs/modules/traces/api-reference/chrome-trace-loader.md
+++ b/docs/modules/traces/api-reference/chrome-trace-loader.md
@@ -1,0 +1,36 @@
+import {TracesDocsTabs} from '@site/src/components/docs/traces-docs-tabs';
+
+# ChromeTraceLoader
+
+<TracesDocsTabs active="chrometraceloader" />
+
+`ChromeTraceLoader` loads Chrome Trace Event JSON payloads. By default it returns a validated JSON
+trace object. Set `chromeTrace.shape: 'arrow-table'` to convert trace events into an Apache Arrow
+table.
+
+## Usage
+
+```typescript
+import {load} from '@loaders.gl/core';
+import {ChromeTraceLoader} from '@loaders.gl/traces';
+
+const trace = await load(url, ChromeTraceLoader);
+
+const table = await load(url, ChromeTraceLoader, {
+  chromeTrace: {shape: 'arrow-table'}
+});
+```
+
+## Options
+
+| Option                    | Type                         | Default | Description                                      |
+| ------------------------- | ---------------------------- | ------- | ------------------------------------------------ |
+| `chromeTrace.shape`       | `'json' \| 'arrow-table'`    | `json`  | Selects the whole-file parser output shape.      |
+| `chromeTrace.batchSize`   | `number`                     | `256`   | Maximum events per Arrow record batch.           |
+| `maxLength`               | `number`                     |         | Maximum input byte length accepted by the loader. |
+
+## Streaming
+
+`parseInBatches` currently requires `chromeTrace.shape: 'arrow-table'` and yields Arrow record
+batches. The module also exports helpers that consume Chrome trace file chunks or Arrow batches and
+publish trace snapshots.

--- a/docs/modules/traces/api-reference/chrome-trace-loader.md
+++ b/docs/modules/traces/api-reference/chrome-trace-loader.md
@@ -23,11 +23,11 @@ const table = await load(url, ChromeTraceLoader, {
 
 ## Options
 
-| Option                    | Type                         | Default | Description                                      |
-| ------------------------- | ---------------------------- | ------- | ------------------------------------------------ |
-| `chromeTrace.shape`       | `'json' \| 'arrow-table'`    | `json`  | Selects the whole-file parser output shape.      |
-| `chromeTrace.batchSize`   | `number`                     | `256`   | Maximum events per Arrow record batch.           |
-| `maxLength`               | `number`                     |         | Maximum input byte length accepted by the loader. |
+| Option                  | Type                      | Default | Description                                       |
+| ----------------------- | ------------------------- | ------- | ------------------------------------------------- |
+| `chromeTrace.shape`     | `'json' \| 'arrow-table'` | `json`  | Selects the whole-file parser output shape.       |
+| `chromeTrace.batchSize` | `number`                  | `256`   | Maximum events per Arrow record batch.            |
+| `maxLength`             | `number`                  |         | Maximum input byte length accepted by the loader. |
 
 ## Streaming
 

--- a/docs/modules/traces/formats/chrome-trace.md
+++ b/docs/modules/traces/formats/chrome-trace.md
@@ -1,0 +1,40 @@
+import {TracesDocsTabs} from '@site/src/components/docs/traces-docs-tabs';
+
+# Chrome Trace
+
+<TracesDocsTabs active="chrome-trace" />
+
+Chrome Trace Event files are JSON payloads with a top-level `traceEvents` array. Each event records
+fields such as `name`, `ph`, `ts`, `pid`, `tid`, `cat`, `dur`, `args`, and flow or async identifiers.
+
+`ChromeTraceLoader` can keep the validated JSON shape or convert trace events into an Apache Arrow
+table for columnar inspection and downstream processing.
+
+## Example
+
+```json
+{
+  "displayTimeUnit": "us",
+  "traceEvents": [
+    {"name": "process_name", "ph": "M", "pid": 100, "tid": 0, "args": {"name": "Renderer"}},
+    {"name": "ParseHTML", "ph": "X", "ts": 1000, "dur": 3200, "pid": 100, "tid": 1}
+  ]
+}
+```
+
+## Arrow Columns
+
+When `chromeTrace.shape: 'arrow-table'` is selected, the loader emits an Arrow table with stable
+columns for common trace fields:
+
+| Column      | Description                                       |
+| ----------- | ------------------------------------------------- |
+| `name`      | Trace event name.                                 |
+| `ph`        | Trace event phase code.                           |
+| `ts`        | Timestamp in the file's display time unit.        |
+| `pid`       | Process identifier, normalized to string values.  |
+| `tid`       | Thread identifier, normalized to string values.   |
+| `cat`       | Event category.                                   |
+| `dur`       | Complete-event duration.                          |
+| `args`      | JSON-encoded event arguments.                     |
+| `extraJson` | JSON-encoded fields that do not have fixed columns. |

--- a/docs/modules/traces/formats/chrome-trace.md
+++ b/docs/modules/traces/formats/chrome-trace.md
@@ -27,14 +27,14 @@ table for columnar inspection and downstream processing.
 When `chromeTrace.shape: 'arrow-table'` is selected, the loader emits an Arrow table with stable
 columns for common trace fields:
 
-| Column      | Description                                       |
-| ----------- | ------------------------------------------------- |
-| `name`      | Trace event name.                                 |
-| `ph`        | Trace event phase code.                           |
-| `ts`        | Timestamp in the file's display time unit.        |
-| `pid`       | Process identifier, normalized to string values.  |
-| `tid`       | Thread identifier, normalized to string values.   |
-| `cat`       | Event category.                                   |
-| `dur`       | Complete-event duration.                          |
-| `args`      | JSON-encoded event arguments.                     |
+| Column      | Description                                         |
+| ----------- | --------------------------------------------------- |
+| `name`      | Trace event name.                                   |
+| `ph`        | Trace event phase code.                             |
+| `ts`        | Timestamp in the file's display time unit.          |
+| `pid`       | Process identifier, normalized to string values.    |
+| `tid`       | Thread identifier, normalized to string values.     |
+| `cat`       | Event category.                                     |
+| `dur`       | Complete-event duration.                            |
+| `args`      | JSON-encoded event arguments.                       |
 | `extraJson` | JSON-encoded fields that do not have fixed columns. |

--- a/modules/traces/README.md
+++ b/modules/traces/README.md
@@ -2,6 +2,13 @@
 
 [loaders.gl](https://loaders.gl/docs) is a collection of framework-independent 3D and geospatial parsers and encoders.
 
-The `@loaders.gl/traces` module will host trace format parsers for Chrome Trace and Perfetto Trace data.
+The `@loaders.gl/traces` module hosts trace format parsers for Chrome Trace and Perfetto Trace data.
+
+## Included APIs
+
+- `ChromeTraceLoader` for full-file and batched Chrome trace parsing
+- `parseChromeTrace(...)` for semantic Chrome trace assembly
+- `streamChromeTraceEventChunks(...)`, `streamChromeTraceArrowChunks(...)`, and `streamChromeTraceFileChunks(...)`
+- `createTraceStreamSession(...)` and the Chrome trace stream consumers
 
 For documentation please visit the [website](https://loaders.gl).

--- a/modules/traces/package.json
+++ b/modules/traces/package.json
@@ -35,6 +35,11 @@
   "scripts": {
     "pre-build": "echo \"Nothing to build in @loaders.gl/traces\""
   },
+  "dependencies": {
+    "@loaders.gl/loader-utils": "4.5.0-alpha.2",
+    "apache-arrow": ">= 17.0.0",
+    "zod": "^4.1.12"
+  },
   "peerDependencies": {
     "@loaders.gl/core": "~4.4.0"
   },

--- a/modules/traces/src/chrome-trace-arrow-adapter.ts
+++ b/modules/traces/src/chrome-trace-arrow-adapter.ts
@@ -1,0 +1,182 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {parseChromeTraceArrowSchemaMetadata} from './chrome-trace-arrow-parser';
+
+import type {
+  ChromeTraceEventArrowRecordBatch,
+  ChromeTraceEventArrowTable
+} from './chrome-trace-arrow-schema';
+import type {ChromeTraceEventPhase, ChromeTraceEventSchema} from './chrome-trace-schema';
+
+/**
+ * One Arrow source item accepted by the Chrome trace streaming adapter.
+ */
+export type ChromeTraceArrowSourceItem =
+  | ChromeTraceEventArrowRecordBatch
+  | ChromeTraceEventArrowTable;
+
+/**
+ * Decodes Arrow-backed Chrome trace rows back into logical event objects.
+ */
+export function decodeChromeTraceArrowSource(
+  source: ChromeTraceArrowSourceItem
+): ChromeTraceEventSchema[] {
+  const events: ChromeTraceEventSchema[] = [];
+
+  for (const row of Array.from(source as Iterable<Record<string, unknown>>)) {
+    const phase = getRequiredChromeTraceString(row.ph) as ChromeTraceEventPhase;
+    const extra = parseChromeTraceArrowJson(row.extraJson) as Record<string, unknown> | undefined;
+
+    const event: ChromeTraceEventSchema = {
+      name: getRequiredChromeTraceString(row.name),
+      ph: phase,
+      pid: restoreChromeTraceIdLike(getOptionalChromeTraceString(row.pid), extra?.pid),
+      tid: restoreChromeTraceIdLike(getOptionalChromeTraceString(row.tid), extra?.tid)
+    };
+
+    assignOptionalChromeTraceNumber(event, 'ts', getOptionalChromeTraceNumber(row.ts));
+    assignOptionalChromeTraceString(event, 'cat', getOptionalChromeTraceString(row.cat));
+    assignOptionalChromeTraceNumber(event, 'dur', getOptionalChromeTraceNumber(row.dur));
+    assignOptionalChromeTraceNumber(event, 'tdur', getOptionalChromeTraceNumber(row.tdur));
+    assignOptionalChromeTraceNumber(event, 'tts', getOptionalChromeTraceNumber(row.tts));
+
+    const idValue = restoreOptionalChromeTraceIdLike(
+      getOptionalChromeTraceString(row.id),
+      extra?.id
+    );
+    if (idValue !== undefined) {
+      event.id = idValue;
+    }
+
+    const bindIdValue = restoreOptionalChromeTraceIdLike(
+      getOptionalChromeTraceString(row.bind_id),
+      extra?.bind_id
+    );
+    if (bindIdValue !== undefined) {
+      event.bind_id = bindIdValue;
+    }
+
+    const scopeValue = getOptionalChromeTraceString(row.scope);
+    if (scopeValue) {
+      if (phase === 'b' || phase === 'e' || phase === 'n') {
+        event.s = scopeValue as 'g' | 'p' | 't';
+      } else {
+        event.scope = scopeValue as 'g' | 'p' | 't';
+      }
+    }
+
+    const argsValue = parseChromeTraceArrowJson(row.args);
+    if (argsValue != null) {
+      event.args = argsValue as Record<string, unknown>;
+    }
+
+    if (extra) {
+      Object.assign(event, extra);
+    }
+
+    events.push(event);
+  }
+
+  return events;
+}
+
+/**
+ * Reads Chrome trace top-level metadata from one Arrow source item.
+ */
+export function readChromeTraceArrowSourceMetadata(source: ChromeTraceArrowSourceItem): {
+  displayTimeUnit?: string;
+  metadata?: Record<string, unknown>;
+} {
+  return parseChromeTraceArrowSchemaMetadata(source.schema.metadata);
+}
+
+/**
+ * Reads one required string value from a decoded Arrow row.
+ */
+function getRequiredChromeTraceString(value: unknown): string {
+  if (typeof value !== 'string') {
+    throw new Error('Chrome trace Arrow rows are missing required string data.');
+  }
+  return value;
+}
+
+/**
+ * Reads one optional string from a decoded Arrow row.
+ */
+function getOptionalChromeTraceString(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}
+
+/**
+ * Reads one optional number from a decoded Arrow row.
+ */
+function getOptionalChromeTraceNumber(value: unknown): number | undefined {
+  return typeof value === 'number' ? value : undefined;
+}
+
+/**
+ * Restores a string-or-number id-like value from the Arrow columns and passthrough JSON.
+ */
+function restoreChromeTraceIdLike(
+  normalizedValue: string | undefined,
+  extraValue: unknown
+): string | number {
+  if (typeof extraValue === 'number' || typeof extraValue === 'string') {
+    return extraValue;
+  }
+
+  if (normalizedValue == null) {
+    throw new Error('Chrome trace Arrow rows must include pid/tid values.');
+  }
+
+  return normalizedValue;
+}
+
+/**
+ * Restores one optional id-like value from the Arrow columns and passthrough JSON.
+ */
+function restoreOptionalChromeTraceIdLike(
+  normalizedValue: string | undefined,
+  extraValue: unknown
+): string | number | undefined {
+  if (typeof extraValue === 'number' || typeof extraValue === 'string') {
+    return extraValue;
+  }
+
+  return normalizedValue;
+}
+
+/**
+ * Assigns one optional numeric field on the target event.
+ */
+function assignOptionalChromeTraceNumber(
+  target: Record<string, unknown>,
+  key: 'ts' | 'dur' | 'tdur' | 'tts',
+  value: unknown
+): void {
+  if (typeof value === 'number') {
+    target[key] = value;
+  }
+}
+
+/**
+ * Assigns one optional string field on the target event.
+ */
+function assignOptionalChromeTraceString(
+  target: Record<string, unknown>,
+  key: 'cat',
+  value: string | undefined
+): void {
+  if (value != null) {
+    target[key] = value;
+  }
+}
+
+/**
+ * Parses one optional JSON string stored in Arrow columns or metadata.
+ */
+function parseChromeTraceArrowJson(value: unknown): unknown {
+  return typeof value === 'string' ? JSON.parse(value) : undefined;
+}

--- a/modules/traces/src/chrome-trace-arrow-parser.ts
+++ b/modules/traces/src/chrome-trace-arrow-parser.ts
@@ -1,0 +1,395 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import * as arrow from 'apache-arrow';
+
+import {chromeTraceEventArrowSchema} from './chrome-trace-arrow-schema';
+import {
+  appendChromeTraceFileChunk,
+  createChromeTraceFileTokenizer,
+  tryParseChromeTraceFileText
+} from './chrome-trace-json-stream';
+import {validateChromeTraceFile} from './chrome-trace-schema';
+
+import type {
+  ChromeTraceEventArrowColumns,
+  ChromeTraceEventArrowRecordBatch,
+  ChromeTraceEventArrowTable
+} from './chrome-trace-arrow-schema';
+import type {
+  ChromeTraceEventSchema,
+  ChromeTraceFileSchema,
+  ChromeTraceValidationOptions
+} from './chrome-trace-schema';
+
+/**
+ * Shared options for converting Chrome trace JSON payloads into Arrow events.
+ */
+export type ChromeTraceArrowParseOptions = ChromeTraceValidationOptions & {
+  /** Maximum number of events emitted in one Arrow record batch. */
+  batchSize?: number;
+};
+
+const CHROME_TRACE_ARROW_METADATA_DISPLAY_TIME_UNIT_KEY = 'chromeTrace.displayTimeUnit';
+const CHROME_TRACE_ARROW_METADATA_JSON_KEY = 'chromeTrace.metadataJson';
+const CHROME_TRACE_NUMERIC_ID_LIKE_KEYS = new Set(['pid', 'tid', 'id', 'bind_id']);
+const CHROME_TRACE_MODELED_EXTRA_KEYS = new Set([
+  'name',
+  'ph',
+  'ts',
+  'pid',
+  'tid',
+  'cat',
+  'dur',
+  'tdur',
+  'tts',
+  'id',
+  'bind_id',
+  'args',
+  'scope'
+]);
+
+/**
+ * Parses one Chrome trace payload into a typed Arrow table of raw events.
+ */
+export function parseChromeTraceToArrowTable(
+  source: string | ArrayBufferLike | ArrayBufferView | ChromeTraceFileSchema,
+  options: ChromeTraceArrowParseOptions = {}
+): ChromeTraceEventArrowTable {
+  const traceFile = parseChromeTraceFile(source, options);
+  return buildChromeTraceEventArrowTable(traceFile.traceEvents, traceFile);
+}
+
+/**
+ * Parses a streamed Chrome trace payload into Arrow record batches of raw events.
+ */
+export async function* parseChromeTraceToArrowRecordBatches(
+  source:
+    | AsyncIterable<string | ArrayBufferLike | ArrayBufferView>
+    | Iterable<string | ArrayBufferLike | ArrayBufferView>,
+  options: ChromeTraceArrowParseOptions = {}
+): AsyncIterable<ChromeTraceEventArrowRecordBatch> {
+  const tokenizer = createChromeTraceFileTokenizer(undefined);
+  const normalizedBatchSize = normalizeChromeTraceBatchSize(options.batchSize);
+  const pendingEvents: ChromeTraceEventSchema[] = [];
+  let deferredBatchEvents: ChromeTraceEventSchema[] | null = null;
+  let rawText = '';
+  let tokenizedEventCount = 0;
+
+  for await (const chunk of source) {
+    const chunkText = decodeChromeTraceSourceChunk(chunk);
+    rawText += chunkText;
+
+    const events = appendChromeTraceFileChunk(tokenizer, chunkText);
+    if (events.length === 0) {
+      continue;
+    }
+
+    tokenizedEventCount += events.length;
+    pendingEvents.push(...events);
+
+    while (pendingEvents.length >= normalizedBatchSize) {
+      const batchEvents = pendingEvents.splice(0, normalizedBatchSize);
+      if (deferredBatchEvents) {
+        yield buildChromeTraceEventArrowRecordBatch(deferredBatchEvents, {
+          displayTimeUnit: tokenizer.displayTimeUnit
+        });
+      }
+      deferredBatchEvents = batchEvents;
+    }
+  }
+
+  const parsedTraceFile = tryParseChromeTraceFileText(rawText);
+  if (tokenizedEventCount === 0 && parsedTraceFile) {
+    yield* emitChromeTraceArrowBatches(
+      parsedTraceFile.traceEvents,
+      {
+        displayTimeUnit: parsedTraceFile.displayTimeUnit,
+        metadata: parsedTraceFile.metadata
+      },
+      normalizedBatchSize
+    );
+    return;
+  }
+
+  const finalTraceFile = {
+    displayTimeUnit: parsedTraceFile?.displayTimeUnit ?? tokenizer.displayTimeUnit,
+    metadata: parsedTraceFile?.metadata
+  };
+
+  if (deferredBatchEvents) {
+    if (pendingEvents.length === 0) {
+      yield buildChromeTraceEventArrowRecordBatch(deferredBatchEvents, finalTraceFile);
+    } else {
+      yield buildChromeTraceEventArrowRecordBatch(deferredBatchEvents, {
+        displayTimeUnit: tokenizer.displayTimeUnit
+      });
+    }
+  }
+
+  if (pendingEvents.length > 0) {
+    yield buildChromeTraceEventArrowRecordBatch(pendingEvents, finalTraceFile);
+  }
+}
+
+/**
+ * Reads Chrome trace file metadata from one Arrow schema.
+ */
+export function parseChromeTraceArrowSchemaMetadata(metadata: Map<string, string>): {
+  displayTimeUnit?: string;
+  metadata?: Record<string, unknown>;
+} {
+  return {
+    displayTimeUnit: metadata.get(CHROME_TRACE_ARROW_METADATA_DISPLAY_TIME_UNIT_KEY) ?? undefined,
+    metadata: parseChromeTraceJsonValue(metadata.get(CHROME_TRACE_ARROW_METADATA_JSON_KEY)) as
+      | Record<string, unknown>
+      | undefined
+  };
+}
+
+/**
+ * Builds one typed Arrow table for a validated Chrome trace file.
+ */
+function buildChromeTraceEventArrowTable(
+  events: readonly ChromeTraceEventSchema[],
+  traceFile: Pick<ChromeTraceFileSchema, 'displayTimeUnit' | 'metadata'>
+): ChromeTraceEventArrowTable {
+  return new arrow.Table(
+    buildChromeTraceEventArrowSchema(buildChromeTraceArrowSchemaMetadata(traceFile)),
+    buildChromeTraceEventArrowColumns(events)
+  );
+}
+
+/**
+ * Builds one typed Arrow record batch for a validated Chrome trace event slice.
+ */
+function buildChromeTraceEventArrowRecordBatch(
+  events: readonly ChromeTraceEventSchema[],
+  traceFile: Pick<ChromeTraceFileSchema, 'displayTimeUnit' | 'metadata'>
+): ChromeTraceEventArrowRecordBatch {
+  const table = buildChromeTraceEventArrowTable(events, traceFile);
+  const [batch] = table.batches;
+
+  if (!batch) {
+    throw new Error('Chrome trace Arrow record batches require at least one event.');
+  }
+
+  return batch as ChromeTraceEventArrowRecordBatch;
+}
+
+/**
+ * Builds Arrow column vectors for one Chrome trace event slice.
+ */
+function buildChromeTraceEventArrowColumns(events: readonly ChromeTraceEventSchema[]): {
+  [P in keyof ChromeTraceEventArrowColumns]: arrow.Vector<ChromeTraceEventArrowColumns[P]>;
+} {
+  return {
+    name: arrow.vectorFromArray(
+      events.map(event => event.name),
+      new arrow.Utf8()
+    ),
+    ph: arrow.vectorFromArray(
+      events.map(event => event.ph),
+      new arrow.Utf8()
+    ),
+    ts: arrow.vectorFromArray(
+      events.map(event => event.ts ?? null),
+      new arrow.Float64()
+    ),
+    pid: arrow.vectorFromArray(
+      events.map(event => normalizeChromeTraceIdLike(event.pid)),
+      new arrow.Utf8()
+    ),
+    tid: arrow.vectorFromArray(
+      events.map(event => normalizeChromeTraceIdLike(event.tid)),
+      new arrow.Utf8()
+    ),
+    cat: arrow.vectorFromArray(
+      events.map(event => event.cat ?? null),
+      new arrow.Utf8()
+    ),
+    dur: arrow.vectorFromArray(
+      events.map(event => event.dur ?? null),
+      new arrow.Float64()
+    ),
+    tdur: arrow.vectorFromArray(
+      events.map(event => event.tdur ?? null),
+      new arrow.Float64()
+    ),
+    tts: arrow.vectorFromArray(
+      events.map(event => event.tts ?? null),
+      new arrow.Float64()
+    ),
+    id: arrow.vectorFromArray(
+      events.map(event => normalizeChromeTraceIdLike(event.id)),
+      new arrow.Utf8()
+    ),
+    bind_id: arrow.vectorFromArray(
+      events.map(event => normalizeChromeTraceIdLike(event.bind_id)),
+      new arrow.Utf8()
+    ),
+    scope: arrow.vectorFromArray(
+      events.map(event => normalizeChromeTraceScope(event)),
+      new arrow.Utf8()
+    ),
+    args: arrow.vectorFromArray(
+      events.map(event => serializeChromeTraceJson(event.args)),
+      new arrow.Utf8()
+    ),
+    extraJson: arrow.vectorFromArray(
+      events.map(event => buildChromeTraceExtraJson(event)),
+      new arrow.Utf8()
+    )
+  };
+}
+
+/**
+ * Builds one Arrow schema instance with per-file metadata attached.
+ */
+function buildChromeTraceEventArrowSchema(
+  metadata: Map<string, string>
+): arrow.Schema<ChromeTraceEventArrowColumns> {
+  return metadata.size > 0
+    ? new arrow.Schema<ChromeTraceEventArrowColumns>(chromeTraceEventArrowSchema.fields, metadata)
+    : chromeTraceEventArrowSchema;
+}
+
+/**
+ * Builds Arrow schema metadata for one Chrome trace file.
+ */
+function buildChromeTraceArrowSchemaMetadata(
+  traceFile: Pick<ChromeTraceFileSchema, 'displayTimeUnit' | 'metadata'>
+): Map<string, string> {
+  const metadata = new Map<string, string>();
+
+  if (traceFile.displayTimeUnit) {
+    metadata.set(CHROME_TRACE_ARROW_METADATA_DISPLAY_TIME_UNIT_KEY, traceFile.displayTimeUnit);
+  }
+
+  if (traceFile.metadata != null) {
+    metadata.set(CHROME_TRACE_ARROW_METADATA_JSON_KEY, JSON.stringify(traceFile.metadata));
+  }
+
+  return metadata;
+}
+
+/**
+ * Parses one source payload into a validated Chrome trace file.
+ */
+function parseChromeTraceFile(
+  source: string | ArrayBufferLike | ArrayBufferView | ChromeTraceFileSchema,
+  options: ChromeTraceValidationOptions
+): ChromeTraceFileSchema {
+  if (
+    typeof source === 'object' &&
+    !ArrayBuffer.isView(source) &&
+    !(source instanceof ArrayBuffer)
+  ) {
+    return validateChromeTraceFile(source, options);
+  }
+
+  const text = decodeChromeTraceSourceChunk(source);
+  return validateChromeTraceFile(JSON.parse(text), options);
+}
+
+/**
+ * Decodes one Chrome trace source chunk into UTF-8 text.
+ */
+function decodeChromeTraceSourceChunk(chunk: string | ArrayBufferLike | ArrayBufferView): string {
+  if (typeof chunk === 'string') {
+    return chunk;
+  }
+
+  if (ArrayBuffer.isView(chunk)) {
+    return new TextDecoder().decode(
+      new Uint8Array(chunk.buffer, chunk.byteOffset, chunk.byteLength)
+    );
+  }
+
+  return new TextDecoder().decode(new Uint8Array(chunk));
+}
+
+/**
+ * Normalizes one Chrome trace id-like field to a nullable string.
+ */
+function normalizeChromeTraceIdLike(value: string | number | null | undefined): string | null {
+  if (value == null) {
+    return null;
+  }
+
+  return String(value);
+}
+
+/**
+ * Normalizes the Chrome trace scope field while preserving async `s` values.
+ */
+function normalizeChromeTraceScope(event: ChromeTraceEventSchema): string | null {
+  return event.scope ?? event.s ?? null;
+}
+
+/**
+ * Serializes one optional JSON-safe value into a nullable string.
+ */
+function serializeChromeTraceJson(value: unknown): string | null {
+  return value == null ? null : JSON.stringify(value);
+}
+
+/**
+ * Builds the passthrough JSON payload for unmodeled fields and numeric id-like values.
+ */
+function buildChromeTraceExtraJson(event: ChromeTraceEventSchema): string | null {
+  const extraEntries = Object.entries(event).filter(([key, value]) => {
+    if (CHROME_TRACE_MODELED_EXTRA_KEYS.has(key)) {
+      return CHROME_TRACE_NUMERIC_ID_LIKE_KEYS.has(key) && typeof value === 'number';
+    }
+
+    if (key === 's' && event.scope == null) {
+      return false;
+    }
+
+    return true;
+  });
+
+  if (extraEntries.length === 0) {
+    return null;
+  }
+
+  return JSON.stringify(Object.fromEntries(extraEntries));
+}
+
+/**
+ * Parses one JSON string value used in Arrow schema metadata.
+ */
+function parseChromeTraceJsonValue(value: string | undefined): unknown {
+  return value == null ? undefined : JSON.parse(value);
+}
+
+/**
+ * Normalizes the requested Arrow batch size.
+ */
+function normalizeChromeTraceBatchSize(batchSize: number | undefined): number {
+  if (!batchSize || !Number.isFinite(batchSize) || batchSize <= 0) {
+    return 256;
+  }
+
+  return Math.max(1, Math.floor(batchSize));
+}
+
+/**
+ * Emits one complete event list as Arrow record batches.
+ */
+async function* emitChromeTraceArrowBatches(
+  events: readonly ChromeTraceEventSchema[],
+  traceFile: Pick<ChromeTraceFileSchema, 'displayTimeUnit' | 'metadata'>,
+  batchSize: number
+): AsyncIterable<ChromeTraceEventArrowRecordBatch> {
+  for (let startIndex = 0; startIndex < events.length; startIndex += batchSize) {
+    const batchEvents = events.slice(startIndex, startIndex + batchSize);
+    if (batchEvents.length === 0) {
+      continue;
+    }
+
+    yield buildChromeTraceEventArrowRecordBatch(batchEvents, traceFile);
+  }
+}

--- a/modules/traces/src/chrome-trace-arrow-parser.ts
+++ b/modules/traces/src/chrome-trace-arrow-parser.ts
@@ -76,14 +76,12 @@ export async function* parseChromeTraceToArrowRecordBatches(
   let deferredBatchEvents: ChromeTraceEventSchema[] | null = null;
   let rawText = '';
   let tokenizedEventCount = 0;
+  const textDecoder = new TextDecoder();
 
-  for await (const chunk of source) {
-    const chunkText = decodeChromeTraceSourceChunk(chunk);
-    rawText += chunkText;
-
-    const events = appendChromeTraceFileChunk(tokenizer, chunkText);
+  const appendTokenizedEvents = (events: ChromeTraceEventSchema[]): ChromeTraceEventSchema[][] => {
+    const readyBatches: ChromeTraceEventSchema[][] = [];
     if (events.length === 0) {
-      continue;
+      return readyBatches;
     }
 
     tokenizedEventCount += events.length;
@@ -92,11 +90,35 @@ export async function* parseChromeTraceToArrowRecordBatches(
     while (pendingEvents.length >= normalizedBatchSize) {
       const batchEvents = pendingEvents.splice(0, normalizedBatchSize);
       if (deferredBatchEvents) {
-        yield buildChromeTraceEventArrowRecordBatch(deferredBatchEvents, {
-          displayTimeUnit: tokenizer.displayTimeUnit
-        });
+        readyBatches.push(deferredBatchEvents);
       }
       deferredBatchEvents = batchEvents;
+    }
+
+    return readyBatches;
+  };
+
+  for await (const chunk of source) {
+    const chunkText = decodeChromeTraceSourceChunk(chunk, textDecoder);
+    rawText += chunkText;
+
+    const events = appendChromeTraceFileChunk(tokenizer, chunkText);
+    for (const batchEvents of appendTokenizedEvents(events)) {
+      yield buildChromeTraceEventArrowRecordBatch(batchEvents, {
+        displayTimeUnit: tokenizer.displayTimeUnit
+      });
+    }
+  }
+
+  const trailingText = textDecoder.decode();
+  if (trailingText) {
+    rawText += trailingText;
+    for (const batchEvents of appendTokenizedEvents(
+      appendChromeTraceFileChunk(tokenizer, trailingText)
+    )) {
+      yield buildChromeTraceEventArrowRecordBatch(batchEvents, {
+        displayTimeUnit: tokenizer.displayTimeUnit
+      });
     }
   }
 
@@ -296,18 +318,24 @@ function parseChromeTraceFile(
 /**
  * Decodes one Chrome trace source chunk into UTF-8 text.
  */
-function decodeChromeTraceSourceChunk(chunk: string | ArrayBufferLike | ArrayBufferView): string {
+function decodeChromeTraceSourceChunk(
+  chunk: string | ArrayBufferLike | ArrayBufferView,
+  decoder?: TextDecoder
+): string {
   if (typeof chunk === 'string') {
-    return chunk;
+    return decoder ? decoder.decode() + chunk : chunk;
   }
 
+  const textDecoder = decoder ?? new TextDecoder();
+
   if (ArrayBuffer.isView(chunk)) {
-    return new TextDecoder().decode(
-      new Uint8Array(chunk.buffer, chunk.byteOffset, chunk.byteLength)
+    return textDecoder.decode(
+      new Uint8Array(chunk.buffer, chunk.byteOffset, chunk.byteLength),
+      decoder ? {stream: true} : undefined
     );
   }
 
-  return new TextDecoder().decode(new Uint8Array(chunk));
+  return textDecoder.decode(new Uint8Array(chunk), decoder ? {stream: true} : undefined);
 }
 
 /**

--- a/modules/traces/src/chrome-trace-arrow-parser.ts
+++ b/modules/traces/src/chrome-trace-arrow-parser.ts
@@ -208,59 +208,59 @@ function buildChromeTraceEventArrowColumns(events: readonly ChromeTraceEventSche
 } {
   return {
     name: arrow.vectorFromArray(
-      events.map(event => event.name),
+      events.map((event) => event.name),
       new arrow.Utf8()
     ),
     ph: arrow.vectorFromArray(
-      events.map(event => event.ph),
+      events.map((event) => event.ph),
       new arrow.Utf8()
     ),
     ts: arrow.vectorFromArray(
-      events.map(event => event.ts ?? null),
+      events.map((event) => event.ts ?? null),
       new arrow.Float64()
     ),
     pid: arrow.vectorFromArray(
-      events.map(event => normalizeChromeTraceIdLike(event.pid)),
+      events.map((event) => normalizeChromeTraceIdLike(event.pid)),
       new arrow.Utf8()
     ),
     tid: arrow.vectorFromArray(
-      events.map(event => normalizeChromeTraceIdLike(event.tid)),
+      events.map((event) => normalizeChromeTraceIdLike(event.tid)),
       new arrow.Utf8()
     ),
     cat: arrow.vectorFromArray(
-      events.map(event => event.cat ?? null),
+      events.map((event) => event.cat ?? null),
       new arrow.Utf8()
     ),
     dur: arrow.vectorFromArray(
-      events.map(event => event.dur ?? null),
+      events.map((event) => event.dur ?? null),
       new arrow.Float64()
     ),
     tdur: arrow.vectorFromArray(
-      events.map(event => event.tdur ?? null),
+      events.map((event) => event.tdur ?? null),
       new arrow.Float64()
     ),
     tts: arrow.vectorFromArray(
-      events.map(event => event.tts ?? null),
+      events.map((event) => event.tts ?? null),
       new arrow.Float64()
     ),
     id: arrow.vectorFromArray(
-      events.map(event => normalizeChromeTraceIdLike(event.id)),
+      events.map((event) => normalizeChromeTraceIdLike(event.id)),
       new arrow.Utf8()
     ),
     bind_id: arrow.vectorFromArray(
-      events.map(event => normalizeChromeTraceIdLike(event.bind_id)),
+      events.map((event) => normalizeChromeTraceIdLike(event.bind_id)),
       new arrow.Utf8()
     ),
     scope: arrow.vectorFromArray(
-      events.map(event => normalizeChromeTraceScope(event)),
+      events.map((event) => normalizeChromeTraceScope(event)),
       new arrow.Utf8()
     ),
     args: arrow.vectorFromArray(
-      events.map(event => serializeChromeTraceJson(event.args)),
+      events.map((event) => serializeChromeTraceJson(event.args)),
       new arrow.Utf8()
     ),
     extraJson: arrow.vectorFromArray(
-      events.map(event => buildChromeTraceExtraJson(event)),
+      events.map((event) => buildChromeTraceExtraJson(event)),
       new arrow.Utf8()
     )
   };

--- a/modules/traces/src/chrome-trace-arrow-schema.ts
+++ b/modules/traces/src/chrome-trace-arrow-schema.ts
@@ -1,0 +1,81 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import * as arrow from 'apache-arrow';
+
+/**
+ * Arrow column map for raw Chrome trace events.
+ */
+export type ChromeTraceEventArrowColumns = {
+  /** Event name from the source row. */
+  name: arrow.Utf8;
+  /** Chrome trace phase discriminator. */
+  ph: arrow.Utf8;
+  /** Raw timestamp in the source file's declared time unit. */
+  ts: arrow.Float64;
+  /** Process identifier normalized to a string. */
+  pid: arrow.Utf8;
+  /** Thread identifier normalized to a string. */
+  tid: arrow.Utf8;
+  /** Optional category label. */
+  cat: arrow.Utf8;
+  /** Optional duration value. */
+  dur: arrow.Float64;
+  /** Optional thread-local duration. */
+  tdur: arrow.Float64;
+  /** Optional thread-local timestamp. */
+  tts: arrow.Float64;
+  /** Optional async or flow identifier normalized to a string. */
+  id: arrow.Utf8;
+  /** Optional bind identifier normalized to a string. */
+  bind_id: arrow.Utf8;
+  /** Optional normalized scope string. */
+  scope: arrow.Utf8;
+  /** Optional JSON-encoded args payload. */
+  args: arrow.Utf8;
+  /** Optional JSON-encoded passthrough payload. */
+  extraJson: arrow.Utf8;
+};
+
+/**
+ * Typed Arrow schema for raw Chrome trace events.
+ */
+export type ChromeTraceEventArrowSchema = arrow.Schema<ChromeTraceEventArrowColumns>;
+
+/**
+ * Typed Arrow table for raw Chrome trace events.
+ */
+export type ChromeTraceEventArrowTable = arrow.Table<ChromeTraceEventArrowColumns>;
+
+/**
+ * Typed Arrow record batch for raw Chrome trace events.
+ */
+export type ChromeTraceEventArrowRecordBatch = arrow.RecordBatch<ChromeTraceEventArrowColumns>;
+
+/**
+ * Ordered Arrow fields for the Chrome trace event schema.
+ */
+export const CHROME_TRACE_EVENT_ARROW_FIELDS = [
+  new arrow.Field('name', new arrow.Utf8(), false),
+  new arrow.Field('ph', new arrow.Utf8(), false),
+  new arrow.Field('ts', new arrow.Float64(), true),
+  new arrow.Field('pid', new arrow.Utf8(), true),
+  new arrow.Field('tid', new arrow.Utf8(), true),
+  new arrow.Field('cat', new arrow.Utf8(), true),
+  new arrow.Field('dur', new arrow.Float64(), true),
+  new arrow.Field('tdur', new arrow.Float64(), true),
+  new arrow.Field('tts', new arrow.Float64(), true),
+  new arrow.Field('id', new arrow.Utf8(), true),
+  new arrow.Field('bind_id', new arrow.Utf8(), true),
+  new arrow.Field('scope', new arrow.Utf8(), true),
+  new arrow.Field('args', new arrow.Utf8(), true),
+  new arrow.Field('extraJson', new arrow.Utf8(), true)
+] as const;
+
+/**
+ * Arrow schema for raw Chrome trace events without per-file metadata attached.
+ */
+export const chromeTraceEventArrowSchema = new arrow.Schema<ChromeTraceEventArrowColumns>([
+  ...CHROME_TRACE_EVENT_ARROW_FIELDS
+]);

--- a/modules/traces/src/chrome-trace-json-stream.ts
+++ b/modules/traces/src/chrome-trace-json-stream.ts
@@ -1,0 +1,180 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {ChromeTraceEventSchema, ChromeTraceFileSchema} from './chrome-trace-schema';
+
+/**
+ * Incremental tokenizer state for one streamed Chrome trace JSON file.
+ */
+export type ChromeTraceFileTokenizer = {
+  /** Remaining undecoded text buffer. */
+  buffer: string;
+  /** Whether parsing has reached the `traceEvents` array. */
+  insideTraceEventsArray: boolean;
+  /** Whether parsing is currently inside a JSON string literal. */
+  insideString: boolean;
+  /** Whether the current string parser is escaping the next character. */
+  escapingCharacter: boolean;
+  /** Current object depth within the trace-events array. */
+  objectDepth: number;
+  /** Buffer index where the current event object started, when present. */
+  objectStartIndex: number | null;
+  /** Optional top-level display time unit discovered from the JSON prefix. */
+  displayTimeUnit?: string;
+};
+
+/**
+ * Creates one incremental tokenizer for a chunked Chrome trace file.
+ */
+export function createChromeTraceFileTokenizer(
+  displayTimeUnit: string | undefined
+): ChromeTraceFileTokenizer {
+  return {
+    buffer: '',
+    insideTraceEventsArray: false,
+    insideString: false,
+    escapingCharacter: false,
+    objectDepth: 0,
+    objectStartIndex: null,
+    displayTimeUnit
+  };
+}
+
+/**
+ * Appends one streamed chunk and returns any fully parsed event objects.
+ */
+export function appendChromeTraceFileChunk(
+  tokenizer: ChromeTraceFileTokenizer,
+  chunk: string | ArrayBufferLike | ArrayBufferView
+): ChromeTraceEventSchema[] {
+  tokenizer.buffer += decodeChromeTraceChunk(chunk);
+  maybeExtractChromeTraceDisplayTimeUnit(tokenizer);
+  return extractChromeTraceEventsFromTokenizer(tokenizer);
+}
+
+/**
+ * Attempts to parse one complete Chrome trace text payload.
+ */
+export function tryParseChromeTraceFileText(text: string): ChromeTraceFileSchema | null {
+  try {
+    const parsed = JSON.parse(text) as ChromeTraceFileSchema;
+    return Array.isArray(parsed?.traceEvents) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Decodes one streamed chunk into UTF-8 text.
+ */
+function decodeChromeTraceChunk(chunk: string | ArrayBufferLike | ArrayBufferView): string {
+  if (typeof chunk === 'string') {
+    return chunk;
+  }
+
+  if (ArrayBuffer.isView(chunk)) {
+    return new TextDecoder().decode(
+      new Uint8Array(chunk.buffer, chunk.byteOffset, chunk.byteLength)
+    );
+  }
+
+  return new TextDecoder().decode(new Uint8Array(chunk));
+}
+
+/**
+ * Extracts the optional display time unit from the JSON prefix.
+ */
+function maybeExtractChromeTraceDisplayTimeUnit(tokenizer: ChromeTraceFileTokenizer): void {
+  if (tokenizer.displayTimeUnit) {
+    return;
+  }
+
+  const match = tokenizer.buffer.match(/"displayTimeUnit"\s*:\s*"([^"]+)"/);
+  if (match?.[1]) {
+    tokenizer.displayTimeUnit = match[1];
+  }
+}
+
+/**
+ * Extracts complete event objects from the tokenizer buffer.
+ */
+function extractChromeTraceEventsFromTokenizer(
+  tokenizer: ChromeTraceFileTokenizer
+): ChromeTraceEventSchema[] {
+  const parsedEvents: ChromeTraceEventSchema[] = [];
+
+  if (!tokenizer.insideTraceEventsArray) {
+    const traceEventsKeyIndex = tokenizer.buffer.indexOf('"traceEvents"');
+    const traceEventsArrayIndex =
+      traceEventsKeyIndex >= 0 ? tokenizer.buffer.indexOf('[', traceEventsKeyIndex) : -1;
+
+    if (traceEventsArrayIndex < 0) {
+      return parsedEvents;
+    }
+
+    tokenizer.buffer = tokenizer.buffer.slice(traceEventsArrayIndex + 1);
+    tokenizer.insideTraceEventsArray = true;
+  }
+
+  let trimIndex = 0;
+
+  for (let index = 0; index < tokenizer.buffer.length; index += 1) {
+    const character = tokenizer.buffer[index];
+
+    if (tokenizer.insideString) {
+      if (tokenizer.escapingCharacter) {
+        tokenizer.escapingCharacter = false;
+      } else if (character === '\\') {
+        tokenizer.escapingCharacter = true;
+      } else if (character === '"') {
+        tokenizer.insideString = false;
+      }
+      continue;
+    }
+
+    if (character === '"') {
+      tokenizer.insideString = true;
+      continue;
+    }
+
+    if (tokenizer.objectStartIndex == null) {
+      if (character === '{') {
+        tokenizer.objectStartIndex = index;
+        tokenizer.objectDepth = 1;
+      } else if (character === ']') {
+        trimIndex = index + 1;
+        break;
+      }
+      continue;
+    }
+
+    if (character === '{') {
+      tokenizer.objectDepth += 1;
+      continue;
+    }
+
+    if (character !== '}') {
+      continue;
+    }
+
+    tokenizer.objectDepth -= 1;
+    if (tokenizer.objectDepth !== 0) {
+      continue;
+    }
+
+    const eventJson = tokenizer.buffer.slice(tokenizer.objectStartIndex, index + 1);
+    parsedEvents.push(JSON.parse(eventJson) as ChromeTraceEventSchema);
+    trimIndex = index + 1;
+    tokenizer.objectStartIndex = null;
+  }
+
+  if (tokenizer.objectStartIndex != null) {
+    tokenizer.buffer = tokenizer.buffer.slice(tokenizer.objectStartIndex);
+    tokenizer.objectStartIndex = 0;
+    return parsedEvents;
+  }
+
+  tokenizer.buffer = tokenizer.buffer.slice(trimIndex);
+  return parsedEvents;
+}

--- a/modules/traces/src/chrome-trace-json-stream.ts
+++ b/modules/traces/src/chrome-trace-json-stream.ts
@@ -8,10 +8,14 @@ import type {ChromeTraceEventSchema, ChromeTraceFileSchema} from './chrome-trace
  * Incremental tokenizer state for one streamed Chrome trace JSON file.
  */
 export type ChromeTraceFileTokenizer = {
+  /** Incremental UTF-8 decoder for binary source chunks. */
+  textDecoder: TextDecoder;
   /** Remaining undecoded text buffer. */
   buffer: string;
   /** Whether parsing has reached the `traceEvents` array. */
   insideTraceEventsArray: boolean;
+  /** Whether the trace-events array has been fully consumed. */
+  traceEventsArrayFinished: boolean;
   /** Whether parsing is currently inside a JSON string literal. */
   insideString: boolean;
   /** Whether the current string parser is escaping the next character. */
@@ -31,8 +35,10 @@ export function createChromeTraceFileTokenizer(
   displayTimeUnit: string | undefined
 ): ChromeTraceFileTokenizer {
   return {
+    textDecoder: new TextDecoder(),
     buffer: '',
     insideTraceEventsArray: false,
+    traceEventsArrayFinished: false,
     insideString: false,
     escapingCharacter: false,
     objectDepth: 0,
@@ -48,7 +54,7 @@ export function appendChromeTraceFileChunk(
   tokenizer: ChromeTraceFileTokenizer,
   chunk: string | ArrayBufferLike | ArrayBufferView
 ): ChromeTraceEventSchema[] {
-  tokenizer.buffer += decodeChromeTraceChunk(chunk);
+  tokenizer.buffer += decodeChromeTraceChunk(tokenizer, chunk);
   maybeExtractChromeTraceDisplayTimeUnit(tokenizer);
   return extractChromeTraceEventsFromTokenizer(tokenizer);
 }
@@ -68,18 +74,22 @@ export function tryParseChromeTraceFileText(text: string): ChromeTraceFileSchema
 /**
  * Decodes one streamed chunk into UTF-8 text.
  */
-function decodeChromeTraceChunk(chunk: string | ArrayBufferLike | ArrayBufferView): string {
+function decodeChromeTraceChunk(
+  tokenizer: ChromeTraceFileTokenizer,
+  chunk: string | ArrayBufferLike | ArrayBufferView
+): string {
   if (typeof chunk === 'string') {
-    return chunk;
+    return tokenizer.textDecoder.decode() + chunk;
   }
 
   if (ArrayBuffer.isView(chunk)) {
-    return new TextDecoder().decode(
-      new Uint8Array(chunk.buffer, chunk.byteOffset, chunk.byteLength)
+    return tokenizer.textDecoder.decode(
+      new Uint8Array(chunk.buffer, chunk.byteOffset, chunk.byteLength),
+      {stream: true}
     );
   }
 
-  return new TextDecoder().decode(new Uint8Array(chunk));
+  return tokenizer.textDecoder.decode(new Uint8Array(chunk), {stream: true});
 }
 
 /**
@@ -105,6 +115,9 @@ function extractChromeTraceEventsFromTokenizer(
   const parsedEvents: ChromeTraceEventSchema[] = [];
 
   if (!tokenizer.insideTraceEventsArray) {
+    if (tokenizer.traceEventsArrayFinished) {
+      return parsedEvents;
+    }
     const traceEventsKeyIndex = tokenizer.buffer.indexOf('"traceEvents"');
     const traceEventsArrayIndex =
       traceEventsKeyIndex >= 0 ? tokenizer.buffer.indexOf('[', traceEventsKeyIndex) : -1;
@@ -144,6 +157,8 @@ function extractChromeTraceEventsFromTokenizer(
         tokenizer.objectDepth = 1;
       } else if (character === ']') {
         trimIndex = index + 1;
+        tokenizer.traceEventsArrayFinished = true;
+        tokenizer.insideTraceEventsArray = false;
         break;
       }
       continue;
@@ -172,6 +187,14 @@ function extractChromeTraceEventsFromTokenizer(
   if (tokenizer.objectStartIndex != null) {
     tokenizer.buffer = tokenizer.buffer.slice(tokenizer.objectStartIndex);
     tokenizer.objectStartIndex = 0;
+    tokenizer.objectDepth = 0;
+    tokenizer.insideString = false;
+    tokenizer.escapingCharacter = false;
+    return parsedEvents;
+  }
+
+  if (tokenizer.traceEventsArrayFinished) {
+    tokenizer.buffer = '';
     return parsedEvents;
   }
 

--- a/modules/traces/src/chrome-trace-loader.ts
+++ b/modules/traces/src/chrome-trace-loader.ts
@@ -1,0 +1,169 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {LoaderOptions, LoaderWithParser} from '@loaders.gl/loader-utils';
+
+import {
+  parseChromeTraceToArrowRecordBatches,
+  parseChromeTraceToArrowTable
+} from './chrome-trace-arrow-parser';
+import {validateChromeTraceFile} from './chrome-trace-schema';
+
+import type {
+  ChromeTraceEventArrowRecordBatch,
+  ChromeTraceEventArrowTable
+} from './chrome-trace-arrow-schema';
+import type {ChromeTraceFileSchema, ChromeTraceValidationOptions} from './chrome-trace-schema';
+
+const CHROME_TRACE_LOADER_VERSION = '4.4.0';
+
+/**
+ * Chrome trace loader options.
+ */
+export type ChromeTraceLoaderOptions = LoaderOptions &
+  ChromeTraceValidationOptions & {
+    /** Selects the returned data shape for whole-file parsing. */
+    shape?: 'json' | 'arrow-table';
+    /** Chrome trace loader-specific options. */
+    chromeTrace?: {
+      /** Selects the returned data shape for whole-file parsing. */
+      shape?: 'json' | 'arrow-table';
+      /** Maximum number of events emitted in one Arrow record batch. */
+      batchSize?: number;
+    };
+  };
+
+/**
+ * loaders.gl-compatible loader for Chrome trace JSON payloads.
+ */
+export const ChromeTraceLoader = {
+  name: 'Chrome Trace Loader',
+  id: 'chromeTrace',
+  module: 'traces',
+  version: CHROME_TRACE_LOADER_VERSION,
+  extensions: ['json'],
+  mimeTypes: ['application/json', 'application/x-chrome-trace+json'],
+  text: true,
+  options: {
+    chromeTrace: {
+      shape: 'json',
+      batchSize: 256
+    }
+  } satisfies ChromeTraceLoaderOptions,
+  parse: async (arrayBuffer: ArrayBuffer, options?: ChromeTraceLoaderOptions) =>
+    parseChromeTraceArrayBuffer(arrayBuffer, options),
+  parseSync: (arrayBuffer: ArrayBuffer, options?: ChromeTraceLoaderOptions) =>
+    parseChromeTraceArrayBufferSync(arrayBuffer, options),
+  parseText: async (text: string, options?: ChromeTraceLoaderOptions) =>
+    parseChromeTraceText(text, options),
+  parseTextSync: (text: string, options?: ChromeTraceLoaderOptions) =>
+    parseChromeTraceTextSync(text, options),
+  parseInBatches: async function* parseChromeTraceBatches(
+    iterator:
+      | AsyncIterable<ArrayBufferLike | ArrayBufferView>
+      | Iterable<ArrayBufferLike | ArrayBufferView>,
+    options?: ChromeTraceLoaderOptions
+  ) {
+    if (resolveChromeTraceLoaderShape(options) !== 'arrow-table') {
+      throw new Error('ChromeTraceLoader.parseInBatches currently requires shape: "arrow-table".');
+    }
+
+    yield* parseChromeTraceToArrowRecordBatches(iterator, {
+      batchSize: resolveChromeTraceLoaderBatchSize(options),
+      maxLength: options?.maxLength
+    });
+  },
+  tests: [testChromeTraceLoader]
+} as const satisfies LoaderWithParser<
+  ChromeTraceFileSchema | ChromeTraceEventArrowTable,
+  ChromeTraceEventArrowRecordBatch,
+  ChromeTraceLoaderOptions
+>;
+
+/**
+ * Parses one Chrome trace binary payload asynchronously.
+ */
+function parseChromeTraceArrayBuffer(
+  arrayBuffer: ArrayBuffer,
+  options?: ChromeTraceLoaderOptions
+): Promise<ChromeTraceFileSchema | ChromeTraceEventArrowTable> {
+  return Promise.resolve(parseChromeTraceArrayBufferSync(arrayBuffer, options));
+}
+
+/**
+ * Parses one Chrome trace binary payload synchronously.
+ */
+function parseChromeTraceArrayBufferSync(
+  arrayBuffer: ArrayBuffer,
+  options?: ChromeTraceLoaderOptions
+): ChromeTraceFileSchema | ChromeTraceEventArrowTable {
+  return parseChromeTraceTextSync(new TextDecoder().decode(new Uint8Array(arrayBuffer)), options);
+}
+
+/**
+ * Parses one Chrome trace text payload asynchronously.
+ */
+function parseChromeTraceText(
+  text: string,
+  options?: ChromeTraceLoaderOptions
+): Promise<ChromeTraceFileSchema | ChromeTraceEventArrowTable> {
+  return Promise.resolve(parseChromeTraceTextSync(text, options));
+}
+
+/**
+ * Parses one Chrome trace text payload synchronously.
+ */
+function parseChromeTraceTextSync(
+  text: string,
+  options?: ChromeTraceLoaderOptions
+): ChromeTraceFileSchema | ChromeTraceEventArrowTable {
+  if (resolveChromeTraceLoaderShape(options) === 'arrow-table') {
+    return parseChromeTraceToArrowTable(text, {
+      maxLength: options?.maxLength
+    });
+  }
+
+  return validateChromeTraceFile(JSON.parse(text), resolveChromeTraceValidationOptions(options));
+}
+
+/**
+ * Resolves the requested loader output shape.
+ */
+function resolveChromeTraceLoaderShape(
+  options: ChromeTraceLoaderOptions | undefined
+): 'json' | 'arrow-table' {
+  const shape = options?.chromeTrace?.shape ?? options?.shape;
+  return shape === 'arrow-table' ? 'arrow-table' : 'json';
+}
+
+/**
+ * Resolves the requested Arrow batch size for streamed parsing.
+ */
+function resolveChromeTraceLoaderBatchSize(
+  options: ChromeTraceLoaderOptions | undefined
+): number | undefined {
+  return (
+    options?.chromeTrace?.batchSize ??
+    (typeof options?.batchSize === 'number' ? options.batchSize : undefined)
+  );
+}
+
+/**
+ * Resolves the validation options shared with the JSON-first parser.
+ */
+function resolveChromeTraceValidationOptions(
+  options: ChromeTraceLoaderOptions | undefined
+): ChromeTraceValidationOptions {
+  return {
+    maxLength: options?.maxLength
+  };
+}
+
+/**
+ * Sniffs a candidate file header to see whether it resembles a Chrome trace payload.
+ */
+function testChromeTraceLoader(arrayBuffer: ArrayBuffer): boolean {
+  const header = new TextDecoder().decode(new Uint8Array(arrayBuffer).slice(0, 2048));
+  return header.includes('"traceEvents"');
+}

--- a/modules/traces/src/chrome-trace-schema.ts
+++ b/modules/traces/src/chrome-trace-schema.ts
@@ -1,0 +1,144 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {ZodError, z} from 'zod';
+
+/**
+ * Supported Chrome trace phase values.
+ * @see https://www.chromium.org/developers/how-tos/trace-event-profiling-tool/trace-event-reading
+ */
+export const CHROME_TRACE_PHASE_VALUES = [
+  'B',
+  'E',
+  'X',
+  'I',
+  'i',
+  'C',
+  'b',
+  'e',
+  'n',
+  's',
+  't',
+  'f',
+  'M',
+  'N',
+  'O',
+  'P',
+  'D',
+  'S',
+  'T',
+  'R',
+  'F',
+  'v',
+  'd'
+] as const;
+
+const chromeTraceEventPhaseSchema = z.enum(CHROME_TRACE_PHASE_VALUES);
+const chromeTraceIdLikeSchema = z.union([z.string(), z.number()]);
+const chromeTraceScopeSchema = z.enum(['g', 'p', 't']);
+
+const chromeTraceEventSchema = z
+  .object({
+    name: z.string(),
+    ph: chromeTraceEventPhaseSchema,
+    ts: z.number().optional(),
+    pid: chromeTraceIdLikeSchema,
+    tid: chromeTraceIdLikeSchema,
+    cat: z.string().optional(),
+    dur: z.number().optional(),
+    tdur: z.number().optional(),
+    tts: z.number().optional(),
+    id: chromeTraceIdLikeSchema.optional(),
+    bind_id: chromeTraceIdLikeSchema.optional(),
+    id2: z
+      .object({
+        local: chromeTraceIdLikeSchema.optional(),
+        global: chromeTraceIdLikeSchema.optional()
+      })
+      .partial()
+      .optional(),
+    s: chromeTraceScopeSchema.optional(),
+    scope: chromeTraceScopeSchema.optional(),
+    args: z.record(z.string(), z.unknown()).optional()
+  })
+  .passthrough();
+
+const chromeTraceFileSchema = z
+  .object({
+    traceEvents: z.array(chromeTraceEventSchema),
+    displayTimeUnit: z.string().optional(),
+    systemTraceEvents: z.unknown().optional(),
+    metadata: z.record(z.string(), z.unknown()).optional()
+  })
+  .passthrough();
+
+/**
+ * One validated Chrome trace file.
+ */
+export type ChromeTraceFileSchema = z.infer<typeof chromeTraceFileSchema>;
+
+/**
+ * One validated Chrome trace event row.
+ */
+export type ChromeTraceEventSchema = z.infer<typeof chromeTraceEventSchema>;
+
+/**
+ * One supported Chrome trace phase.
+ */
+export type ChromeTraceEventPhase = z.infer<typeof chromeTraceEventPhaseSchema>;
+
+/**
+ * Validation options shared by the Chrome trace helpers.
+ */
+export type ChromeTraceValidationOptions = {
+  /** Maximum number of events to validate structurally before returning the input. */
+  maxLength?: number;
+};
+
+const DEFAULT_MAX_LENGTH = 1000;
+
+/**
+ * Returns whether an unknown value resembles a Chrome trace file.
+ */
+export function maybeChromeTraceFile(data: unknown): data is ChromeTraceFileSchema {
+  return Boolean(
+    data && typeof data === 'object' && Array.isArray((data as {traceEvents?: unknown}).traceEvents)
+  );
+}
+
+/**
+ * Validates one parsed Chrome trace file and preserves any passthrough fields.
+ */
+export function validateChromeTraceFile(
+  pathData: unknown,
+  options: ChromeTraceValidationOptions = {}
+): ChromeTraceFileSchema {
+  const {maxLength = DEFAULT_MAX_LENGTH} = options;
+
+  try {
+    if (!pathData || typeof pathData !== 'object') {
+      return chromeTraceFileSchema.parse(pathData);
+    }
+
+    const traceEvents = (pathData as {traceEvents?: unknown}).traceEvents;
+    const slicedTraceEvents = Array.isArray(traceEvents)
+      ? traceEvents.slice(0, maxLength)
+      : traceEvents;
+
+    chromeTraceFileSchema.parse({
+      ...(pathData as Record<string, unknown>),
+      traceEvents: slicedTraceEvents
+    });
+
+    return pathData as ChromeTraceFileSchema;
+  } catch (error) {
+    if (error instanceof ZodError) {
+      const message = error.issues
+        .map(issue => `${issue.message}: ${issue.path.join('.')}`)
+        .join('\n');
+      throw new Error(message);
+    }
+    throw error;
+  }
+}

--- a/modules/traces/src/chrome-trace-schema.ts
+++ b/modules/traces/src/chrome-trace-schema.ts
@@ -135,7 +135,7 @@ export function validateChromeTraceFile(
   } catch (error) {
     if (error instanceof ZodError) {
       const message = error.issues
-        .map(issue => `${issue.message}: ${issue.path.join('.')}`)
+        .map((issue) => `${issue.message}: ${issue.path.join('.')}`)
         .join('\n');
       throw new Error(message);
     }

--- a/modules/traces/src/chrome-trace-stream.ts
+++ b/modules/traces/src/chrome-trace-stream.ts
@@ -1,0 +1,259 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {
+  decodeChromeTraceArrowSource,
+  readChromeTraceArrowSourceMetadata
+} from './chrome-trace-arrow-adapter';
+import {parseChromeTraceToArrowRecordBatches} from './chrome-trace-arrow-parser';
+import {parseChromeTrace} from './parse-chrome-trace';
+import {createTraceStreamReplaceChunk} from './trace-stream-session';
+
+import type {ChromeTraceArrowParseOptions} from './chrome-trace-arrow-parser';
+import type {ChromeTraceArrowSourceItem} from './chrome-trace-arrow-adapter';
+import type {ChromeTraceEventSchema, ChromeTraceFileSchema} from './chrome-trace-schema';
+import type {ChromeTraceParseOptions} from './parse-chrome-trace';
+import type {
+  TraceStreamChunk,
+  TraceStreamPublishedSnapshot,
+  TraceStreamSession
+} from './trace-stream-session';
+
+/**
+ * One item yielded by a parsed Chrome event async stream.
+ */
+export type ChromeTraceEventStreamItem =
+  | ChromeTraceEventSchema
+  | ReadonlyArray<ChromeTraceEventSchema>;
+
+/**
+ * Shared options for Chrome trace streaming helpers.
+ */
+export type ChromeTraceStreamOptions = ChromeTraceParseOptions &
+  ChromeTraceArrowParseOptions & {
+    /** Human-readable trace name used in replacement snapshots. */
+    name?: string;
+    /** Explicit display time unit used before streamed metadata is discovered. */
+    displayTimeUnit?: string;
+    /** Explicit top-level metadata used before streamed metadata is discovered. */
+    metadata?: Record<string, unknown>;
+    /** Event threshold that triggers one replacement publish. */
+    publishEveryEvents?: number;
+  };
+
+type ChromeTraceAccumulatorState = {
+  /** Human-readable replacement snapshot name. */
+  name: string;
+  /** Accumulated logical Chrome trace events. */
+  events: ChromeTraceEventSchema[];
+  /** Optional display time unit resolved from the stream. */
+  displayTimeUnit?: string;
+  /** Optional top-level metadata resolved from the stream. */
+  metadata?: Record<string, unknown>;
+  /** Event threshold for replacement publishes. */
+  publishEveryEvents: number;
+  /** Number of events added since the previous publish. */
+  eventsSincePublish: number;
+  /** Parse options reused for every replacement publish. */
+  parseOptions: ChromeTraceParseOptions;
+};
+
+/**
+ * Builds replacement chunks from a parsed Chrome trace event stream.
+ */
+export async function* streamChromeTraceEventChunks(
+  source: AsyncIterable<ChromeTraceEventStreamItem>,
+  options: ChromeTraceStreamOptions = {}
+): AsyncIterable<TraceStreamChunk> {
+  const state = createChromeTraceAccumulator(options);
+
+  for await (const item of source) {
+    const events = Array.isArray(item) ? item : [item];
+    appendChromeTraceEvents(state, events);
+
+    if (state.eventsSincePublish >= state.publishEveryEvents) {
+      const chunk = buildChromeTraceAccumulatorChunk(state);
+      if (chunk) {
+        yield chunk;
+      }
+    }
+  }
+
+  const finalChunk = buildChromeTraceAccumulatorChunk(state);
+  if (finalChunk) {
+    yield finalChunk;
+  }
+}
+
+/**
+ * Builds replacement chunks from an Arrow-backed Chrome trace event stream.
+ */
+export async function* streamChromeTraceArrowChunks(
+  source: AsyncIterable<ChromeTraceArrowSourceItem>,
+  options: ChromeTraceStreamOptions = {}
+): AsyncIterable<TraceStreamChunk> {
+  const state = createChromeTraceAccumulator(options);
+
+  for await (const item of source) {
+    const metadata = readChromeTraceArrowSourceMetadata(item);
+    state.displayTimeUnit = metadata.displayTimeUnit ?? state.displayTimeUnit;
+    state.metadata = metadata.metadata ?? state.metadata;
+
+    appendChromeTraceEvents(state, decodeChromeTraceArrowSource(item));
+
+    if (state.eventsSincePublish >= state.publishEveryEvents) {
+      const chunk = buildChromeTraceAccumulatorChunk(state);
+      if (chunk) {
+        yield chunk;
+      }
+    }
+  }
+
+  const finalChunk = buildChromeTraceAccumulatorChunk(state);
+  if (finalChunk) {
+    yield finalChunk;
+  }
+}
+
+/**
+ * Builds replacement chunks from a chunked Chrome trace JSON file stream.
+ */
+export async function* streamChromeTraceFileChunks(
+  source: AsyncIterable<string | ArrayBufferLike | ArrayBufferView>,
+  options: ChromeTraceStreamOptions = {}
+): AsyncIterable<TraceStreamChunk> {
+  const arrowSource = parseChromeTraceToArrowRecordBatches(source, {
+    batchSize: options.batchSize,
+    maxLength: options.maxLength
+  });
+
+  yield* streamChromeTraceArrowChunks(arrowSource, options);
+}
+
+/**
+ * Consumes a parsed Chrome trace event stream into one live trace session.
+ */
+export async function consumeChromeTraceEventStream(
+  session: TraceStreamSession,
+  source: AsyncIterable<ChromeTraceEventStreamItem>,
+  options: ChromeTraceStreamOptions = {}
+): Promise<TraceStreamPublishedSnapshot | null> {
+  let latestSnapshot: TraceStreamPublishedSnapshot | null = null;
+
+  for await (const chunk of streamChromeTraceEventChunks(source, options)) {
+    session.applyChunk(chunk);
+    latestSnapshot = session.publishSnapshot() ?? latestSnapshot;
+  }
+
+  return latestSnapshot ?? session.publishSnapshot();
+}
+
+/**
+ * Consumes an Arrow-backed Chrome trace stream into one live trace session.
+ */
+export async function consumeChromeTraceArrowStream(
+  session: TraceStreamSession,
+  source: AsyncIterable<ChromeTraceArrowSourceItem>,
+  options: ChromeTraceStreamOptions = {}
+): Promise<TraceStreamPublishedSnapshot | null> {
+  let latestSnapshot: TraceStreamPublishedSnapshot | null = null;
+
+  for await (const chunk of streamChromeTraceArrowChunks(source, options)) {
+    session.applyChunk(chunk);
+    latestSnapshot = session.publishSnapshot() ?? latestSnapshot;
+  }
+
+  return latestSnapshot ?? session.publishSnapshot();
+}
+
+/**
+ * Consumes a chunked Chrome trace JSON file stream into one live trace session.
+ */
+export async function consumeChromeTraceFileStream(
+  session: TraceStreamSession,
+  source: AsyncIterable<string | ArrayBufferLike | ArrayBufferView>,
+  options: ChromeTraceStreamOptions = {}
+): Promise<TraceStreamPublishedSnapshot | null> {
+  let latestSnapshot: TraceStreamPublishedSnapshot | null = null;
+
+  for await (const chunk of streamChromeTraceFileChunks(source, options)) {
+    session.applyChunk(chunk);
+    latestSnapshot = session.publishSnapshot() ?? latestSnapshot;
+  }
+
+  return latestSnapshot ?? session.publishSnapshot();
+}
+
+/**
+ * Creates one mutable accumulator used by the Chrome streaming helpers.
+ */
+function createChromeTraceAccumulator(
+  options: ChromeTraceStreamOptions
+): ChromeTraceAccumulatorState {
+  return {
+    name: options.name ?? 'Chrome Trace Live Stream',
+    events: [],
+    displayTimeUnit: options.displayTimeUnit,
+    metadata: options.metadata,
+    publishEveryEvents: normalizeChromeTracePublishEveryEvents(options.publishEveryEvents),
+    eventsSincePublish: 0,
+    parseOptions: options
+  };
+}
+
+/**
+ * Appends parsed logical Chrome events into the shared accumulator.
+ */
+function appendChromeTraceEvents(
+  state: ChromeTraceAccumulatorState,
+  events: ReadonlyArray<ChromeTraceEventSchema>
+): void {
+  if (events.length === 0) {
+    return;
+  }
+
+  state.events.push(...events);
+  state.eventsSincePublish += events.length;
+}
+
+/**
+ * Builds one immutable replacement chunk from the accumulated Chrome events.
+ */
+function buildChromeTraceAccumulatorChunk(
+  state: ChromeTraceAccumulatorState
+): TraceStreamChunk | null {
+  if (state.events.length === 0) {
+    return null;
+  }
+
+  const traceFile: ChromeTraceFileSchema = {
+    traceEvents: state.events,
+    ...(state.displayTimeUnit ? {displayTimeUnit: state.displayTimeUnit} : {}),
+    ...(state.metadata ? {metadata: state.metadata} : {})
+  };
+  const trace = parseChromeTrace(traceFile, state.parseOptions);
+  const chunk = createTraceStreamReplaceChunk({
+    name: state.name,
+    trace,
+    traceFile
+  });
+
+  state.eventsSincePublish = 0;
+  return chunk;
+}
+
+/**
+ * Normalizes the incremental publish threshold.
+ */
+function normalizeChromeTracePublishEveryEvents(publishEveryEvents: number | undefined): number {
+  if (
+    publishEveryEvents == null ||
+    !Number.isFinite(publishEveryEvents) ||
+    publishEveryEvents <= 0
+  ) {
+    return 256;
+  }
+
+  return Math.max(1, Math.floor(publishEveryEvents));
+}

--- a/modules/traces/src/chrome-trace-types.ts
+++ b/modules/traces/src/chrome-trace-types.ts
@@ -1,0 +1,123 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+/**
+ * One parsed Chrome trace grouped into processes and threads.
+ */
+export type ChromeTrace = {
+  /** Parsed processes in the order they first appeared. */
+  processes: ChromeTraceProcess[];
+  /** Optional top-level trace metadata from the source file. */
+  metadata?: Record<string, unknown>;
+};
+
+/**
+ * One Chrome trace process.
+ */
+export type ChromeTraceProcess = {
+  /** Stable process identifier. */
+  id: string;
+  /** Human-readable process label. */
+  label: string;
+  /** Parsed threads that belong to the process. */
+  threads: ChromeTraceThread[];
+};
+
+/**
+ * One Chrome trace thread.
+ */
+export type ChromeTraceThread = {
+  /** Stable thread identifier. */
+  id: string;
+  /** Owning process identifier. */
+  pid: string;
+  /** Source thread identifier. */
+  tid: string;
+  /** Human-readable thread label. */
+  label: string;
+  /** Parsed duration spans for the thread. */
+  spans: ChromeTraceSpan[];
+  /** Parsed instant events for the thread. */
+  instants: ChromeTraceInstant[];
+  /** Parsed counters for the thread. */
+  counters: ChromeTraceCounter[];
+  /** Parsed flows for the thread. */
+  flows: ChromeTraceFlow[];
+};
+
+/**
+ * One parsed span with start and end times in milliseconds.
+ */
+export type ChromeTraceSpan = {
+  /** Stable span identifier. */
+  spanId: string;
+  /** Stable thread track identifier. */
+  trackId: string;
+  /** Span name. */
+  name: string;
+  /** Inclusive start time in milliseconds. */
+  startTimeMs: number;
+  /** Exclusive end time in milliseconds. */
+  endTimeMs: number;
+  /** Optional user payload from the source event. */
+  userData?: Record<string, unknown>;
+};
+
+/**
+ * One parsed instant event.
+ */
+export type ChromeTraceInstant = {
+  /** Stable instant identifier. */
+  id: string;
+  /** Stable thread track identifier. */
+  trackId: string;
+  /** Instant name. */
+  name: string;
+  /** Instant timestamp in milliseconds. */
+  atMs: number;
+  /** Instant scope. */
+  scope: 'g' | 'p' | 't';
+  /** Optional user payload from the source event. */
+  userData?: Record<string, unknown>;
+};
+
+/**
+ * One parsed counter event.
+ */
+export type ChromeTraceCounter = {
+  /** Stable counter identifier. */
+  id: string;
+  /** Stable thread track identifier. */
+  trackId: string;
+  /** Counter name. */
+  name: string;
+  /** Counter timestamp in milliseconds. */
+  atMs: number;
+  /** Counter series payload. */
+  series: Record<string, unknown>;
+  /** Optional user payload from the source event. */
+  userData?: Record<string, unknown>;
+};
+
+/**
+ * One parsed flow event.
+ */
+export type ChromeTraceFlow = {
+  /** Stable flow identifier. */
+  id: string;
+  /** Optional bind identifier associated with the flow. */
+  bindId: string;
+  /** Flow event kind. */
+  kind: 'start' | 'step' | 'end';
+  /** Stable key that groups related flow events. */
+  eventKey: string;
+  /** Optional track identifier for the flow event. */
+  trackId?: string;
+  /** Flow timestamp in milliseconds. */
+  atMs: number;
+  /** Optional flow label. */
+  name?: string;
+  /** Optional user payload from the source event. */
+  userData?: Record<string, unknown>;
+};

--- a/modules/traces/src/index.ts
+++ b/modules/traces/src/index.ts
@@ -1,0 +1,46 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+export {
+  ChromeTraceLoader,
+  type ChromeTraceLoaderOptions
+} from './chrome-trace-loader';
+export {
+  type ChromeTraceEventArrowRecordBatch,
+  type ChromeTraceEventArrowTable
+} from './chrome-trace-arrow-schema';
+export type {
+  ChromeTraceEventSchema,
+  ChromeTraceFileSchema,
+  ChromeTraceValidationOptions
+} from './chrome-trace-schema';
+export {parseChromeTrace, type ChromeTraceParseOptions} from './parse-chrome-trace';
+export {
+  consumeChromeTraceArrowStream,
+  consumeChromeTraceEventStream,
+  consumeChromeTraceFileStream,
+  streamChromeTraceArrowChunks,
+  streamChromeTraceEventChunks,
+  streamChromeTraceFileChunks,
+  type ChromeTraceEventStreamItem,
+  type ChromeTraceStreamOptions
+} from './chrome-trace-stream';
+export {
+  createTraceStreamSession,
+  type TraceStreamChunk,
+  type TraceStreamPublishedSnapshot,
+  type TraceStreamReplaceSnapshot,
+  type TraceStreamSession,
+  type TraceStreamSessionListener,
+  type TraceStreamSessionOptions
+} from './trace-stream-session';
+export type {
+  ChromeTrace,
+  ChromeTraceCounter,
+  ChromeTraceFlow,
+  ChromeTraceInstant,
+  ChromeTraceProcess,
+  ChromeTraceSpan,
+  ChromeTraceThread
+} from './chrome-trace-types';

--- a/modules/traces/src/index.ts
+++ b/modules/traces/src/index.ts
@@ -2,10 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-export {
-  ChromeTraceLoader,
-  type ChromeTraceLoaderOptions
-} from './chrome-trace-loader';
+export {ChromeTraceLoader, type ChromeTraceLoaderOptions} from './chrome-trace-loader';
 export {
   type ChromeTraceEventArrowRecordBatch,
   type ChromeTraceEventArrowTable

--- a/modules/traces/src/parse-chrome-trace.ts
+++ b/modules/traces/src/parse-chrome-trace.ts
@@ -1,0 +1,246 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {validateChromeTraceFile} from './chrome-trace-schema';
+
+import type {ChromeTraceValidationOptions} from './chrome-trace-schema';
+import type {
+  ChromeTrace,
+  ChromeTraceCounter,
+  ChromeTraceFlow,
+  ChromeTraceInstant,
+  ChromeTraceProcess,
+  ChromeTraceSpan,
+  ChromeTraceThread
+} from './chrome-trace-types';
+
+const DEFAULT_TIME_UNIT_TO_MS = 1 / 1000;
+const TIME_UNIT_TO_MS: Record<string, number> = {
+  ns: 1 / 1_000_000,
+  nanoseconds: 1 / 1_000_000,
+  μs: 1 / 1000,
+  µs: 1 / 1000,
+  us: 1 / 1000,
+  microseconds: 1 / 1000,
+  ms: 1,
+  milliseconds: 1,
+  s: 1000,
+  seconds: 1000
+};
+
+type StackEntry = {
+  /** Stable span identifier. */
+  spanId: string;
+  /** Stable track identifier. */
+  trackId: string;
+  /** Span name. */
+  name: string;
+  /** Start time in milliseconds. */
+  startTimeMs: number;
+  /** Optional begin-event payload. */
+  userData?: Record<string, unknown>;
+};
+
+/**
+ * Options supported by `parseChromeTrace`.
+ */
+export type ChromeTraceParseOptions = ChromeTraceValidationOptions;
+
+/**
+ * Parses one validated Chrome trace file into processes, threads, and events.
+ */
+export function parseChromeTrace(
+  traceFile: unknown,
+  options: ChromeTraceParseOptions = {}
+): ChromeTrace {
+  const validatedTraceFile = validateChromeTraceFile(traceFile, options);
+  const timeUnitToMs = getTimeUnitToMs(validatedTraceFile.displayTimeUnit);
+  const toMs = (value: number) => value * timeUnitToMs;
+
+  const processes: Record<string, ChromeTraceProcess> = {};
+  const threadsByTid: Record<string, Record<string, ChromeTraceThread>> = {};
+  const stacks: Record<string, StackEntry[]> = {};
+
+  for (const event of validatedTraceFile.traceEvents) {
+    const processId = String(event.pid);
+    const threadId = String(event.tid);
+    const trackId = `${processId}:${threadId}`;
+
+    if (!processes[processId]) {
+      processes[processId] = {
+        id: processId,
+        label: processId,
+        threads: []
+      };
+      threadsByTid[processId] = {};
+    }
+
+    let thread = threadsByTid[processId]?.[threadId];
+    if (!thread) {
+      thread = {
+        id: trackId,
+        pid: processId,
+        tid: threadId,
+        label: isNumericLabel(threadId) ? `Thread ${threadId}` : threadId,
+        spans: [],
+        instants: [],
+        counters: [],
+        flows: []
+      };
+      processes[processId].threads.push(thread);
+      threadsByTid[processId][threadId] = thread;
+    }
+
+    const eventTimestamp = typeof event.ts === 'number' ? event.ts : event.ph === 'M' ? 0 : null;
+    if (eventTimestamp == null) {
+      continue;
+    }
+
+    const eventTimeMs = toMs(eventTimestamp);
+
+    switch (event.ph) {
+      case 'X':
+        if (typeof event.dur === 'number') {
+          thread.spans.push({
+            spanId: `${trackId}:${event.name}:${eventTimestamp}`,
+            trackId,
+            name: event.name,
+            startTimeMs: eventTimeMs,
+            endTimeMs: eventTimeMs + toMs(event.dur),
+            userData: event.args
+          } satisfies ChromeTraceSpan);
+        }
+        break;
+
+      case 'B':
+        if (!stacks[trackId]) {
+          stacks[trackId] = [];
+        }
+
+        stacks[trackId].push({
+          spanId: `${trackId}:${event.name}:${eventTimestamp}`,
+          trackId,
+          name: event.name,
+          startTimeMs: eventTimeMs,
+          userData: event.args
+        });
+        break;
+
+      case 'E': {
+        const stack = stacks[trackId];
+        if (!stack?.length) {
+          break;
+        }
+
+        const begin = stack.pop()!;
+        thread.spans.push({
+          spanId: begin.spanId,
+          trackId,
+          name: begin.name,
+          startTimeMs: begin.startTimeMs,
+          endTimeMs: eventTimeMs,
+          userData: begin.userData
+        } satisfies ChromeTraceSpan);
+        break;
+      }
+
+      case 'i':
+      case 'I':
+        thread.instants.push({
+          id: `${trackId}:${event.name}:${eventTimestamp}`,
+          trackId,
+          name: event.name,
+          atMs: eventTimeMs,
+          scope: (event.scope ?? event.s ?? 't') as 'g' | 'p' | 't',
+          userData: event.args
+        } satisfies ChromeTraceInstant);
+        break;
+
+      case 'C':
+        thread.counters.push({
+          id: `${trackId}:${event.name}:${eventTimestamp}`,
+          trackId,
+          name: event.name,
+          atMs: eventTimeMs,
+          series: event.args ?? {},
+          userData: event.args
+        } satisfies ChromeTraceCounter);
+        break;
+
+      case 's':
+      case 't':
+      case 'f':
+        thread.flows.push({
+          id: `${trackId}:${event.name}:${eventTimestamp}`,
+          bindId: String(event.bind_id ?? ''),
+          kind: event.ph === 's' ? 'start' : event.ph === 't' ? 'step' : 'end',
+          eventKey: `${trackId}:${event.name}`,
+          trackId,
+          atMs: eventTimeMs,
+          name: event.name,
+          userData: event.args
+        } satisfies ChromeTraceFlow);
+        break;
+
+      case 'M': {
+        const metadataName = getChromeTraceMetadataName(event.args);
+        if (!metadataName) {
+          break;
+        }
+
+        if (event.name === 'thread_name') {
+          thread.label = metadataName;
+        } else if (event.name === 'process_name') {
+          processes[processId].label = metadataName;
+        }
+        break;
+      }
+
+      default:
+        break;
+    }
+  }
+
+  return {
+    processes: Object.values(processes),
+    metadata: validatedTraceFile.metadata
+  };
+}
+
+/**
+ * Returns whether a label consists only of digits.
+ */
+function isNumericLabel(label: string): boolean {
+  return /^[0-9]+$/.test(label);
+}
+
+/**
+ * Resolves one Chrome trace display time unit to milliseconds.
+ */
+function getTimeUnitToMs(displayTimeUnit?: string): number {
+  if (!displayTimeUnit) {
+    return DEFAULT_TIME_UNIT_TO_MS;
+  }
+
+  return TIME_UNIT_TO_MS[displayTimeUnit.trim().toLowerCase()] ?? DEFAULT_TIME_UNIT_TO_MS;
+}
+
+/**
+ * Extracts one human-readable metadata label from a metadata event payload.
+ */
+function getChromeTraceMetadataName(args: Record<string, unknown> | undefined): string | undefined {
+  if (typeof args?.name === 'string' && args.name.trim()) {
+    return args.name.trim();
+  }
+
+  if (typeof args?.thread_name === 'string' && args.thread_name.trim()) {
+    return args.thread_name.trim();
+  }
+
+  if (typeof args?.process_name === 'string' && args.process_name.trim()) {
+    return args.process_name.trim();
+  }
+
+  return undefined;
+}

--- a/modules/traces/src/parse-chrome-trace.ts
+++ b/modules/traces/src/parse-chrome-trace.ts
@@ -152,7 +152,7 @@ export function parseChromeTrace(
           trackId,
           name: event.name,
           atMs: eventTimeMs,
-          scope: (event.scope ?? event.s ?? 't') as 'g' | 'p' | 't',
+          scope: (event.scope ?? event.s ?? 't'),
           userData: event.args
         } satisfies ChromeTraceInstant);
         break;
@@ -170,18 +170,23 @@ export function parseChromeTrace(
 
       case 's':
       case 't':
-      case 'f':
+      case 'f': {
+        const flowScope = event.s ?? event.scope ?? 't';
+        const flowId = event.id != null ? String(event.id) : `${event.name}:${event.bind_id ?? ''}`;
+        const eventKey = `${flowScope}:${flowId}`;
+
         thread.flows.push({
-          id: `${trackId}:${event.name}:${eventTimestamp}`,
+          id: `${eventKey}:${event.ph}:${eventTimestamp}`,
           bindId: String(event.bind_id ?? ''),
           kind: event.ph === 's' ? 'start' : event.ph === 't' ? 'step' : 'end',
-          eventKey: `${trackId}:${event.name}`,
+          eventKey,
           trackId,
           atMs: eventTimeMs,
           name: event.name,
           userData: event.args
         } satisfies ChromeTraceFlow);
         break;
+      }
 
       case 'M': {
         const metadataName = getChromeTraceMetadataName(event.args);

--- a/modules/traces/src/parse-chrome-trace.ts
+++ b/modules/traces/src/parse-chrome-trace.ts
@@ -152,7 +152,7 @@ export function parseChromeTrace(
           trackId,
           name: event.name,
           atMs: eventTimeMs,
-          scope: (event.scope ?? event.s ?? 't'),
+          scope: event.scope ?? event.s ?? 't',
           userData: event.args
         } satisfies ChromeTraceInstant);
         break;

--- a/modules/traces/src/trace-stream-session.ts
+++ b/modules/traces/src/trace-stream-session.ts
@@ -1,0 +1,251 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {ChromeTrace} from './chrome-trace-types';
+import type {ChromeTraceFileSchema} from './chrome-trace-schema';
+
+/**
+ * Full immutable replacement payload applied by one streamed chunk.
+ */
+export type TraceStreamReplaceSnapshot = {
+  /** Human-readable trace name. */
+  name: string;
+  /** Parsed Chrome trace graph. */
+  trace: ChromeTrace;
+  /** Canonical trace file assembled from the stream so far. */
+  traceFile: ChromeTraceFileSchema;
+};
+
+/**
+ * Normalized streaming chunk applied into one live trace session.
+ */
+export type TraceStreamChunk = {
+  /** Optional session name override. */
+  name?: string;
+  /** Optional full-state replacement snapshot. */
+  replaceSnapshot?: TraceStreamReplaceSnapshot;
+};
+
+/**
+ * Immutable snapshot published by a live trace session.
+ */
+export type TraceStreamPublishedSnapshot = {
+  /** Monotonic snapshot sequence. */
+  sequence: number;
+  /** Human-readable trace name. */
+  name: string;
+  /** Parsed Chrome trace graph. */
+  trace: ChromeTrace;
+  /** Canonical trace file assembled from the stream. */
+  traceFile: ChromeTraceFileSchema;
+};
+
+/**
+ * Listener invoked when a live trace session publishes a new snapshot.
+ */
+export type TraceStreamSessionListener = (
+  snapshot: TraceStreamPublishedSnapshot
+) => void | Promise<void>;
+
+/**
+ * Options for creating one live trace session.
+ */
+export type TraceStreamSessionOptions = {
+  /** Human-readable session name used until a chunk overrides it. */
+  name?: string;
+  /** Minimum delay before a scheduled publish flushes dirty state. */
+  publishIntervalMs?: number;
+};
+
+/**
+ * Mutable live trace session that accepts replacement chunks and publishes immutable snapshots.
+ */
+export type TraceStreamSession = {
+  /** Applies one normalized chunk into mutable session state. */
+  applyChunk: (chunk: TraceStreamChunk) => void;
+  /** Forces publication of the latest dirty state. */
+  publishSnapshot: () => TraceStreamPublishedSnapshot | null;
+  /** Reads the latest published immutable snapshot. */
+  getPublishedSnapshot: () => TraceStreamPublishedSnapshot | null;
+  /** Subscribes to published snapshots. */
+  subscribe: (listener: TraceStreamSessionListener) => () => void;
+  /** Closes the session and cancels any pending scheduled publish. */
+  close: () => void;
+};
+
+type TraceStreamSessionState = {
+  /** Human-readable session name. */
+  name: string;
+  /** Minimum publish interval. */
+  publishIntervalMs: number;
+  /** Whether the session has been closed. */
+  closed: boolean;
+  /** Whether mutable state differs from the latest published snapshot. */
+  dirty: boolean;
+  /** Monotonic published sequence. */
+  sequence: number;
+  /** Latest replacement snapshot staged for publication. */
+  replacementSnapshot: TraceStreamReplaceSnapshot | null;
+  /** Latest published immutable snapshot. */
+  publishedSnapshot: TraceStreamPublishedSnapshot | null;
+  /** Pending publish timer. */
+  publishTimer: ReturnType<typeof setTimeout> | null;
+  /** Snapshot listeners. */
+  listeners: Set<TraceStreamSessionListener>;
+};
+
+/**
+ * Creates one live trace session.
+ */
+export function createTraceStreamSession(
+  options: TraceStreamSessionOptions = {}
+): TraceStreamSession {
+  const state = createTraceStreamSessionState(options);
+
+  return {
+    applyChunk: chunk => {
+      assertTraceStreamSessionOpen(state);
+      applyTraceStreamChunk(state, chunk);
+      scheduleTraceStreamPublish(state);
+    },
+    publishSnapshot: () => {
+      assertTraceStreamSessionOpen(state);
+      return publishTraceStreamSnapshot(state);
+    },
+    getPublishedSnapshot: () => state.publishedSnapshot,
+    subscribe: listener => {
+      assertTraceStreamSessionOpen(state);
+      state.listeners.add(listener);
+
+      if (state.publishedSnapshot) {
+        void listener(state.publishedSnapshot);
+      }
+
+      return () => {
+        state.listeners.delete(listener);
+      };
+    },
+    close: () => {
+      if (state.publishTimer != null) {
+        clearTimeout(state.publishTimer);
+      }
+
+      state.publishTimer = null;
+      state.closed = true;
+      state.listeners.clear();
+    }
+  };
+}
+
+/**
+ * Creates one full replacement chunk from an immutable snapshot payload.
+ */
+export function createTraceStreamReplaceChunk(
+  snapshot: TraceStreamReplaceSnapshot
+): TraceStreamChunk {
+  return {
+    name: snapshot.name,
+    replaceSnapshot: snapshot
+  };
+}
+
+/**
+ * Creates mutable state for one live trace session.
+ */
+function createTraceStreamSessionState(
+  options: TraceStreamSessionOptions
+): TraceStreamSessionState {
+  return {
+    name: options.name ?? 'Live Trace',
+    publishIntervalMs: normalizeTraceStreamPublishIntervalMs(options.publishIntervalMs),
+    closed: false,
+    dirty: false,
+    sequence: 0,
+    replacementSnapshot: null,
+    publishedSnapshot: null,
+    publishTimer: null,
+    listeners: new Set()
+  };
+}
+
+/**
+ * Applies one normalized chunk into mutable session state.
+ */
+function applyTraceStreamChunk(state: TraceStreamSessionState, chunk: TraceStreamChunk): void {
+  if (chunk.name) {
+    state.name = chunk.name;
+  }
+
+  if (chunk.replaceSnapshot) {
+    state.name = chunk.replaceSnapshot.name;
+    state.replacementSnapshot = chunk.replaceSnapshot;
+    state.dirty = true;
+  }
+}
+
+/**
+ * Schedules one delayed publish when state is dirty.
+ */
+function scheduleTraceStreamPublish(state: TraceStreamSessionState): void {
+  if (!state.dirty || state.publishTimer != null || state.closed) {
+    return;
+  }
+
+  state.publishTimer = setTimeout(() => {
+    state.publishTimer = null;
+    publishTraceStreamSnapshot(state);
+  }, state.publishIntervalMs);
+}
+
+/**
+ * Publishes the latest replacement snapshot when state is dirty.
+ */
+function publishTraceStreamSnapshot(
+  state: TraceStreamSessionState
+): TraceStreamPublishedSnapshot | null {
+  if (!state.replacementSnapshot) {
+    return state.publishedSnapshot;
+  }
+
+  if (!state.dirty && state.publishedSnapshot) {
+    return state.publishedSnapshot;
+  }
+
+  const snapshot: TraceStreamPublishedSnapshot = {
+    sequence: state.sequence + 1,
+    name: state.replacementSnapshot.name || state.name,
+    trace: state.replacementSnapshot.trace,
+    traceFile: state.replacementSnapshot.traceFile
+  };
+
+  state.sequence = snapshot.sequence;
+  state.publishedSnapshot = snapshot;
+  state.dirty = false;
+
+  for (const listener of state.listeners) {
+    void listener(snapshot);
+  }
+
+  return snapshot;
+}
+
+/**
+ * Normalizes the configured publish interval.
+ */
+function normalizeTraceStreamPublishIntervalMs(publishIntervalMs: number | undefined): number {
+  if (publishIntervalMs == null || !Number.isFinite(publishIntervalMs) || publishIntervalMs < 0) {
+    return 16;
+  }
+
+  return Math.floor(publishIntervalMs);
+}
+
+/**
+ * Throws when a closed session is used again.
+ */
+function assertTraceStreamSessionOpen(state: TraceStreamSessionState): void {
+  if (state.closed) {
+    throw new Error('TraceStreamSession has already been closed.');
+  }
+}

--- a/modules/traces/src/trace-stream-session.ts
+++ b/modules/traces/src/trace-stream-session.ts
@@ -104,7 +104,7 @@ export function createTraceStreamSession(
   const state = createTraceStreamSessionState(options);
 
   return {
-    applyChunk: chunk => {
+    applyChunk: (chunk) => {
       assertTraceStreamSessionOpen(state);
       applyTraceStreamChunk(state, chunk);
       scheduleTraceStreamPublish(state);
@@ -114,7 +114,7 @@ export function createTraceStreamSession(
       return publishTraceStreamSnapshot(state);
     },
     getPublishedSnapshot: () => state.publishedSnapshot,
-    subscribe: listener => {
+    subscribe: (listener) => {
       assertTraceStreamSessionOpen(state);
       state.listeners.add(listener);
 

--- a/modules/traces/test/chrome-trace-loader.spec.ts
+++ b/modules/traces/test/chrome-trace-loader.spec.ts
@@ -1,0 +1,222 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {parse, parseInBatches} from '@loaders.gl/core';
+import * as arrow from 'apache-arrow';
+import {describe, expect, it} from 'vitest';
+
+import {ChromeTraceLoader} from '../src';
+
+import type {ChromeTraceFileSchema} from '../src';
+
+/**
+ * Builds a compact Chrome trace fixture that exercises Arrow encoding edge cases.
+ */
+function createChromeTraceFixture(): ChromeTraceFileSchema {
+  return {
+    displayTimeUnit: 'us',
+    metadata: {
+      source: 'unit-test',
+      version: 1
+    },
+    traceEvents: [
+      {
+        name: 'process_name',
+        ph: 'M',
+        pid: 7,
+        tid: 'main',
+        args: {name: 'proc-7'}
+      },
+      {
+        name: 'complete-span',
+        ph: 'X',
+        ts: 100,
+        pid: 7,
+        tid: 'main',
+        cat: 'blink',
+        dur: 25,
+        args: {nested: {ok: true}},
+        id2: {global: 'g-1'},
+        custom_flag: true
+      },
+      {
+        name: 'flow-start',
+        ph: 's',
+        ts: 200,
+        pid: '8',
+        tid: 9,
+        id: 'flow-1',
+        bind_id: 42,
+        s: 'p'
+      },
+      {
+        name: 'instant-no-args',
+        ph: 'i',
+        ts: 250,
+        pid: '8',
+        tid: 9
+      }
+    ]
+  };
+}
+
+/**
+ * Encodes one Chrome trace fixture into an ArrayBuffer.
+ */
+function encodeChromeTraceFixture(traceFile: ChromeTraceFileSchema): ArrayBuffer {
+  const bytes = new TextEncoder().encode(JSON.stringify(traceFile));
+  return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength);
+}
+
+/**
+ * Splits one Chrome trace fixture into ArrayBuffer chunks.
+ */
+async function* streamChromeTraceFixture(
+  traceFile: ChromeTraceFileSchema
+): AsyncIterable<ArrayBuffer> {
+  const text = JSON.stringify(traceFile);
+
+  for (let startIndex = 0; startIndex < text.length; startIndex += 37) {
+    const slice = text.slice(startIndex, startIndex + 37);
+    const bytes = new TextEncoder().encode(slice);
+    yield bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength);
+  }
+}
+
+describe('ChromeTraceLoader', () => {
+  it('parses to the expected Arrow schema contract', async () => {
+    const traceFile = createChromeTraceFixture();
+    const parsed = await parse(encodeChromeTraceFixture(traceFile), ChromeTraceLoader, {
+      chromeTrace: {
+        shape: 'arrow-table'
+      }
+    });
+    const table = parsed as arrow.Table;
+
+    expect(table.schema.fields.map(field => field.name)).toEqual([
+      'name',
+      'ph',
+      'ts',
+      'pid',
+      'tid',
+      'cat',
+      'dur',
+      'tdur',
+      'tts',
+      'id',
+      'bind_id',
+      'scope',
+      'args',
+      'extraJson'
+    ]);
+
+    expect(table.schema.fields.map(field => field.nullable)).toEqual([
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true
+    ]);
+
+    expect(table.schema.fields.map(field => field.type.typeId)).toEqual([
+      new arrow.Utf8().typeId,
+      new arrow.Utf8().typeId,
+      new arrow.Float64().typeId,
+      new arrow.Utf8().typeId,
+      new arrow.Utf8().typeId,
+      new arrow.Utf8().typeId,
+      new arrow.Float64().typeId,
+      new arrow.Float64().typeId,
+      new arrow.Float64().typeId,
+      new arrow.Utf8().typeId,
+      new arrow.Utf8().typeId,
+      new arrow.Utf8().typeId,
+      new arrow.Utf8().typeId,
+      new arrow.Utf8().typeId
+    ]);
+  });
+
+  it('parses a full Chrome trace into an Arrow table with encoded args and schema metadata', async () => {
+    const traceFile = createChromeTraceFixture();
+    const parsed = await parse(encodeChromeTraceFixture(traceFile), ChromeTraceLoader, {
+      chromeTrace: {
+        shape: 'arrow-table'
+      }
+    });
+    const table = parsed as arrow.Table;
+
+    expect(table.numRows).toBe(4);
+    expect(table.schema.metadata.get('chromeTrace.displayTimeUnit')).toBe('us');
+    expect(table.schema.metadata.get('chromeTrace.metadataJson')).toBe(
+      JSON.stringify(traceFile.metadata)
+    );
+    expect(table.getChild('pid')?.get(0)).toBe('7');
+    expect(table.getChild('tid')?.get(0)).toBe('main');
+    expect(table.getChild('args')?.get(1)).toBe('{"nested":{"ok":true}}');
+    expect(table.getChild('args')?.get(3)).toBeNull();
+    expect(table.getChild('scope')?.get(2)).toBe('p');
+
+    const extraJson = table.getChild('extraJson')?.get(1);
+    expect(typeof extraJson).toBe('string');
+    expect(JSON.parse(extraJson as string)).toEqual({
+      pid: 7,
+      id2: {global: 'g-1'},
+      custom_flag: true
+    });
+  });
+
+  it('emits Arrow record batches whose concatenation matches the full Arrow table rows', async () => {
+    const traceFile = createChromeTraceFixture();
+    const parsed = await parse(encodeChromeTraceFixture(traceFile), ChromeTraceLoader, {
+      chromeTrace: {
+        shape: 'arrow-table'
+      }
+    });
+    const table = parsed as arrow.Table;
+
+    const batchIterable = await parseInBatches(
+      streamChromeTraceFixture(traceFile),
+      ChromeTraceLoader,
+      {
+        chromeTrace: {
+          shape: 'arrow-table',
+          batchSize: 2
+        }
+      }
+    );
+
+    const batches: arrow.RecordBatch[] = [];
+    for await (const batch of batchIterable) {
+      batches.push(batch as arrow.RecordBatch);
+    }
+
+    expect(batches).toHaveLength(2);
+
+    const combinedTable = new arrow.Table(batches[0].schema, batches);
+    expect(combinedTable.numRows).toBe(table.numRows);
+
+    for (const fieldName of table.schema.fields.map(field => field.name)) {
+      const expectedValues = Array.from({length: table.numRows}, (_, rowIndex) =>
+        table.getChild(fieldName)?.get(rowIndex)
+      );
+      const actualValues = Array.from({length: combinedTable.numRows}, (_, rowIndex) =>
+        combinedTable.getChild(fieldName)?.get(rowIndex)
+      );
+      expect(actualValues).toEqual(expectedValues);
+    }
+
+    expect(batches[1].schema.metadata.get('chromeTrace.metadataJson')).toBe(
+      JSON.stringify(traceFile.metadata)
+    );
+  });
+});

--- a/modules/traces/test/chrome-trace-loader.spec.ts
+++ b/modules/traces/test/chrome-trace-loader.spec.ts
@@ -94,7 +94,7 @@ describe('ChromeTraceLoader', () => {
     });
     const table = parsed as arrow.Table;
 
-    expect(table.schema.fields.map(field => field.name)).toEqual([
+    expect(table.schema.fields.map((field) => field.name)).toEqual([
       'name',
       'ph',
       'ts',
@@ -111,7 +111,7 @@ describe('ChromeTraceLoader', () => {
       'extraJson'
     ]);
 
-    expect(table.schema.fields.map(field => field.nullable)).toEqual([
+    expect(table.schema.fields.map((field) => field.nullable)).toEqual([
       false,
       false,
       true,
@@ -128,7 +128,7 @@ describe('ChromeTraceLoader', () => {
       true
     ]);
 
-    expect(table.schema.fields.map(field => field.type.typeId)).toEqual([
+    expect(table.schema.fields.map((field) => field.type.typeId)).toEqual([
       new arrow.Utf8().typeId,
       new arrow.Utf8().typeId,
       new arrow.Float64().typeId,
@@ -205,7 +205,7 @@ describe('ChromeTraceLoader', () => {
     const combinedTable = new arrow.Table(batches[0].schema, batches);
     expect(combinedTable.numRows).toBe(table.numRows);
 
-    for (const fieldName of table.schema.fields.map(field => field.name)) {
+    for (const fieldName of table.schema.fields.map((field) => field.name)) {
       const expectedValues = Array.from({length: table.numRows}, (_, rowIndex) =>
         table.getChild(fieldName)?.get(rowIndex)
       );

--- a/modules/traces/test/chrome-trace-loader.spec.ts
+++ b/modules/traces/test/chrome-trace-loader.spec.ts
@@ -6,7 +6,7 @@ import {parse, parseInBatches} from '@loaders.gl/core';
 import * as arrow from 'apache-arrow';
 import {describe, expect, it} from 'vitest';
 
-import {ChromeTraceLoader} from '../src';
+import {ChromeTraceLoader, parseChromeTrace} from '../src';
 
 import type {ChromeTraceFileSchema} from '../src';
 
@@ -218,5 +218,26 @@ describe('ChromeTraceLoader', () => {
     expect(batches[1].schema.metadata.get('chromeTrace.metadataJson')).toBe(
       JSON.stringify(traceFile.metadata)
     );
+  });
+
+  it('correlates flow events using their source id and scope', () => {
+    const trace = parseChromeTrace({
+      traceEvents: [
+        {name: 'start', ph: 's', pid: 1, tid: 1, ts: 1, id: 'flow-1', s: 'p'},
+        {name: 'step', ph: 't', pid: 2, tid: 2, ts: 2, id: 'flow-1', s: 'p'},
+        {name: 'end', ph: 'f', pid: 1, tid: 1, ts: 3, id: 'flow-1', s: 'p'}
+      ]
+    });
+
+    const flowKeys: string[] = [];
+    for (const process of trace.processes) {
+      for (const thread of process.threads) {
+        for (const flow of thread.flows) {
+          flowKeys.push(flow.eventKey);
+        }
+      }
+    }
+
+    expect(flowKeys).toEqual(['p:flow-1', 'p:flow-1', 'p:flow-1']);
   });
 });

--- a/modules/traces/test/chrome-trace-stream.spec.ts
+++ b/modules/traces/test/chrome-trace-stream.spec.ts
@@ -1,0 +1,310 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {parse, parseInBatches} from '@loaders.gl/core';
+import {describe, expect, it} from 'vitest';
+
+import {
+  ChromeTraceLoader,
+  consumeChromeTraceArrowStream,
+  consumeChromeTraceEventStream,
+  consumeChromeTraceFileStream,
+  createTraceStreamSession,
+  streamChromeTraceArrowChunks,
+  streamChromeTraceFileChunks
+} from '../src';
+
+import type {ChromeTraceEventSchema, ChromeTraceFileSchema, TraceStreamChunk} from '../src';
+
+/**
+ * Builds one minimal metadata event.
+ */
+function createMetadataEvent(
+  name: 'process_name' | 'thread_name',
+  tid: number,
+  args: Record<string, unknown>
+): ChromeTraceEventSchema {
+  return {
+    name,
+    ph: 'M',
+    pid: 1,
+    tid,
+    args
+  };
+}
+
+/**
+ * Builds one minimal complete span event.
+ */
+function createCompleteSpanEvent(name: string, ts: number, dur: number): ChromeTraceEventSchema {
+  return {
+    name,
+    ph: 'X',
+    ts,
+    dur,
+    pid: 1,
+    tid: 1,
+    cat: 'blink',
+    args: {}
+  };
+}
+
+/**
+ * Builds one streaming fixture.
+ */
+function createChromeTraceFixture(): ChromeTraceFileSchema {
+  return {
+    displayTimeUnit: 'us',
+    metadata: {
+      stream: true
+    },
+    traceEvents: [
+      createMetadataEvent('process_name', 0, {name: 'proc-1'}),
+      createMetadataEvent('thread_name', 1, {name: 'main'}),
+      createCompleteSpanEvent('span-1', 1000, 2000),
+      createCompleteSpanEvent('span-2', 4000, 1000)
+    ]
+  };
+}
+
+/**
+ * Streams one Chrome trace file as JSON chunks.
+ */
+async function* streamChromeTraceFile(
+  traceFile: ChromeTraceFileSchema
+): AsyncIterable<ArrayBuffer> {
+  const text = JSON.stringify(traceFile);
+
+  for (let startIndex = 0; startIndex < text.length; startIndex += 41) {
+    const slice = text.slice(startIndex, startIndex + 41);
+    const bytes = new TextEncoder().encode(slice);
+    yield bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength);
+  }
+}
+
+/**
+ * Encodes one Chrome trace fixture into an ArrayBuffer.
+ */
+function encodeChromeTraceFixture(traceFile: ChromeTraceFileSchema): ArrayBuffer {
+  const bytes = new TextEncoder().encode(JSON.stringify(traceFile));
+  return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength);
+}
+
+/**
+ * Parses one Chrome trace fixture to a public Arrow table through the loader.
+ */
+async function parseChromeTraceArrowTable(traceFile: ChromeTraceFileSchema): Promise<arrow.Table> {
+  const parsed = await parse(encodeChromeTraceFixture(traceFile), ChromeTraceLoader, {
+    chromeTrace: {
+      shape: 'arrow-table'
+    }
+  });
+
+  return parsed as arrow.Table;
+}
+
+/**
+ * Parses one streamed Chrome trace fixture to public Arrow record batches through the loader.
+ */
+async function parseChromeTraceArrowBatches(
+  traceFile: ChromeTraceFileSchema,
+  batchSize: number
+): Promise<arrow.RecordBatch[]> {
+  const batchIterable = await parseInBatches(streamChromeTraceFile(traceFile), ChromeTraceLoader, {
+    chromeTrace: {
+      shape: 'arrow-table',
+      batchSize
+    }
+  });
+
+  const batches: arrow.RecordBatch[] = [];
+  for await (const batch of batchIterable) {
+    batches.push(batch as arrow.RecordBatch);
+  }
+
+  return batches;
+}
+
+/**
+ * Creates one comparable summary for a streamed replacement chunk sequence.
+ */
+function summarizeChunks(chunks: TraceStreamChunk[]): unknown[] {
+  return chunks.map(chunk => ({
+    name: chunk.name,
+    eventCount: chunk.replaceSnapshot?.traceFile.traceEvents.length,
+    metadata: chunk.replaceSnapshot?.traceFile.metadata,
+    processCount: chunk.replaceSnapshot?.trace.processes.length,
+    threadLabels: chunk.replaceSnapshot?.trace.processes.flatMap(process =>
+      process.threads.map(thread => thread.label)
+    )
+  }));
+}
+
+describe('chrome-trace-stream', () => {
+  it('publishes replacement snapshots while consuming parsed event streams', async () => {
+    const session = createTraceStreamSession({publishIntervalMs: 0});
+    const snapshots: number[] = [];
+    session.subscribe(snapshot => {
+      snapshots.push(snapshot.sequence);
+    });
+
+    async function* source() {
+      yield [
+        createMetadataEvent('process_name', 0, {name: 'proc-1'}),
+        createMetadataEvent('thread_name', 1, {name: 'main'})
+      ];
+      yield createCompleteSpanEvent('span-1', 1000, 2000);
+      yield createCompleteSpanEvent('span-2', 4000, 1000);
+    }
+
+    const snapshot = await consumeChromeTraceEventStream(session, source(), {
+      name: 'streamed-events',
+      publishEveryEvents: 1
+    });
+
+    expect(snapshot?.name).toBe('streamed-events');
+    expect(
+      snapshot?.trace.processes.flatMap(process => process.threads.flatMap(thread => thread.spans))
+    ).toHaveLength(2);
+    expect(snapshots.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('routes file streaming through the Arrow parser and matches the Arrow chunk path', async () => {
+    const traceFile = createChromeTraceFixture();
+    const fileChunks: TraceStreamChunk[] = [];
+    const arrowChunks: TraceStreamChunk[] = [];
+    const arrowBatches = await parseChromeTraceArrowBatches(traceFile, 2);
+
+    for await (const chunk of streamChromeTraceFileChunks(streamChromeTraceFile(traceFile), {
+      name: 'streamed-file',
+      publishEveryEvents: 1,
+      batchSize: 2
+    })) {
+      fileChunks.push(chunk);
+    }
+
+    async function* batchSource() {
+      for (const batch of arrowBatches) {
+        yield batch;
+      }
+    }
+
+    for await (const chunk of streamChromeTraceArrowChunks(batchSource(), {
+      name: 'streamed-file',
+      publishEveryEvents: 1
+    })) {
+      arrowChunks.push(chunk);
+    }
+
+    expect(summarizeChunks(fileChunks)).toEqual(summarizeChunks(arrowChunks));
+  });
+
+  it('publishes equivalent snapshots for file and Arrow stream consumption', async () => {
+    const traceFile = createChromeTraceFixture();
+    const fileSession = createTraceStreamSession({publishIntervalMs: 0});
+    const arrowSession = createTraceStreamSession({publishIntervalMs: 0});
+    const arrowBatches = await parseChromeTraceArrowBatches(traceFile, 2);
+
+    const fileSnapshot = await consumeChromeTraceFileStream(
+      fileSession,
+      streamChromeTraceFile(traceFile),
+      {
+        name: 'streamed-file',
+        publishEveryEvents: 1,
+        batchSize: 2
+      }
+    );
+
+    async function* batchSource() {
+      for (const batch of arrowBatches) {
+        yield batch;
+      }
+    }
+
+    const arrowSnapshot = await consumeChromeTraceArrowStream(arrowSession, batchSource(), {
+      name: 'streamed-file',
+      publishEveryEvents: 1
+    });
+
+    expect(arrowSnapshot).toEqual(fileSnapshot);
+  });
+
+  it('pipes parseInBatches output from ChromeTraceLoader into streamChromeTraceArrowChunks', async () => {
+    const traceFile = createChromeTraceFixture();
+    const batchIterable = await parseInBatches(
+      streamChromeTraceFile(traceFile),
+      ChromeTraceLoader,
+      {
+        chromeTrace: {
+          shape: 'arrow-table',
+          batchSize: 2
+        }
+      }
+    );
+
+    const chunks: TraceStreamChunk[] = [];
+    for await (const chunk of streamChromeTraceArrowChunks(batchIterable as AsyncIterable<any>, {
+      name: 'loader-batches',
+      publishEveryEvents: 1
+    })) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks.at(-1)?.replaceSnapshot?.traceFile.metadata).toEqual(traceFile.metadata);
+    expect(
+      chunks
+        .at(-1)
+        ?.replaceSnapshot?.trace.processes.flatMap(process =>
+          process.threads.flatMap(thread => thread.spans)
+        )
+    ).toHaveLength(2);
+  });
+
+  it('preserves metadata and async scope when consuming a public Arrow table stream', async () => {
+    const traceFile: ChromeTraceFileSchema = {
+      displayTimeUnit: 'us',
+      metadata: {
+        buildId: 'abc123'
+      },
+      traceEvents: [
+        createMetadataEvent('process_name', 0, {name: 'proc-1'}),
+        createMetadataEvent('thread_name', 1, {name: 'main'}),
+        {
+          name: 'async-start',
+          ph: 'b',
+          ts: 200,
+          pid: 'worker',
+          tid: 7,
+          id: 77,
+          s: 'p'
+        },
+        createCompleteSpanEvent('span-1', 1000, 2000)
+      ]
+    };
+    const table = await parseChromeTraceArrowTable(traceFile);
+
+    async function* tableSource() {
+      yield table as arrow.Table;
+    }
+
+    const chunks: TraceStreamChunk[] = [];
+    for await (const chunk of streamChromeTraceArrowChunks(tableSource(), {
+      name: 'public-arrow-table',
+      publishEveryEvents: 1
+    })) {
+      chunks.push(chunk);
+    }
+
+    const finalChunk = chunks.at(-1);
+    expect(finalChunk?.replaceSnapshot?.traceFile.metadata).toEqual(traceFile.metadata);
+    expect(finalChunk?.replaceSnapshot?.traceFile.traceEvents[2]).toMatchObject({
+      name: 'async-start',
+      ph: 'b',
+      pid: 'worker',
+      tid: 7,
+      id: 77,
+      s: 'p'
+    });
+  });
+});

--- a/modules/traces/test/chrome-trace-stream.spec.ts
+++ b/modules/traces/test/chrome-trace-stream.spec.ts
@@ -165,7 +165,7 @@ describe('chrome-trace-stream', () => {
 
     expect(snapshot?.name).toBe('streamed-events');
     expect(
-      snapshot?.trace.processes.flatMap(process => process.threads.flatMap(thread => thread.spans))
+      snapshot?.trace.processes.flatMap(process => process.threads).flatMap(thread => thread.spans)
     ).toHaveLength(2);
     expect(snapshots.length).toBeGreaterThanOrEqual(2);
   });
@@ -255,9 +255,9 @@ describe('chrome-trace-stream', () => {
     expect(
       chunks
         .at(-1)
-        ?.replaceSnapshot?.trace.processes.flatMap(process =>
-          process.threads.flatMap(thread => thread.spans)
-        )
+        ?.replaceSnapshot?.trace.processes
+        .flatMap(process => process.threads)
+        .flatMap(thread => thread.spans)
     ).toHaveLength(2);
   });
 

--- a/modules/traces/test/chrome-trace-stream.spec.ts
+++ b/modules/traces/test/chrome-trace-stream.spec.ts
@@ -130,13 +130,13 @@ async function parseChromeTraceArrowBatches(
  * Creates one comparable summary for a streamed replacement chunk sequence.
  */
 function summarizeChunks(chunks: TraceStreamChunk[]): unknown[] {
-  return chunks.map(chunk => ({
+  return chunks.map((chunk) => ({
     name: chunk.name,
     eventCount: chunk.replaceSnapshot?.traceFile.traceEvents.length,
     metadata: chunk.replaceSnapshot?.traceFile.metadata,
     processCount: chunk.replaceSnapshot?.trace.processes.length,
-    threadLabels: chunk.replaceSnapshot?.trace.processes.flatMap(process =>
-      process.threads.map(thread => thread.label)
+    threadLabels: chunk.replaceSnapshot?.trace.processes.flatMap((process) =>
+      process.threads.map((thread) => thread.label)
     )
   }));
 }
@@ -145,7 +145,7 @@ describe('chrome-trace-stream', () => {
   it('publishes replacement snapshots while consuming parsed event streams', async () => {
     const session = createTraceStreamSession({publishIntervalMs: 0});
     const snapshots: number[] = [];
-    session.subscribe(snapshot => {
+    session.subscribe((snapshot) => {
       snapshots.push(snapshot.sequence);
     });
 
@@ -165,7 +165,9 @@ describe('chrome-trace-stream', () => {
 
     expect(snapshot?.name).toBe('streamed-events');
     expect(
-      snapshot?.trace.processes.flatMap(process => process.threads).flatMap(thread => thread.spans)
+      snapshot?.trace.processes
+        .flatMap((process) => process.threads)
+        .flatMap((thread) => thread.spans)
     ).toHaveLength(2);
     expect(snapshots.length).toBeGreaterThanOrEqual(2);
   });
@@ -255,9 +257,8 @@ describe('chrome-trace-stream', () => {
     expect(
       chunks
         .at(-1)
-        ?.replaceSnapshot?.trace.processes
-        .flatMap(process => process.threads)
-        .flatMap(thread => thread.spans)
+        ?.replaceSnapshot?.trace.processes.flatMap((process) => process.threads)
+        .flatMap((thread) => thread.spans)
     ).toHaveLength(2);
   });
 
@@ -330,7 +331,7 @@ describe('chrome-trace-stream', () => {
       batches.push(batch as arrow.RecordBatch);
     }
 
-    expect(batches.map(batch => batch.getChild('name')?.get(0))).toEqual(['é', 'second']);
+    expect(batches.map((batch) => batch.getChild('name')?.get(0))).toEqual(['é', 'second']);
     expect(batches[0].getChild('args')?.get(0)).toBe('{"label":"é"}');
   });
 });

--- a/modules/traces/test/chrome-trace-stream.spec.ts
+++ b/modules/traces/test/chrome-trace-stream.spec.ts
@@ -285,7 +285,7 @@ describe('chrome-trace-stream', () => {
     const table = await parseChromeTraceArrowTable(traceFile);
 
     async function* tableSource() {
-      yield table as arrow.Table;
+      yield table;
     }
 
     const chunks: TraceStreamChunk[] = [];
@@ -306,5 +306,31 @@ describe('chrome-trace-stream', () => {
       id: 77,
       s: 'p'
     });
+  });
+
+  it('preserves UTF-8 text and partial events across binary chunk boundaries', async () => {
+    const traceFile: ChromeTraceFileSchema = {
+      traceEvents: [
+        {name: 'é', ph: 'X', pid: 1, tid: 1, ts: 1, dur: 1, args: {label: 'é'}},
+        {name: 'second', ph: 'X', pid: 1, tid: 1, ts: 2, dur: 1, args: {nested: {ok: true}}}
+      ]
+    };
+    const bytes = new TextEncoder().encode(JSON.stringify(traceFile));
+
+    async function* source(): AsyncIterable<Uint8Array> {
+      for (let startIndex = 0; startIndex < bytes.length; startIndex += 7) {
+        yield bytes.slice(startIndex, startIndex + 7);
+      }
+    }
+
+    const batches = [];
+    for await (const batch of parseInBatches(source(), ChromeTraceLoader, {
+      chromeTrace: {shape: 'arrow-table', batchSize: 1}
+    })) {
+      batches.push(batch as arrow.RecordBatch);
+    }
+
+    expect(batches.map(batch => batch.getChild('name')?.get(0))).toEqual(['é', 'second']);
+    expect(batches[0].getChild('args')?.get(0)).toBe('{"label":"é"}');
   });
 });

--- a/modules/traces/test/data/chrome-trace/sample-chrome-trace.json
+++ b/modules/traces/test/data/chrome-trace/sample-chrome-trace.json
@@ -1,0 +1,98 @@
+{
+  "displayTimeUnit": "us",
+  "metadata": {
+    "name": "loaders.gl sample Chrome trace",
+    "source": "website-example"
+  },
+  "traceEvents": [
+    {
+      "name": "process_name",
+      "ph": "M",
+      "pid": 100,
+      "tid": 0,
+      "args": {
+        "name": "Renderer"
+      }
+    },
+    {
+      "name": "thread_name",
+      "ph": "M",
+      "pid": 100,
+      "tid": 1,
+      "args": {
+        "name": "Main"
+      }
+    },
+    {
+      "name": "ParseHTML",
+      "cat": "blink",
+      "ph": "X",
+      "ts": 1000,
+      "dur": 3200,
+      "pid": 100,
+      "tid": 1,
+      "args": {
+        "url": "https://loaders.gl/examples/traces/chrome-trace"
+      }
+    },
+    {
+      "name": "EvaluateScript",
+      "cat": "v8",
+      "ph": "X",
+      "ts": 4700,
+      "dur": 1800,
+      "pid": 100,
+      "tid": 1,
+      "args": {
+        "scriptName": "table-live-example.tsx"
+      }
+    },
+    {
+      "name": "Layout",
+      "cat": "blink",
+      "ph": "X",
+      "ts": 7000,
+      "dur": 950,
+      "pid": 100,
+      "tid": 1,
+      "args": {
+        "dirtyObjects": 24
+      }
+    },
+    {
+      "name": "Paint",
+      "cat": "devtools.timeline",
+      "ph": "X",
+      "ts": 8200,
+      "dur": 450,
+      "pid": 100,
+      "tid": 1,
+      "args": {
+        "layerId": 3
+      }
+    },
+    {
+      "name": "async-resource",
+      "cat": "netlog",
+      "ph": "b",
+      "ts": 9100,
+      "pid": 100,
+      "tid": 1,
+      "id": "resource-1",
+      "s": "p"
+    },
+    {
+      "name": "async-resource",
+      "cat": "netlog",
+      "ph": "e",
+      "ts": 11200,
+      "pid": 100,
+      "tid": 1,
+      "id": "resource-1",
+      "s": "p",
+      "args": {
+        "encodedDataLength": 4096
+      }
+    }
+  ]
+}

--- a/modules/traces/test/index.ts
+++ b/modules/traces/test/index.ts
@@ -1,0 +1,6 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import './chrome-trace-loader.spec';
+import './chrome-trace-stream.spec';

--- a/modules/traces/tsconfig.json
+++ b/modules/traces/tsconfig.json
@@ -8,5 +8,6 @@
     "outDir": "dist"
   },
   "references": [
+    {"path": "../loader-utils"}
   ]
 }

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "@loaders.gl/terrain": "^4.4.0",
     "@loaders.gl/textures": "^4.4.0",
     "@loaders.gl/tiles": "^4.4.0",
+    "@loaders.gl/traces": "^4.4.0",
     "@loaders.gl/worker-utils": "^4.4.0",
     "@loaders.gl/wms": "^4.4.0",
     "@loaders.gl/zip": "^4.4.0"

--- a/test/modules.ts
+++ b/test/modules.ts
@@ -65,6 +65,7 @@ import '@loaders.gl/csv/test';
 import '@loaders.gl/json/test';
 import '@loaders.gl/excel/test';
 import '@loaders.gl/parquet/test';
+import '@loaders.gl/traces/test';
 
 // unstructured (JSON) formats
 // JSON listed in tabular loaders since it optionally supports that category

--- a/test/modules.ts
+++ b/test/modules.ts
@@ -65,7 +65,6 @@ import '@loaders.gl/csv/test';
 import '@loaders.gl/json/test';
 import '@loaders.gl/excel/test';
 import '@loaders.gl/parquet/test';
-import '@loaders.gl/traces/test';
 
 // unstructured (JSON) formats
 // JSON listed in tabular loaders since it optionally supports that category

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -275,6 +275,12 @@
       "@loaders.gl/textures/test": [
         "modules/textures/test"
       ],
+      "@loaders.gl/traces": [
+        "modules/traces/src"
+      ],
+      "@loaders.gl/traces/test": [
+        "modules/traces/test"
+      ],
       "@loaders.gl/video": [
         "modules/video/src"
       ],

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -104,6 +104,7 @@ const config = {
             '@loaders.gl/tile-converter': resolve('../apps/tile/converter/src-'),
             '@loaders.gl/tiles': resolve('../modules/tiles/src'),
             '@loaders.gl/tiles-2d': resolve('../modules/tiles-2d/src'),
+            '@loaders.gl/traces': resolve('../modules/traces/src'),
             '@loaders.gl/type-analyzer': resolve('../modules/type-analyzer/src'),
             '@loaders.gl/video': resolve('../modules/video/src'),
             '@loaders.gl/wkt': resolve('../modules/wkt/src'),

--- a/website/src/components/docs/traces-docs-tabs.tsx
+++ b/website/src/components/docs/traces-docs-tabs.tsx
@@ -1,0 +1,58 @@
+import React, {type ReactNode} from 'react';
+import Link from '@docusaurus/Link';
+
+type TracesDocsTab = {
+  /** Stable tab identifier. */
+  id: TracesDocsTabId;
+  /** User-facing tab label. */
+  label: string;
+  /** Documentation page URL. */
+  href: string;
+};
+
+/** Traces documentation tab identifiers. */
+export type TracesDocsTabId = 'try-it' | 'overview' | 'chrome-trace' | 'chrometraceloader';
+
+const TRACES_DOCS_TABS: TracesDocsTab[] = [
+  {id: 'try-it', label: 'Try It', href: '/examples/traces/chrome-trace'},
+  {id: 'overview', label: 'Overview', href: '/docs/modules/traces'},
+  {
+    id: 'chrome-trace',
+    label: 'Chrome Trace',
+    href: '/docs/modules/traces/formats/chrome-trace'
+  },
+  {
+    id: 'chrometraceloader',
+    label: 'ChromeTraceLoader',
+    href: '/docs/modules/traces/api-reference/chrome-trace-loader'
+  }
+];
+
+/**
+ * Renders page links with the same visual treatment as tabs for Traces documentation pages.
+ */
+export function TracesDocsTabs({
+  active
+}: {
+  /** Active tab identifier. */
+  active: TracesDocsTabId;
+}): ReactNode {
+  return (
+    <nav className="docs-page-tabs" aria-label="Traces documentation sections">
+      {TRACES_DOCS_TABS.map(tab => (
+        <Link
+          key={tab.id}
+          className={
+            tab.id === active
+              ? 'docs-page-tabs__tab docs-page-tabs__tab--active'
+              : 'docs-page-tabs__tab'
+          }
+          to={tab.href}
+          aria-current={tab.id === active ? 'page' : undefined}
+        >
+          {tab.label}
+        </Link>
+      ))}
+    </nav>
+  );
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5406,6 +5406,10 @@ __metadata:
 "@loaders.gl/traces@workspace:modules/traces":
   version: 0.0.0-use.local
   resolution: "@loaders.gl/traces@workspace:modules/traces"
+  dependencies:
+    "@loaders.gl/loader-utils": "npm:4.5.0-alpha.2"
+    apache-arrow: "npm:>= 17.0.0"
+    zod: "npm:^4.1.12"
   peerDependencies:
     "@loaders.gl/core": ~4.4.0
   languageName: unknown


### PR DESCRIPTION
## Goals
- Bring the Chrome Trace loader APIs to the 4.5-release branch as a focused, standalone backport.

## Changes
- Add `ChromeTraceLoader` with JSON and Arrow-table parsing.
- Add semantic parsing, streaming helpers, chunk consumers, and trace stream sessions.
- Add Chrome Trace schemas/types, focused fixtures, and loader/stream tests.
- Add module and API documentation plus documentation tabs.
- Keep the existing 4.5 internal dependency versions (`@loaders.gl/loader-utils` 4.5.0-alpha.2).

Target branch: `4.5-release`.