### PR TITLE
feat(mvt): backport MapStyleLoader to 4.5

### DIFF
--- a/docs/modules/mvt/README.md
+++ b/docs/modules/mvt/README.md
@@ -15,8 +15,18 @@ npm install @loaders.gl/core
 
 | Loader / Writer                                           |
 | --------------------------------------------------------- |
+| [`MapStyleLoader`](/docs/modules/mvt/api-reference/map-style-loader) |
 | [`MVTLoader`](/docs/modules/mvt/api-reference/mvt-loader) |
+| [`TileJSONLoader`](/docs/modules/mvt/api-reference/tilejson-loader) |
 | [`MVTWriter`](/docs/modules/mvt/api-reference/mvt-writer) |
+
+## Formats
+
+| Format |
+| ------ |
+| [`Map Styles`](/docs/modules/mvt/formats/map-style) |
+| [`MVT`](/docs/modules/mvt/formats/mvt) |
+| [`TileJSON`](/docs/modules/mvt/formats/tilejson) |
 
 ## Sources
 

--- a/docs/modules/mvt/README.md
+++ b/docs/modules/mvt/README.md
@@ -13,20 +13,20 @@ npm install @loaders.gl/core
 
 ## Loaders and Writers
 
-| Loader / Writer                                           |
-| --------------------------------------------------------- |
+| Loader / Writer                                                      |
+| -------------------------------------------------------------------- |
 | [`MapStyleLoader`](/docs/modules/mvt/api-reference/map-style-loader) |
-| [`MVTLoader`](/docs/modules/mvt/api-reference/mvt-loader) |
-| [`TileJSONLoader`](/docs/modules/mvt/api-reference/tilejson-loader) |
-| [`MVTWriter`](/docs/modules/mvt/api-reference/mvt-writer) |
+| [`MVTLoader`](/docs/modules/mvt/api-reference/mvt-loader)            |
+| [`TileJSONLoader`](/docs/modules/mvt/api-reference/tilejson-loader)  |
+| [`MVTWriter`](/docs/modules/mvt/api-reference/mvt-writer)            |
 
 ## Formats
 
-| Format |
-| ------ |
+| Format                                              |
+| --------------------------------------------------- |
 | [`Map Styles`](/docs/modules/mvt/formats/map-style) |
-| [`MVT`](/docs/modules/mvt/formats/mvt) |
-| [`TileJSON`](/docs/modules/mvt/formats/tilejson) |
+| [`MVT`](/docs/modules/mvt/formats/mvt)              |
+| [`TileJSON`](/docs/modules/mvt/formats/tilejson)    |
 
 ## Sources
 

--- a/docs/modules/mvt/api-reference/map-style-loader.md
+++ b/docs/modules/mvt/api-reference/map-style-loader.md
@@ -1,0 +1,197 @@
+# MapStyleLoader
+
+<p class="badges">
+  <img src="https://img.shields.io/badge/From-v4.4-blue.svg?style=flat-square" alt="From-v4.4" />
+</p>
+
+The `MapStyleLoader` parses MapLibre / Mapbox style JSON and returns a normalized style object with
+resolved tile-source metadata.
+
+It is designed for applications that need to inspect style documents, derive tile endpoints, or
+bridge style metadata into other runtimes such as deck.gl tile workflows.
+
+| Loader                | Characteristic                                           |
+| --------------------- | -------------------------------------------------------- |
+| File Extension        | `.json`                                                  |
+| File Type             | Text                                                     |
+| File Format           | [Map Styles](/docs/modules/mvt/formats/map-style)        |
+| Data Format           | `ResolvedMapStyle`                                       |
+| Decoder Type          | Asynchronous                                             |
+| Worker Thread Support | No                                                       |
+| Streaming Support     | No                                                       |
+
+## Usage
+
+```typescript
+import {load} from '@loaders.gl/core';
+import {MapStyleLoader} from '@loaders.gl/mvt';
+
+const style = await load('https://example.com/styles/base/style.json', MapStyleLoader);
+```
+
+With explicit URL resolution options:
+
+```typescript
+import {parse} from '@loaders.gl/core';
+import {MapStyleLoader} from '@loaders.gl/mvt';
+
+const style = await parse(styleJsonText, MapStyleLoader, {
+  mapStyle: {
+    baseUrl: 'https://example.com/styles/base/style.json',
+    fetch: customFetch,
+    fetchOptions: {headers: {'x-token': token}}
+  }
+});
+```
+
+Direct style resolution without the loader:
+
+```typescript
+import {resolveMapStyle} from '@loaders.gl/mvt';
+
+const style = await resolveMapStyle('https://example.com/styles/base/style.json');
+```
+
+## What the loader resolves
+
+`MapStyleLoader`:
+
+- parses the style JSON
+- preserves unknown fields on the style, sources, and layers
+- resolves relative `sources.*.url` values
+- fetches TileJSON documents referenced from `sources.*.url`
+- merges fetched TileJSON fields into the source
+- resolves `sources.*.tiles[]` entries relative to the correct base URL
+- guarantees that `sources` and `layers` are present in the returned object
+
+It does not fetch or expand other style sub resources such as:
+
+- `sprite`
+- `glyphs`
+- external images referenced by renderer-specific metadata
+
+Those fields remain untouched in the returned metadata.
+
+## Returned Data Format
+
+The loader returns a `ResolvedMapStyle` object.
+
+```typescript
+type ResolvedMapStyle = MapStyle & {
+  sources: Record<string, MapStyleSource>;
+  layers: MapStyleLayer[];
+};
+```
+
+### `MapStyle`
+
+```typescript
+type MapStyle = {
+  version?: number;
+  metadata?: Record<string, unknown>;
+  sources?: Record<string, MapStyleSource>;
+  layers?: MapStyleLayer[];
+  [key: string]: unknown;
+};
+```
+
+### `MapStyleSource`
+
+```typescript
+type MapStyleSource = {
+  type?: string;
+  url?: string;
+  tiles?: string[];
+  minzoom?: number;
+  maxzoom?: number;
+  tileSize?: number;
+  [key: string]: unknown;
+};
+```
+
+### `MapStyleLayer`
+
+```typescript
+type MapStyleLayer = {
+  id: string;
+  type: string;
+  source?: string;
+  'source-layer'?: string;
+  minzoom?: number;
+  maxzoom?: number;
+  filter?: unknown[];
+  paint?: Record<string, unknown>;
+  layout?: Record<string, unknown>;
+  [key: string]: unknown;
+};
+```
+
+## Example Returned Object
+
+```json
+{
+  "version": 8,
+  "sources": {
+    "basemap": {
+      "type": "vector",
+      "url": "https://example.com/styles/basemap.tilejson",
+      "tiles": ["https://example.com/styles/tiles/{z}/{x}/{y}.pbf"],
+      "minzoom": 0,
+      "maxzoom": 14
+    }
+  },
+  "layers": [
+    {
+      "id": "water",
+      "type": "fill",
+      "source": "basemap",
+      "source-layer": "water"
+    }
+  ]
+}
+```
+
+Two details matter here:
+
+- `sources` and `layers` are always initialized, even when omitted in the input
+- source URLs and tile templates are already normalized, so downstream code can use them directly
+
+## Options
+
+`MapStyleLoader` uses the `mapStyle` namespaced option group.
+
+| Option                  | Type             | Default | Description |
+| ----------------------- | ---------------- | ------- | ----------- |
+| `mapStyle.baseUrl`      | `string`         | `null`  | Base URL used to resolve relative source URLs and tile templates for in-memory styles. |
+| `mapStyle.fetch`        | `typeof fetch`   | global `fetch` | Fetch implementation used to load the style URL and source sub resources. |
+| `mapStyle.fetchOptions` | `RequestInit`    | `null`  | Request options forwarded to the selected fetch implementation. |
+
+## Resolution Rules
+
+When a source contains:
+
+```json
+{
+  "url": "./basemap.tilejson"
+}
+```
+
+the loader resolves it against the base style URL. If that TileJSON contains:
+
+```json
+{
+  "tiles": ["./tiles/{z}/{x}/{y}.pbf"]
+}
+```
+
+those tile templates are then resolved against the fetched TileJSON URL, not against the original
+style URL.
+
+This two-step resolution is the main reason to use `MapStyleLoader` instead of parsing the JSON
+manually.
+
+## Related APIs
+
+- [`TileJSONLoader`](/docs/modules/mvt/api-reference/tilejson-loader)
+- [`MVTSource`](/docs/modules/mvt/api-reference/mvt-source)
+- [`Map Styles`](/docs/modules/mvt/formats/map-style)

