### PR TITLE
fix(traces): harden Chrome Trace streaming parser

### DIFF
--- a/modules/traces/src/chrome-trace-arrow-parser.ts
+++ b/modules/traces/src/chrome-trace-arrow-parser.ts
@@ -76,14 +76,12 @@ export async function* parseChromeTraceToArrowRecordBatches(
   let deferredBatchEvents: ChromeTraceEventSchema[] | null = null;
   let rawText = '';
   let tokenizedEventCount = 0;
+  const textDecoder = new TextDecoder();
 
-  for await (const chunk of source) {
-    const chunkText = decodeChromeTraceSourceChunk(chunk);
-    rawText += chunkText;
-
-    const events = appendChromeTraceFileChunk(tokenizer, chunkText);
+  const appendTokenizedEvents = (events: ChromeTraceEventSchema[]): ChromeTraceEventSchema[][] => {
+    const readyBatches: ChromeTraceEventSchema[][] = [];
     if (events.length === 0) {
-      continue;
+      return readyBatches;
     }
 
     tokenizedEventCount += events.length;
@@ -92,11 +90,35 @@ export async function* parseChromeTraceToArrowRecordBatches(
     while (pendingEvents.length >= normalizedBatchSize) {
       const batchEvents = pendingEvents.splice(0, normalizedBatchSize);
       if (deferredBatchEvents) {
-        yield buildChromeTraceEventArrowRecordBatch(deferredBatchEvents, {
-          displayTimeUnit: tokenizer.displayTimeUnit
-        });
+        readyBatches.push(deferredBatchEvents);
       }
       deferredBatchEvents = batchEvents;
+    }
+
+    return readyBatches;
+  };
+
+  for await (const chunk of source) {
+    const chunkText = decodeChromeTraceSourceChunk(chunk, textDecoder);
+    rawText += chunkText;
+
+    const events = appendChromeTraceFileChunk(tokenizer, chunkText);
+    for (const batchEvents of appendTokenizedEvents(events)) {
+      yield buildChromeTraceEventArrowRecordBatch(batchEvents, {
+        displayTimeUnit: tokenizer.displayTimeUnit
+      });
+    }
+  }
+
+  const trailingText = textDecoder.decode();
+  if (trailingText) {
+    rawText += trailingText;
+    for (const batchEvents of appendTokenizedEvents(
+      appendChromeTraceFileChunk(tokenizer, trailingText)
+    )) {
+      yield buildChromeTraceEventArrowRecordBatch(batchEvents, {
+        displayTimeUnit: tokenizer.displayTimeUnit
+      });
     }
   }
 
@@ -296,18 +318,24 @@ function parseChromeTraceFile(
 /**
  * Decodes one Chrome trace source chunk into UTF-8 text.
  */
-function decodeChromeTraceSourceChunk(chunk: string | ArrayBufferLike | ArrayBufferView): string {
+function decodeChromeTraceSourceChunk(
+  chunk: string | ArrayBufferLike | ArrayBufferView,
+  decoder?: TextDecoder
+): string {
   if (typeof chunk === 'string') {
-    return chunk;
+    return decoder ? decoder.decode() + chunk : chunk;
   }
 
+  const textDecoder = decoder ?? new TextDecoder();
+
   if (ArrayBuffer.isView(chunk)) {
-    return new TextDecoder().decode(
-      new Uint8Array(chunk.buffer, chunk.byteOffset, chunk.byteLength)
+    return textDecoder.decode(
+      new Uint8Array(chunk.buffer, chunk.byteOffset, chunk.byteLength),
+      decoder ? {stream: true} : undefined
     );
   }
 
-  return new TextDecoder().decode(new Uint8Array(chunk));
+  return textDecoder.decode(new Uint8Array(chunk), decoder ? {stream: true} : undefined);
 }
 
 /**

--- a/modules/traces/src/chrome-trace-arrow-parser.ts
+++ b/modules/traces/src/chrome-trace-arrow-parser.ts
@@ -78,6 +78,9 @@ export async function* parseChromeTraceToArrowRecordBatches(
   let tokenizedEventCount = 0;
   const textDecoder = new TextDecoder();
 
+  /**
+   * Appends tokenized events and returns batches ready for deferred emission.
+   */
   const appendTokenizedEvents = (events: ChromeTraceEventSchema[]): ChromeTraceEventSchema[][] => {
     const readyBatches: ChromeTraceEventSchema[][] = [];
     if (events.length === 0) {

--- a/modules/traces/src/chrome-trace-json-stream.ts
+++ b/modules/traces/src/chrome-trace-json-stream.ts
@@ -8,10 +8,14 @@ import type {ChromeTraceEventSchema, ChromeTraceFileSchema} from './chrome-trace
  * Incremental tokenizer state for one streamed Chrome trace JSON file.
  */
 export type ChromeTraceFileTokenizer = {
+  /** Incremental UTF-8 decoder for binary source chunks. */
+  textDecoder: TextDecoder;
   /** Remaining undecoded text buffer. */
   buffer: string;
   /** Whether parsing has reached the `traceEvents` array. */
   insideTraceEventsArray: boolean;
+  /** Whether the trace-events array has been fully consumed. */
+  traceEventsArrayFinished: boolean;
   /** Whether parsing is currently inside a JSON string literal. */
   insideString: boolean;
   /** Whether the current string parser is escaping the next character. */
@@ -31,8 +35,10 @@ export function createChromeTraceFileTokenizer(
   displayTimeUnit: string | undefined
 ): ChromeTraceFileTokenizer {
   return {
+    textDecoder: new TextDecoder(),
     buffer: '',
     insideTraceEventsArray: false,
+    traceEventsArrayFinished: false,
     insideString: false,
     escapingCharacter: false,
     objectDepth: 0,
@@ -48,7 +54,7 @@ export function appendChromeTraceFileChunk(
   tokenizer: ChromeTraceFileTokenizer,
   chunk: string | ArrayBufferLike | ArrayBufferView
 ): ChromeTraceEventSchema[] {
-  tokenizer.buffer += decodeChromeTraceChunk(chunk);
+  tokenizer.buffer += decodeChromeTraceChunk(tokenizer, chunk);
   maybeExtractChromeTraceDisplayTimeUnit(tokenizer);
   return extractChromeTraceEventsFromTokenizer(tokenizer);
 }
@@ -68,18 +74,22 @@ export function tryParseChromeTraceFileText(text: string): ChromeTraceFileSchema
 /**
  * Decodes one streamed chunk into UTF-8 text.
  */
-function decodeChromeTraceChunk(chunk: string | ArrayBufferLike | ArrayBufferView): string {
+function decodeChromeTraceChunk(
+  tokenizer: ChromeTraceFileTokenizer,
+  chunk: string | ArrayBufferLike | ArrayBufferView
+): string {
   if (typeof chunk === 'string') {
-    return chunk;
+    return tokenizer.textDecoder.decode() + chunk;
   }
 
   if (ArrayBuffer.isView(chunk)) {
-    return new TextDecoder().decode(
-      new Uint8Array(chunk.buffer, chunk.byteOffset, chunk.byteLength)
+    return tokenizer.textDecoder.decode(
+      new Uint8Array(chunk.buffer, chunk.byteOffset, chunk.byteLength),
+      {stream: true}
     );
   }
 
-  return new TextDecoder().decode(new Uint8Array(chunk));
+  return tokenizer.textDecoder.decode(new Uint8Array(chunk), {stream: true});
 }
 
 /**
@@ -105,6 +115,9 @@ function extractChromeTraceEventsFromTokenizer(
   const parsedEvents: ChromeTraceEventSchema[] = [];
 
   if (!tokenizer.insideTraceEventsArray) {
+    if (tokenizer.traceEventsArrayFinished) {
+      return parsedEvents;
+    }
     const traceEventsKeyIndex = tokenizer.buffer.indexOf('"traceEvents"');
     const traceEventsArrayIndex =
       traceEventsKeyIndex >= 0 ? tokenizer.buffer.indexOf('[', traceEventsKeyIndex) : -1;
@@ -144,6 +157,8 @@ function extractChromeTraceEventsFromTokenizer(
         tokenizer.objectDepth = 1;
       } else if (character === ']') {
         trimIndex = index + 1;
+        tokenizer.traceEventsArrayFinished = true;
+        tokenizer.insideTraceEventsArray = false;
         break;
       }
       continue;
@@ -172,6 +187,14 @@ function extractChromeTraceEventsFromTokenizer(
   if (tokenizer.objectStartIndex != null) {
     tokenizer.buffer = tokenizer.buffer.slice(tokenizer.objectStartIndex);
     tokenizer.objectStartIndex = 0;
+    tokenizer.objectDepth = 0;
+    tokenizer.insideString = false;
+    tokenizer.escapingCharacter = false;
+    return parsedEvents;
+  }
+
+  if (tokenizer.traceEventsArrayFinished) {
+    tokenizer.buffer = '';
     return parsedEvents;
   }
 

--- a/modules/traces/src/parse-chrome-trace.ts
+++ b/modules/traces/src/parse-chrome-trace.ts
@@ -173,7 +173,13 @@ export function parseChromeTrace(
       case 'f': {
         const flowScope = event.s ?? event.scope ?? 't';
         const flowId = event.id != null ? String(event.id) : `${event.name}:${event.bind_id ?? ''}`;
-        const eventKey = `${flowScope}:${flowId}`;
+        const flowScopeKey =
+          flowScope === 'g'
+            ? 'g'
+            : flowScope === 'p'
+              ? `p:${processId}`
+              : `t:${processId}:${threadId}`;
+        const eventKey = `${flowScopeKey}:${flowId}`;
 
         thread.flows.push({
           id: `${eventKey}:${event.ph}:${eventTimestamp}`,

--- a/modules/traces/src/parse-chrome-trace.ts
+++ b/modules/traces/src/parse-chrome-trace.ts
@@ -152,7 +152,7 @@ export function parseChromeTrace(
           trackId,
           name: event.name,
           atMs: eventTimeMs,
-          scope: (event.scope ?? event.s ?? 't') as 'g' | 'p' | 't',
+          scope: (event.scope ?? event.s ?? 't'),
           userData: event.args
         } satisfies ChromeTraceInstant);
         break;
@@ -170,18 +170,23 @@ export function parseChromeTrace(
 
       case 's':
       case 't':
-      case 'f':
+      case 'f': {
+        const flowScope = event.s ?? event.scope ?? 't';
+        const flowId = event.id != null ? String(event.id) : `${event.name}:${event.bind_id ?? ''}`;
+        const eventKey = `${flowScope}:${flowId}`;
+
         thread.flows.push({
-          id: `${trackId}:${event.name}:${eventTimestamp}`,
+          id: `${eventKey}:${event.ph}:${eventTimestamp}`,
           bindId: String(event.bind_id ?? ''),
           kind: event.ph === 's' ? 'start' : event.ph === 't' ? 'step' : 'end',
-          eventKey: `${trackId}:${event.name}`,
+          eventKey,
           trackId,
           atMs: eventTimeMs,
           name: event.name,
           userData: event.args
         } satisfies ChromeTraceFlow);
         break;
+      }
 
       case 'M': {
         const metadataName = getChromeTraceMetadataName(event.args);

--- a/modules/traces/src/parse-chrome-trace.ts
+++ b/modules/traces/src/parse-chrome-trace.ts
@@ -152,7 +152,7 @@ export function parseChromeTrace(
           trackId,
           name: event.name,
           atMs: eventTimeMs,
-          scope: (event.scope ?? event.s ?? 't'),
+          scope: event.scope ?? event.s ?? 't',
           userData: event.args
         } satisfies ChromeTraceInstant);
         break;

--- a/modules/traces/test/chrome-trace-stream.cross.spec.ts
+++ b/modules/traces/test/chrome-trace-stream.cross.spec.ts
@@ -298,7 +298,7 @@ describe('chrome-trace-stream', () => {
     const table = await parseChromeTraceArrowTable(traceFile);
 
     async function* tableSource() {
-      yield table as arrow.Table;
+      yield table;
     }
 
     const chunks: TraceStreamChunk[] = [];
@@ -319,5 +319,31 @@ describe('chrome-trace-stream', () => {
       id: 77,
       s: 'p'
     });
+  });
+
+  it('preserves UTF-8 text and partial events across binary chunk boundaries', async () => {
+    const traceFile: ChromeTraceFileSchema = {
+      traceEvents: [
+        {name: 'é', ph: 'X', pid: 1, tid: 1, ts: 1, dur: 1, args: {label: 'é'}},
+        {name: 'second', ph: 'X', pid: 1, tid: 1, ts: 2, dur: 1, args: {nested: {ok: true}}}
+      ]
+    };
+    const bytes = new TextEncoder().encode(JSON.stringify(traceFile));
+
+    async function* source(): AsyncIterable<Uint8Array> {
+      for (let startIndex = 0; startIndex < bytes.length; startIndex += 7) {
+        yield bytes.slice(startIndex, startIndex + 7);
+      }
+    }
+
+    const batches = [];
+    for await (const batch of parseInBatches(source(), ChromeTraceLoader, {
+      chromeTrace: {shape: 'arrow-table', batchSize: 1}
+    })) {
+      batches.push(batch as arrow.RecordBatch);
+    }
+
+    expect(batches.map(batch => batch.getChild('name')?.get(0))).toEqual(['é', 'second']);
+    expect(batches[0].getChild('args')?.get(0)).toBe('{"label":"é"}');
   });
 });

--- a/modules/traces/test/chrome-trace-stream.cross.spec.ts
+++ b/modules/traces/test/chrome-trace-stream.cross.spec.ts
@@ -165,7 +165,7 @@ describe('chrome-trace-stream', () => {
 
     expect(snapshot?.name).toBe('streamed-events');
     expect(
-      snapshot?.trace.processes.flatMap(process => process.threads.flatMap(thread => thread.spans))
+      snapshot?.trace.processes.flatMap(process => process.threads).flatMap(thread => thread.spans)
     ).toHaveLength(2);
     expect(snapshots.length).toBeGreaterThanOrEqual(2);
   });
@@ -268,9 +268,9 @@ describe('chrome-trace-stream', () => {
     expect(
       chunks
         .at(-1)
-        ?.replaceSnapshot?.trace.processes.flatMap(process =>
-          process.threads.flatMap(thread => thread.spans)
-        )
+        ?.replaceSnapshot?.trace.processes
+        .flatMap(process => process.threads)
+        .flatMap(thread => thread.spans)
     ).toHaveLength(2);
   });
 

--- a/modules/traces/test/chrome-trace-stream.cross.spec.ts
+++ b/modules/traces/test/chrome-trace-stream.cross.spec.ts
@@ -268,8 +268,7 @@ describe('chrome-trace-stream', () => {
     expect(
       chunks
         .at(-1)
-        ?.replaceSnapshot?.trace.processes
-        .flatMap(process => process.threads)
+        ?.replaceSnapshot?.trace.processes.flatMap(process => process.threads)
         .flatMap(thread => thread.spans)
     ).toHaveLength(2);
   });
@@ -337,7 +336,7 @@ describe('chrome-trace-stream', () => {
     }
 
     const batches = [];
-    for await (const batch of parseInBatches(source(), ChromeTraceLoader, {
+    for await (const batch of await parseInBatches(source(), ChromeTraceLoader, {
       chromeTrace: {shape: 'arrow-table', batchSize: 1}
     })) {
       batches.push(batch as arrow.RecordBatch);


### PR DESCRIPTION
Goals

- Apply the Chrome Trace streaming correctness fixes to master as well as the 4.5 backport.

Changes

- Preserve tokenizer state when an event spans chunks.
- Decode UTF-8 incrementally across binary chunk boundaries.
- Stop tokenizing after the traceEvents array closes.
- Correlate flow records by source flow id and scope.
- Add focused stream regression coverage.