--- a/docs/modules/mvt/api-reference/map-style-loader.md
+++ b/docs/modules/mvt/api-reference/map-style-loader.md
@@ -10,15 +10,15 @@ resolved tile-source metadata.
 It is designed for applications that need to inspect style documents, derive tile endpoints, or
 bridge style metadata into other runtimes such as deck.gl tile workflows.
 
-| Loader                | Characteristic                                           |
-| --------------------- | -------------------------------------------------------- |
-| File Extension        | `.json`                                                  |
-| File Type             | Text                                                     |
-| File Format           | [Map Styles](/docs/modules/mvt/formats/map-style)        |
-| Data Format           | `ResolvedMapStyle`                                       |
-| Decoder Type          | Asynchronous                                             |
-| Worker Thread Support | No                                                       |
-| Streaming Support     | No                                                       |
+| Loader                | Characteristic                                    |
+| --------------------- | ------------------------------------------------- |
+| File Extension        | `.json`                                           |
+| File Type             | Text                                              |
+| File Format           | [Map Styles](/docs/modules/mvt/formats/map-style) |
+| Data Format           | `ResolvedMapStyle`                                |
+| Decoder Type          | Asynchronous                                      |
+| Worker Thread Support | No                                                |
+| Streaming Support     | No                                                |
 
 ## Usage
 
@@ -160,11 +160,11 @@ Two details matter here:
 
 `MapStyleLoader` uses the `mapStyle` namespaced option group.
 
-| Option                  | Type             | Default | Description |
-| ----------------------- | ---------------- | ------- | ----------- |
-| `mapStyle.baseUrl`      | `string`         | `null`  | Base URL used to resolve relative source URLs and tile templates for in-memory styles. |
-| `mapStyle.fetch`        | `typeof fetch`   | global `fetch` | Fetch implementation used to load the style URL and source sub resources. |
-| `mapStyle.fetchOptions` | `RequestInit`    | `null`  | Request options forwarded to the selected fetch implementation. |
+| Option                  | Type           | Default        | Description                                                                            |
+| ----------------------- | -------------- | -------------- | -------------------------------------------------------------------------------------- |
+| `mapStyle.baseUrl`      | `string`       | `null`         | Base URL used to resolve relative source URLs and tile templates for in-memory styles. |
+| `mapStyle.fetch`        | `typeof fetch` | global `fetch` | Fetch implementation used to load the style URL and source sub resources.              |
+| `mapStyle.fetchOptions` | `RequestInit`  | `null`         | Request options forwarded to the selected fetch implementation.                        |
 
 ## Resolution Rules
 

--- a/docs/modules/mvt/api-reference/map-style-loader.md
+++ b/docs/modules/mvt/api-reference/map-style-loader.md
@@ -1,7 +1,7 @@
 # MapStyleLoader
 
 <p class="badges">
-  <img src="https://img.shields.io/badge/From-v4.4-blue.svg?style=flat-square" alt="From-v4.4" />
+  <img src="https://img.shields.io/badge/From-v4.5-blue.svg?style=flat-square" alt="From-v4.5" />
 </p>
 
 The `MapStyleLoader` parses MapLibre / Mapbox style JSON and returns a normalized style object with
@@ -114,7 +114,7 @@ type MapStyleSource = {
 ```typescript
 type MapStyleLayer = {
   id: string;
-  type: string;
+  type?: string;
   source?: string;
   'source-layer'?: string;
   minzoom?: number;
@@ -160,11 +160,11 @@ Two details matter here:
 
 `MapStyleLoader` uses the `mapStyle` namespaced option group.
 
-| Option                  | Type           | Default        | Description                                                                            |
-| ----------------------- | -------------- | -------------- | -------------------------------------------------------------------------------------- |
-| `mapStyle.baseUrl`      | `string`       | `null`         | Base URL used to resolve relative source URLs and tile templates for in-memory styles. |
-| `mapStyle.fetch`        | `typeof fetch` | global `fetch` | Fetch implementation used to load the style URL and source sub resources.              |
-| `mapStyle.fetchOptions` | `RequestInit`  | `null`         | Request options forwarded to the selected fetch implementation.                        |
+| Option                  | Type           | Default        | Description                                                                                                                                 |
+| ----------------------- | -------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `mapStyle.baseUrl`      | `string`       | `null`         | Base URL used to resolve relative source URLs and tile templates for in-memory styles.                                                      |
+| `mapStyle.fetch`        | `typeof fetch` | global `fetch` | Fetch implementation used for source subresources and direct `resolveMapStyle()` calls. For the initial `load()` request, use `core.fetch`. |
+| `mapStyle.fetchOptions` | `RequestInit`  | `null`         | Request options forwarded to the selected fetch implementation.                                                                             |
 
 ## Resolution Rules
 

--- a/docs/modules/mvt/formats/map-style.md
+++ b/docs/modules/mvt/formats/map-style.md
@@ -1,0 +1,171 @@
+# Map Styles
+
+- _[`@loaders.gl/mvt`](/docs/modules/mvt)_
+- _[Mapbox Style Specification](https://docs.mapbox.com/style-spec/guides/)_
+- _[MapLibre Style Specification](https://maplibre.org/maplibre-style-spec/)_
+
+## Overview
+
+A map style document is a JSON file that describes how a tiled basemap should be assembled and
+styled. It does not contain the tile data itself. Instead, it points at tile sources and defines
+an ordered layer list that tells a renderer which source to read from and how to draw each layer.
+
+`MapStyleLoader` in loaders.gl focuses on the metadata and resource resolution part of the format:
+
+- parsing style JSON
+- resolving relative source URLs
+- dereferencing TileJSON-backed sources
+- normalizing tile template URLs so downstream code can fetch tiles directly
+
+It does not implement the full style rendering model. Expressions, paint rules, symbol placement,
+fonts, sprites, and renderer-specific behavior are preserved as metadata for an application to use.
+
+## Main Sections
+
+### Top-level metadata
+
+Common top-level fields include:
+
+- `version`: style-spec version, typically `8`
+- `name`: human-readable style name
+- `metadata`: implementation-specific metadata bag
+- `center`, `zoom`, `bearing`, `pitch`: default camera hints
+- `sprite`: sprite sheet base URL
+- `glyphs`: font glyph URL template
+
+These fields describe the style document itself and often contain additional sub resources that a
+renderer may need later.
+
+### `sources`
+
+`sources` is a dictionary keyed by source id. Each source describes where tile data or imagery
+comes from.
+
+Common source fields include:
+
+- `type`: source kind such as `vector`, `raster`, `raster-dem`, `geojson`, or `image`
+- `tiles`: direct tile URL templates
+- `url`: an indirection URL, commonly a TileJSON document
+- `minzoom`, `maxzoom`
+- `tileSize`
+- format-specific fields such as `bounds`, `scheme`, `attribution`, or custom metadata
+
+For loaders.gl, `sources` is the critical section because it determines which sub resources must be
+resolved before the style is immediately usable.
+
+### `layers`
+
+`layers` is an ordered array. Each entry references a source and describes how a logical layer
+should be rendered.
+
+Common layer fields include:
+
+- `id`
+- `type`
+- `source`
+- `source-layer`
+- `minzoom`, `maxzoom`
+- `filter`
+- `layout`
+- `paint`
+
+Layer order matters. Even when loaders.gl is not rendering the style directly, preserving layer
+order and metadata is important because applications often inspect this list to decide which tile
+layers to load or how to configure a renderer.
+
+## Sub Resources
+
+A style document often depends on additional resources:
+
+- TileJSON documents referenced from `sources.*.url`
+- tile templates referenced from `sources.*.tiles`
+- sprite manifests and sprite images from `sprite`
+- font glyph PBF ranges from `glyphs`
+- images, models, or other renderer-specific assets referenced through metadata or extensions
+
+`MapStyleLoader` currently resolves only the tile-source side of this graph:
+
+- the top-level style JSON itself
+- any source `url` values
+- any `tiles` arrays found in the source or fetched TileJSON
+
+Other resources such as sprites and glyphs remain untouched in the returned object.
+
+## Resolution Complications
+
+### Relative URL resolution
+
+Style files frequently use relative paths:
+
+```json
+{
+  "sources": {
+    "basemap": {
+      "type": "vector",
+      "url": "./tileset.tilejson"
+    }
+  },
+  "glyphs": "./fonts/{fontstack}/{range}.pbf"
+}
+```
+
+Those paths are ambiguous without a base URL. loaders.gl resolves source URLs against:
+
+1. `mapStyle.baseUrl` when provided
+2. the loader context URL when the style was loaded from a URL or file
+3. the fetched style URL itself when `resolveMapStyle(styleUrl)` is used
+
+### TileJSON indirection
+
+Many styles do not list tile templates directly. Instead, a source points at TileJSON:
+
+```json
+{
+  "sources": {
+    "basemap": {
+      "type": "vector",
+      "url": "https://example.com/basemap.tilejson"
+    }
+  }
+}
+```
+
+That TileJSON may itself contain relative `tiles` entries. In that case there are two resolution
+steps:
+
+1. resolve the TileJSON URL relative to the style
+2. resolve the TileJSON `tiles` entries relative to the fetched TileJSON URL
+
+This second hop is why applications often end up with broken tile requests if they only resolve the
+style URL and forget that the sub resource can introduce a new base path.
+
+### Partial specification support
+
+The style specification is broad. Some fields are renderer-level semantics rather than loader-level
+metadata. loaders.gl preserves unknown fields, but it only validates and normalizes the portions
+needed to make tile sources consumable.
+
+### Mixed source shapes
+
+Not every source looks the same:
+
+- direct `tiles` arrays
+- `url` indirection through TileJSON
+- non-tile sources such as inline GeoJSON
+- renderer extensions with extra metadata
+
+`MapStyleLoader` keeps the returned source objects permissive so these variants survive intact after
+parsing.
+
+## Returned Shape in loaders.gl
+
+loaders.gl returns a normalized object with:
+
+- all original style fields preserved
+- `sources` always present as an object
+- `layers` always present as an array
+- fetched TileJSON fields merged into the corresponding source
+- resolved absolute URLs in `source.url` and `source.tiles[]`
+
+See [`MapStyleLoader`](/docs/modules/mvt/api-reference/map-style-loader) for the exact returned
+data format.

--- a/modules/mvt/README.md
+++ b/modules/mvt/README.md
@@ -4,6 +4,11 @@ This module contains a geometry loader for Mapbox Vector Tiles (MVT) and a write
 
 [loaders.gl](https://loaders.gl/docs) is a collection of framework-independent visualization-focused loaders (parsers).
 
+## Metadata
+
+Use `TileJSONLoader` to parse tileset metadata and `MapStyleLoader` to parse MapLibre / Mapbox
+style JSON into a normalized style document with resolved source URLs and tile templates.
+
 ## Writing
 
 Use the `MVTWriter` with `@loaders.gl/core`'s `encode` helper to serialize GeoJSON into a Mapbox Vector Tile `ArrayBuffer`.

--- a/modules/mvt/package.json
+++ b/modules/mvt/package.json
@@ -51,7 +51,8 @@
     "@loaders.gl/schema-utils": "4.5.0-alpha.2",
     "@math.gl/polygon": "^4.1.0",
     "@probe.gl/stats": "^4.1.1",
-    "pbf": "^3.2.1"
+    "pbf": "^3.2.1",
+    "zod": "^4.1.12"
   },
   "devDependencies": {
     "@types/pbf": "^3.0.2"

--- a/modules/mvt/src/index.ts
+++ b/modules/mvt/src/index.ts
@@ -8,6 +8,19 @@ export {TileJSONLoader} from './tilejson-loader';
 export type {TileJSONLoaderOptions} from './tilejson-loader';
 export type {TileJSON} from './lib/parse-tilejson';
 
+// MapStyleLoader
+
+export {MapStyleLoader} from './map-style-loader';
+export {MapStyleSchema, ResolvedMapStyleSchema} from './map-style-schema';
+export {
+  resolveMapStyle,
+  type MapStyle,
+  type MapStyleLayer,
+  type MapStyleLoadOptions,
+  type MapStyleSource,
+  type ResolvedMapStyle
+} from './map-style';
+
 // MVTLoader
 
 export {MVTLoader, MVTWorkerLoader} from './mvt-loader';

--- a/modules/mvt/src/map-style-loader.ts
+++ b/modules/mvt/src/map-style-loader.ts
@@ -1,0 +1,50 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {LoaderContext, LoaderWithParser} from '@loaders.gl/loader-utils';
+import {ResolvedMapStyleSchema} from './map-style-schema';
+import {
+  getMapStyleLoadOptions,
+  resolveMapStyle,
+  type MapStyle,
+  type MapStyleLoadOptions,
+  type ResolvedMapStyle
+} from './map-style';
+
+// __VERSION__ is injected by babel-plugin-version-inline
+// @ts-ignore TS2304: Cannot find name '__VERSION__'.
+const VERSION = typeof __VERSION__ !== 'undefined' ? __VERSION__ : 'latest';
+
+/**
+ * Loader for MapLibre / Mapbox style JSON metadata.
+ */
+export const MapStyleLoader = {
+  dataType: null as unknown as ResolvedMapStyle,
+  batchType: null as never,
+
+  name: 'Map Style',
+  id: 'map-style',
+  module: 'mvt',
+  version: VERSION,
+  worker: false,
+  extensions: ['json'],
+  mimeTypes: ['application/json', 'application/vnd.mapbox.style+json'],
+  text: true,
+  options: {
+    mapStyle: {}
+  },
+  parse: async (
+    arrayBuffer: ArrayBuffer,
+    options?: MapStyleLoadOptions,
+    context?: LoaderContext
+  ) => {
+    const text = new TextDecoder().decode(arrayBuffer);
+    const style = JSON.parse(text) as MapStyle;
+    const resolvedStyle = await resolveMapStyle(style, {
+      ...options,
+      mapStyle: getMapStyleLoadOptions(options, context)
+    });
+    return ResolvedMapStyleSchema.parse(resolvedStyle);
+  }
+} as const satisfies LoaderWithParser<ResolvedMapStyle, never, MapStyleLoadOptions>;

--- a/modules/mvt/src/map-style-loader.ts
+++ b/modules/mvt/src/map-style-loader.ts
@@ -40,11 +40,24 @@ export const MapStyleLoader = {
     context?: LoaderContext
   ) => {
     const text = new TextDecoder().decode(arrayBuffer);
-    const style = JSON.parse(text) as MapStyle;
-    const resolvedStyle = await resolveMapStyle(style, {
-      ...options,
-      mapStyle: getMapStyleLoadOptions(options, context)
-    });
-    return ResolvedMapStyleSchema.parse(resolvedStyle);
-  }
+    return parseMapStyleText(text, options, context);
+  },
+  parseText: async (text: string, options?: MapStyleLoadOptions, context?: LoaderContext) =>
+    parseMapStyleText(text, options, context)
 } as const satisfies LoaderWithParser<ResolvedMapStyle, never, MapStyleLoadOptions>;
+
+/**
+ * Parses and resolves a MapLibre / Mapbox style JSON document.
+ */
+async function parseMapStyleText(
+  text: string,
+  options?: MapStyleLoadOptions,
+  context?: LoaderContext
+): Promise<ResolvedMapStyle> {
+  const style = JSON.parse(text) as MapStyle;
+  const resolvedStyle = await resolveMapStyle(style, {
+    ...options,
+    mapStyle: getMapStyleLoadOptions(options, context)
+  });
+  return ResolvedMapStyleSchema.parse(resolvedStyle);
+}

--- a/modules/mvt/src/map-style-schema.ts
+++ b/modules/mvt/src/map-style-schema.ts
@@ -1,0 +1,53 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {z} from 'zod';
+import type {MapStyle, MapStyleLayer, MapStyleSource, ResolvedMapStyle} from './map-style';
+
+const MapStyleSourceSchemaInternal = z
+  .object({
+    type: z.string().optional(),
+    url: z.string().optional(),
+    tiles: z.array(z.string()).optional(),
+    minzoom: z.number().optional(),
+    maxzoom: z.number().optional(),
+    tileSize: z.number().optional()
+  })
+  .catchall(z.unknown()) satisfies z.ZodType<MapStyleSource>;
+
+const MapStyleLayerSchemaInternal = z
+  .object({
+    id: z.string(),
+    type: z.string(),
+    source: z.string().optional(),
+    'source-layer': z.string().optional(),
+    minzoom: z.number().optional(),
+    maxzoom: z.number().optional(),
+    filter: z.array(z.unknown()).optional(),
+    paint: z.record(z.string(), z.unknown()).optional(),
+    layout: z.record(z.string(), z.unknown()).optional()
+  })
+  .catchall(z.unknown()) satisfies z.ZodType<MapStyleLayer>;
+
+/** Zod schema for a MapLibre / Mapbox style document. */
+export const MapStyleSchema = z
+  .object({
+    version: z.number().optional(),
+    metadata: z.record(z.string(), z.unknown()).optional(),
+    sources: z.record(z.string(), MapStyleSourceSchemaInternal).optional(),
+    layers: z.array(MapStyleLayerSchemaInternal).optional()
+  })
+  .catchall(z.unknown()) satisfies z.ZodType<MapStyle>;
+
+/** Zod schema for a fully resolved style document. */
+export const ResolvedMapStyleSchema = z
+  .object({
+    version: z.number().optional(),
+    metadata: z.record(z.string(), z.unknown()).optional(),
+    sources: z.record(z.string(), MapStyleSourceSchemaInternal),
+    layers: z.array(MapStyleLayerSchemaInternal)
+  })
+  .catchall(z.unknown()) satisfies z.ZodType<ResolvedMapStyle>;
+
+export const MapStyleSourceSchema = MapStyleSourceSchemaInternal;

--- a/modules/mvt/src/map-style-schema.ts
+++ b/modules/mvt/src/map-style-schema.ts
@@ -19,7 +19,7 @@ const MapStyleSourceSchemaInternal = z
 const MapStyleLayerSchemaInternal = z
   .object({
     id: z.string(),
-    type: z.string(),
+    type: z.string().optional(),
     source: z.string().optional(),
     'source-layer': z.string().optional(),
     minzoom: z.number().optional(),

--- a/modules/mvt/src/map-style.ts
+++ b/modules/mvt/src/map-style.ts
@@ -1,0 +1,215 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {LoaderContext, LoaderOptions} from '@loaders.gl/loader-utils';
+import {MapStyleSchema, MapStyleSourceSchema, ResolvedMapStyleSchema} from './map-style-schema';
+
+/**
+ * A style source entry from a MapLibre or Mapbox style document.
+ */
+export type MapStyleSource = {
+  /** Source kind such as `vector` or `raster`. */
+  type?: string;
+  /** Optional TileJSON URL used to resolve the source metadata. */
+  url?: string;
+  /** Inline tile templates for the source. */
+  tiles?: string[];
+  /** Minimum source zoom. */
+  minzoom?: number;
+  /** Maximum source zoom. */
+  maxzoom?: number;
+  /** Tile size in pixels. */
+  tileSize?: number;
+  /** Additional source properties are preserved verbatim. */
+  [key: string]: unknown;
+};
+
+/**
+ * A style layer entry.
+ */
+export type MapStyleLayer = {
+  /** Unique layer identifier. */
+  id: string;
+  /** Style layer type such as `background`, `fill`, `line`, `symbol`, or `raster`. */
+  type: string;
+  /** Referenced source identifier. */
+  source?: string;
+  /** Referenced vector source-layer identifier. */
+  'source-layer'?: string;
+  /** Optional minimum zoom. */
+  minzoom?: number;
+  /** Optional maximum zoom. */
+  maxzoom?: number;
+  /** Optional style-spec filter expression. */
+  filter?: unknown[];
+  /** Paint properties from the source style layer. */
+  paint?: Record<string, unknown>;
+  /** Layout properties from the source style layer. */
+  layout?: Record<string, unknown>;
+  /** Additional layer properties are preserved verbatim. */
+  [key: string]: unknown;
+};
+
+/**
+ * A MapLibre or Mapbox style document.
+ */
+export type MapStyle = {
+  /** Style-spec version number. */
+  version?: number;
+  /** Optional style metadata bag. */
+  metadata?: Record<string, unknown>;
+  /** Named source definitions used by the style. */
+  sources?: Record<string, MapStyleSource>;
+  /** Ordered list of style layers. */
+  layers?: MapStyleLayer[];
+  /** Additional style properties are preserved verbatim. */
+  [key: string]: unknown;
+};
+
+/**
+ * A style document after all sources have been normalized and TileJSON-backed sources resolved.
+ */
+export type ResolvedMapStyle = MapStyle & {
+  /** Fully resolved source definitions. */
+  sources: Record<string, MapStyleSource>;
+  /** Style layers copied into a mutable array. */
+  layers: MapStyleLayer[];
+};
+
+/**
+ * Load options accepted by {@link resolveMapStyle}.
+ */
+export type MapStyleLoadOptions = LoaderOptions & {
+  mapStyle?: {
+    /** Base URL used to resolve relative style source or tile URLs. */
+    baseUrl?: string;
+    /** Optional custom fetch implementation. */
+    fetch?: typeof fetch;
+    /** Optional init object passed to the selected fetch implementation. */
+    fetchOptions?: RequestInit;
+    /** Additional loader options are accepted for forward compatibility. */
+    [key: string]: unknown;
+  };
+};
+
+/**
+ * Extracts map style options from loader options and loader context.
+ */
+export function getMapStyleLoadOptions(
+  options?: MapStyleLoadOptions,
+  context?: LoaderContext
+): NonNullable<MapStyleLoadOptions['mapStyle']> {
+  return {
+    ...options?.mapStyle,
+    baseUrl: options?.mapStyle?.baseUrl || context?.url || context?.baseUrl,
+    fetch: options?.mapStyle?.fetch || (context?.fetch as typeof fetch | undefined)
+  };
+}
+
+/**
+ * Resolves a URL against the provided base URL.
+ */
+export function normalizeMapStyleUrl(url: string | undefined, baseUrl?: string): string | undefined {
+  if (!url) {
+    return url;
+  }
+
+  try {
+    return decodeURI(new URL(url, baseUrl).toString());
+  } catch {
+    return url;
+  }
+}
+
+/**
+ * Resolves all tile templates in a source against the provided base URL.
+ */
+export function normalizeMapStyleTiles(
+  tiles: string[] | undefined,
+  baseUrl?: string
+): string[] | undefined {
+  return Array.isArray(tiles)
+    ? tiles.map((tile) => normalizeMapStyleUrl(tile, baseUrl) || tile)
+    : tiles;
+}
+
+/**
+ * Fetches and parses a JSON resource.
+ */
+export async function fetchMapStyleJson(
+  url: string,
+  loadOptions?: NonNullable<MapStyleLoadOptions['mapStyle']>
+): Promise<unknown> {
+  const fetchFunction = loadOptions?.fetch || fetch;
+  const response = await fetchFunction(url, loadOptions?.fetchOptions);
+
+  if (!response.ok) {
+    throw new Error(`Failed to load map style resource: ${url} (${response.status})`);
+  }
+
+  return await response.json();
+}
+
+/**
+ * Resolves a single source, including optional TileJSON indirection.
+ */
+export async function resolveMapStyleSource(
+  source: MapStyleSource | undefined,
+  baseUrl: string | undefined,
+  loadOptions?: NonNullable<MapStyleLoadOptions['mapStyle']>
+): Promise<MapStyleSource | undefined> {
+  if (!source) {
+    return source;
+  }
+
+  const resolvedSource: MapStyleSource = {...source};
+  let sourceBaseUrl = baseUrl;
+
+  if (resolvedSource.url) {
+    const tileJsonUrl = normalizeMapStyleUrl(resolvedSource.url, baseUrl);
+    const tileJson = MapStyleSourceSchema.parse(
+      await fetchMapStyleJson(tileJsonUrl || resolvedSource.url, loadOptions)
+    );
+    Object.assign(resolvedSource, tileJson);
+    resolvedSource.url = tileJsonUrl;
+    sourceBaseUrl = tileJsonUrl;
+  }
+
+  if (resolvedSource.tiles) {
+    resolvedSource.tiles = normalizeMapStyleTiles(resolvedSource.tiles, sourceBaseUrl);
+  }
+
+  return resolvedSource;
+}
+
+/**
+ * Resolves a style input into a style object whose sources contain directly consumable tile
+ * templates and source metadata.
+ */
+export async function resolveMapStyle(
+  style: string | MapStyle,
+  options?: MapStyleLoadOptions
+): Promise<ResolvedMapStyle> {
+  const mapStyleOptions = getMapStyleLoadOptions(options);
+  const styleDefinition = MapStyleSchema.parse(
+    typeof style === 'string'
+      ? await fetchMapStyleJson(style, mapStyleOptions)
+      : structuredClone(style)
+  );
+  const baseUrl = typeof style === 'string' ? style : mapStyleOptions.baseUrl;
+  const resolvedSources: Record<string, MapStyleSource> = {};
+
+  await Promise.all(
+    Object.entries(styleDefinition.sources || {}).map(async ([sourceId, source]) => {
+      resolvedSources[sourceId] =
+        (await resolveMapStyleSource(source, baseUrl, mapStyleOptions)) || {};
+    })
+  );
+
+  return ResolvedMapStyleSchema.parse({
+    ...styleDefinition,
+    sources: resolvedSources,
+    layers: [...(styleDefinition.layers || [])]
+  });
+}

--- a/modules/mvt/src/map-style.ts
+++ b/modules/mvt/src/map-style.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import type {LoaderContext, LoaderOptions} from '@loaders.gl/loader-utils';
+import {path, type LoaderContext, type LoaderOptions} from '@loaders.gl/loader-utils';
 import {MapStyleSchema, MapStyleSourceSchema, ResolvedMapStyleSchema} from './map-style-schema';
 
 /**
@@ -31,8 +31,8 @@ export type MapStyleSource = {
 export type MapStyleLayer = {
   /** Unique layer identifier. */
   id: string;
-  /** Style layer type such as `background`, `fill`, `line`, `symbol`, or `raster`. */
-  type: string;
+  /** Style layer type, omitted for layers that use the style-spec `ref` property. */
+  type?: string;
   /** Referenced source identifier. */
   source?: string;
   /** Referenced vector source-layer identifier. */
@@ -118,11 +118,23 @@ export function normalizeMapStyleUrl(
     return url;
   }
 
+  if (isAbsoluteFilePath(baseUrl)) {
+    const basePath = baseUrl.endsWith('/') ? baseUrl : path.dirname(baseUrl);
+    return path.resolve(basePath, url);
+  }
+
   try {
     return decodeURI(new URL(url, baseUrl).toString());
   } catch {
     return url;
   }
+}
+
+/**
+ * Tests whether a base URL is an absolute filesystem path rather than a URL with a scheme.
+ */
+function isAbsoluteFilePath(url: string | undefined): url is string {
+  return Boolean(url && (/^\//.test(url) || /^[A-Za-z]:[\\/]/.test(url)));
 }
 
 /**

--- a/modules/mvt/src/map-style.ts
+++ b/modules/mvt/src/map-style.ts
@@ -110,7 +110,10 @@ export function getMapStyleLoadOptions(
 /**
  * Resolves a URL against the provided base URL.
  */
-export function normalizeMapStyleUrl(url: string | undefined, baseUrl?: string): string | undefined {
+export function normalizeMapStyleUrl(
+  url: string | undefined,
+  baseUrl?: string
+): string | undefined {
   if (!url) {
     return url;
   }

--- a/modules/mvt/src/map-style.ts
+++ b/modules/mvt/src/map-style.ts
@@ -118,6 +118,14 @@ export function normalizeMapStyleUrl(
     return url;
   }
 
+  if (/^[A-Za-z][A-Za-z\d+.-]*:/.test(url) || url.startsWith('//')) {
+    try {
+      return decodeURI(new URL(url, baseUrl).toString());
+    } catch {
+      return url;
+    }
+  }
+
   if (isAbsoluteFilePath(baseUrl)) {
     const basePath = baseUrl.endsWith('/') ? baseUrl : path.dirname(baseUrl);
     return path.resolve(basePath, url);

--- a/modules/mvt/test/data/map-style/inline.style.json
+++ b/modules/mvt/test/data/map-style/inline.style.json
@@ -1,0 +1,32 @@
+{
+  "version": 8,
+  "metadata": {
+    "name": "Inline style"
+  },
+  "sources": {
+    "inline-source": {
+      "type": "vector",
+      "tiles": ["./tiles/{z}/{x}/{y}.mvt"],
+      "minzoom": 1,
+      "maxzoom": 12,
+      "custom": {
+        "preserved": true
+      }
+    }
+  },
+  "layers": [
+    {
+      "id": "land",
+      "type": "fill",
+      "source": "inline-source",
+      "source-layer": "land",
+      "paint": {
+        "fill-color": "#f0f0f0"
+      },
+      "metadata": {
+        "layerCategory": "background"
+      }
+    }
+  ],
+  "glyphs": "./fonts/{fontstack}/{range}.pbf"
+}

--- a/modules/mvt/test/index.ts
+++ b/modules/mvt/test/index.ts
@@ -13,6 +13,7 @@ import './lib/vector-tiler/simplify-path.spec';
 
 import './lib/utils/geometry-utils.spec';
 
+import './map-style-loader.spec';
 import './tilejson-loader.spec';
 
 import './mvt-loader.spec';

--- a/modules/mvt/test/map-style-loader.spec.ts
+++ b/modules/mvt/test/map-style-loader.spec.ts
@@ -1,0 +1,208 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import test from 'tape-promise/tape';
+import {readFile} from 'fs/promises';
+import {parse} from '@loaders.gl/core';
+import {validateLoader} from 'test/common/conformance';
+import {
+  MapStyleLoader,
+  resolveMapStyle,
+  type MapStyle,
+  type MapStyleLoadOptions
+} from '../src/index';
+
+const INLINE_STYLE_URL = new URL('./data/map-style/inline.style.json', import.meta.url);
+const STYLE_BASE_URL = 'https://example.com/styles/root.style.json';
+const TILEJSON_URL = 'https://example.com/styles/terrain.tilejson';
+const TILE_TEMPLATE_URL = 'https://example.com/styles/tiles/{z}/{x}/{y}.pbf';
+
+function createJsonResponse(json: unknown, ok = true, status = 200) {
+  return {
+    ok,
+    status,
+    async json() {
+      return json;
+    }
+  };
+}
+
+test('MapStyleLoader#loader conformance', (t) => {
+  validateLoader(t, MapStyleLoader, 'MapStyleLoader');
+  t.end();
+});
+
+test('MapStyleLoader#parse inline style fixture', async (t) => {
+  const styleText = await readFile(INLINE_STYLE_URL, 'utf8');
+  const style = await parse(styleText, MapStyleLoader, {
+    mapStyle: {baseUrl: INLINE_STYLE_URL.href}
+  });
+
+  t.equal(style.version, 8, 'style version is preserved');
+  t.equal(style.layers.length, 1, 'style layers are loaded');
+  t.equal(style.sources['inline-source']?.type, 'vector', 'source metadata is preserved');
+  t.equal(
+    style.sources['inline-source']?.tiles?.[0]?.includes('/tiles/{z}/{x}/{y}.mvt'),
+    true,
+    'relative tile template is normalized'
+  );
+  t.deepEqual(
+    style.sources['inline-source']?.custom,
+    {preserved: true},
+    'unknown source fields are preserved'
+  );
+
+  t.end();
+});
+
+test('resolveMapStyle resolves relative tiles from baseUrl', async (t) => {
+  const style: MapStyle = {
+    version: 8,
+    sources: {
+      basemap: {
+        type: 'vector',
+        tiles: ['./tiles/{z}/{x}/{y}.mvt']
+      }
+    },
+    layers: [{id: 'land', type: 'fill', source: 'basemap'}]
+  };
+
+  const resolvedStyle = await resolveMapStyle(style, {
+    mapStyle: {baseUrl: STYLE_BASE_URL}
+  });
+
+  t.equal(
+    resolvedStyle.sources.basemap.tiles?.[0],
+    'https://example.com/styles/tiles/{z}/{x}/{y}.mvt',
+    'tile template is resolved against baseUrl'
+  );
+
+  t.end();
+});
+
+test('resolveMapStyle resolves TileJSON-backed sources', async (t) => {
+  let requestedUrl = '';
+  const resolvedStyle = await resolveMapStyle(
+    {
+      version: 8,
+      sources: {
+        terrain: {
+          type: 'vector',
+          url: './terrain.tilejson',
+          attribution: 'kept'
+        }
+      },
+      layers: [{id: 'terrain-fill', type: 'fill', source: 'terrain'}]
+    },
+    {
+      mapStyle: {
+        baseUrl: STYLE_BASE_URL,
+        fetch: async (url) => {
+          requestedUrl = String(url);
+          return createJsonResponse({
+            tiles: ['./tiles/{z}/{x}/{y}.pbf'],
+            minzoom: 2,
+            maxzoom: 14,
+            name: 'Terrain tiles'
+          }) as Response;
+        }
+      }
+    }
+  );
+
+  t.equal(requestedUrl, TILEJSON_URL, 'relative TileJSON URL is resolved before fetch');
+  t.equal(resolvedStyle.sources.terrain.url, TILEJSON_URL, 'resolved source URL is stored');
+  t.equal(
+    resolvedStyle.sources.terrain.tiles?.[0],
+    TILE_TEMPLATE_URL,
+    'TileJSON tiles are resolved against the TileJSON URL'
+  );
+  t.equal(resolvedStyle.sources.terrain.minzoom, 2, 'TileJSON fields are merged');
+  t.equal(resolvedStyle.sources.terrain.attribution, 'kept', 'existing source fields are preserved');
+
+  t.end();
+});
+
+test('MapStyleLoader honors custom fetch implementation', async (t) => {
+  const arrayBuffer = new TextEncoder().encode(
+    JSON.stringify({
+      version: 8,
+      sources: {
+        basemap: {
+          type: 'vector',
+          url: './terrain.tilejson'
+        }
+      },
+      layers: [{id: 'water', type: 'fill', source: 'basemap'}]
+    })
+  ).buffer;
+  const requestedUrls: string[] = [];
+  const options: MapStyleLoadOptions = {
+    mapStyle: {
+      baseUrl: STYLE_BASE_URL,
+      fetch: async (url) => {
+        requestedUrls.push(String(url));
+        return createJsonResponse({tiles: ['./tiles/{z}/{x}/{y}.mvt']}) as Response;
+      }
+    }
+  };
+
+  const style = await parse(arrayBuffer, MapStyleLoader, options);
+
+  t.deepEqual(requestedUrls, [TILEJSON_URL], 'custom fetch is used for source resolution');
+  t.equal(style.sources.basemap.tiles?.[0], 'https://example.com/styles/tiles/{z}/{x}/{y}.mvt');
+
+  t.end();
+});
+
+test('resolveMapStyle preserves extra fields and initializes empty collections', async (t) => {
+  const style = await resolveMapStyle({
+    version: 8,
+    metadata: {theme: 'test'},
+    custom: {enabled: true}
+  });
+
+  t.deepEqual(style.sources, {}, 'sources default to an empty object');
+  t.deepEqual(style.layers, [], 'layers default to an empty array');
+  t.deepEqual(style.custom, {enabled: true}, 'extra top-level fields are preserved');
+
+  t.end();
+});
+
+test('MapStyleLoader rejects invalid JSON', async (t) => {
+  await t.rejects(
+    async () => await MapStyleLoader.parse(new TextEncoder().encode('{"version":8').buffer, {}),
+    /JSON/,
+    'invalid JSON is rejected'
+  );
+
+  t.end();
+});
+
+test('resolveMapStyle rejects invalid fetched TileJSON', async (t) => {
+  await t.rejects(
+    async () =>
+      await resolveMapStyle(
+        {
+          version: 8,
+          sources: {
+            basemap: {
+              type: 'vector',
+              url: './terrain.tilejson'
+            }
+          }
+        },
+        {
+          mapStyle: {
+            baseUrl: STYLE_BASE_URL,
+            fetch: async () => createJsonResponse('not-an-object') as Response
+          }
+        }
+      ),
+    /Invalid input/,
+    'invalid fetched TileJSON is rejected'
+  );
+
+  t.end();
+});

--- a/modules/mvt/test/map-style-loader.spec.ts
+++ b/modules/mvt/test/map-style-loader.spec.ts
@@ -17,6 +17,8 @@ const INLINE_STYLE_URL = new URL('./data/map-style/inline.style.json', import.me
 const STYLE_BASE_URL = 'https://example.com/styles/root.style.json';
 const TILEJSON_URL = 'https://example.com/styles/terrain.tilejson';
 const TILE_TEMPLATE_URL = 'https://example.com/styles/tiles/{z}/{x}/{y}.pbf';
+const FILE_STYLE_BASE_URL = '/tmp/styles/root.style.json';
+const FILE_TILEJSON_URL = '/tmp/styles/terrain.tilejson';
 
 function createJsonResponse(json: unknown, ok = true, status = 200) {
   return {
@@ -124,6 +126,48 @@ test('resolveMapStyle resolves TileJSON-backed sources', async (t) => {
     'kept',
     'existing source fields are preserved'
   );
+
+  t.end();
+});
+
+test('resolveMapStyle resolves filesystem paths and ref layers', async (t) => {
+  let requestedUrl = '';
+  const resolvedStyle = await resolveMapStyle(
+    {
+      version: 8,
+      sources: {
+        terrain: {
+          type: 'vector',
+          url: './terrain.tilejson'
+        }
+      },
+      layers: [
+        {id: 'terrain-fill', type: 'fill', source: 'terrain'},
+        {id: 'terrain-outline', ref: 'terrain-fill'}
+      ]
+    },
+    {
+      mapStyle: {
+        baseUrl: FILE_STYLE_BASE_URL,
+        fetch: async (url) => {
+          requestedUrl = String(url);
+          return createJsonResponse({tiles: ['./tiles/{z}/{x}/{y}.pbf']}) as Response;
+        }
+      }
+    }
+  );
+
+  t.equal(
+    requestedUrl,
+    FILE_TILEJSON_URL,
+    'relative TileJSON path is resolved from the style path'
+  );
+  t.equal(
+    resolvedStyle.sources.terrain.tiles?.[0],
+    '/tmp/styles/tiles/{z}/{x}/{y}.pbf',
+    'filesystem tile template is resolved from the TileJSON path'
+  );
+  t.equal(resolvedStyle.layers[1]?.type, undefined, 'ref layers may omit type');
 
   t.end();
 });

--- a/modules/mvt/test/map-style-loader.spec.ts
+++ b/modules/mvt/test/map-style-loader.spec.ts
@@ -119,7 +119,11 @@ test('resolveMapStyle resolves TileJSON-backed sources', async (t) => {
     'TileJSON tiles are resolved against the TileJSON URL'
   );
   t.equal(resolvedStyle.sources.terrain.minzoom, 2, 'TileJSON fields are merged');
-  t.equal(resolvedStyle.sources.terrain.attribution, 'kept', 'existing source fields are preserved');
+  t.equal(
+    resolvedStyle.sources.terrain.attribution,
+    'kept',
+    'existing source fields are preserved'
+  );
 
   t.end();
 });

--- a/modules/mvt/test/map-style-loader.spec.ts
+++ b/modules/mvt/test/map-style-loader.spec.ts
@@ -172,6 +172,28 @@ test('resolveMapStyle resolves filesystem paths and ref layers', async (t) => {
   t.end();
 });
 
+test('normalizeMapStyleUrl preserves absolute URLs with filesystem bases', async (t) => {
+  const resolvedStyle = await resolveMapStyle(
+    {
+      sources: {
+        remote: {
+          type: 'vector',
+          tiles: ['https://cdn.example.com/tiles/{z}/{x}/{y}.pbf']
+        }
+      }
+    },
+    {mapStyle: {baseUrl: FILE_STYLE_BASE_URL}}
+  );
+
+  t.equal(
+    resolvedStyle.sources.remote.tiles?.[0],
+    'https://cdn.example.com/tiles/{z}/{x}/{y}.pbf',
+    'absolute URLs are not treated as filesystem-relative paths'
+  );
+
+  t.end();
+});
+
 test('MapStyleLoader honors custom fetch implementation', async (t) => {
   const arrayBuffer = new TextEncoder().encode(
     JSON.stringify({

--- a/yarn.lock
+++ b/yarn.lock
@@ -5028,6 +5028,7 @@ __metadata:
     "@probe.gl/stats": "npm:^4.1.1"
     "@types/pbf": "npm:^3.0.2"
     pbf: "npm:^3.2.1"
+    zod: "npm:^4.1.12"
   peerDependencies:
     "@loaders.gl/core": ~4.4.0
   languageName: unknown


### PR DESCRIPTION
Goals

- Backport MapStyleLoader from #3371 to the 4.5 release line.
- Provide normalized MapLibre/Mapbox style metadata without pulling in 5.0-only changes.

Changes

- Add MapStyleLoader with text and binary parsing support.
- Resolve relative source URLs and tile templates, including TileJSON-backed sources.
- Preserve unknown style/source/layer fields and initialize sources/layers collections.
- Export MapStyle types, schemas, and resolveMapStyle from @loaders.gl/mvt.
- Add focused loader, URL-resolution, TileJSON, validation, and preservation tests.
- Add module and API/format documentation plus the zod dependency/lockfile update.

Validation

- Direct MapStyleLoader test: 26 passing assertions.
- Full repository build completed successfully before the final text-parser adjustment; focused tests pass after it.