### PR TITLE
docs: finalize v4.5 release notes

### DIFF
--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -6,26 +6,7 @@ v4.5 is additive. Existing loaders and defaults continue to work unchanged, exce
 
 **@loaders.gl/splats**
 
-- Install the new experimental package with `npm install @loaders.gl/splats` and load SPLAT, KSPLAT, SPZ, or RAD data through its exported loaders.
-- SPZ and compressed RAD data require an application-provided `zstd-codec` module; pass it through `options.modules`.
-
-**@loaders.gl/parquet**
-
-- `ParquetLoader` and the deprecated Parquet JSON aliases retain their existing behavior.
-- To opt into the TypeScript parser, import `ParquetJSLoader` from `@loaders.gl/parquet` or `@loaders.gl/parquet/parquet-js-loader`.
-
-**@loaders.gl/traces**
-
-- Install `@loaders.gl/traces` to parse Chrome Trace Event JSON with `ChromeTraceLoader`. Use `shape: 'arrow-table'` for Arrow output or the exported streaming helpers for incremental events, Arrow batches, and file chunks.
-
-**@loaders.gl/mvt**
-
-- `MapStyleLoader` is additive. It resolves relative Mapbox/MapLibre source and TileJSON URLs while preserving style metadata. Pass `mapStyle.baseUrl`, `mapStyle.fetch`, or `mapStyle.fetchOptions` when resolving in-memory styles or supplying a custom request implementation.
-
-**@loaders.gl/gltf**
-
-- No migration is required. `GLTFLoader` now handles per-texture UV transforms and selects AVIF texture sources when the active image decoder supports them.
-- `KHR_meshopt_compression` support and portable `LINE_LOOP` / `TRIANGLE_FAN` normalization are enabled automatically; no application changes are required.
+- SPZ decoding requires an application-provided `zstd-codec` module passed through `options.modules`. RAD gzip chunks are decompressed internally and do not require `zstd-codec`.
 
 **@loaders.gl/textures**
 

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -2,7 +2,7 @@
 
 ## Upgrading to v4.5
 
-Aside from the experimental writer prerequisite noted below, v4.5 is additive. Existing loaders and defaults continue to work unchanged.
+v4.5 is additive. Existing loaders and defaults continue to work unchanged, except for the explicit installation requirement for the experimental texture writer noted below.
 
 **@loaders.gl/splats**
 
@@ -14,9 +14,18 @@ Aside from the experimental writer prerequisite noted below, v4.5 is additive. E
 - `ParquetLoader` and the deprecated Parquet JSON aliases retain their existing behavior.
 - To opt into the TypeScript parser, import `ParquetJSLoader` from `@loaders.gl/parquet` or `@loaders.gl/parquet/parquet-js-loader`.
 
+**@loaders.gl/traces**
+
+- Install `@loaders.gl/traces` to parse Chrome Trace Event JSON with `ChromeTraceLoader`. Use `shape: 'arrow-table'` for Arrow output or the exported streaming helpers for incremental events, Arrow batches, and file chunks.
+
+**@loaders.gl/mvt**
+
+- `MapStyleLoader` is additive. It resolves relative Mapbox/MapLibre source and TileJSON URLs while preserving style metadata. Pass `mapStyle.baseUrl`, `mapStyle.fetch`, or `mapStyle.fetchOptions` when resolving in-memory styles or supplying a custom request implementation.
+
 **@loaders.gl/gltf**
 
 - No migration is required. `GLTFLoader` now handles per-texture UV transforms and selects AVIF texture sources when the active image decoder supports them.
+- `KHR_meshopt_compression` support and portable `LINE_LOOP` / `TRIANGLE_FAN` normalization are enabled automatically; no application changes are required.
 
 **@loaders.gl/textures**
 

--- a/docs/whats-new.mdx
+++ b/docs/whats-new.mdx
@@ -1,14 +1,19 @@
 # What's New
 
-## v4.5 (Alpha)
+## v4.5
 
-v4.5 adds experimental Gaussian splat and TypeScript Parquet support while improving glTF texture handling.
+Release Date: Sep 7, 2026
+
+v4.5 adds experimental Gaussian splat and TypeScript Parquet support, Chrome Trace parsing, Mapbox/MapLibre style resolution, and glTF texture handling improvements.
 
 **Highlights**
 
 - **@loaders.gl/splats** - New loaders for raw SPLAT, KSPLAT, SPZ, and Spark RAD Gaussian-splat data. `RADSourceLoader` supports progressive chunk loading for paged RAD scenes.
 - **@loaders.gl/parquet** - New experimental `ParquetJSLoader` makes the TypeScript Parquet backend available through an explicit loader import.
+- **@loaders.gl/traces** - New `ChromeTraceLoader` parses Chrome Trace Event JSON as normalized JSON or Arrow tables. Streaming helpers support incremental event, Arrow-batch, and file parsing.
+- **@loaders.gl/mvt** - New `MapStyleLoader` parses Mapbox/MapLibre style JSON, resolves relative source and TileJSON URLs, preserves metadata, and supports custom fetch and base URL options.
 - **@loaders.gl/gltf** - `KHR_texture_transform` now supports independent transforms on textures that share a UV attribute, and `GLTFLoader` selects `EXT_texture_avif` sources when AVIF is available.
+- **@loaders.gl/textures** - The experimental `CompressedTextureWriter` no longer installs `texture-compressor` for every consumer; applications that use the writer can opt in explicitly.
 
 The release also includes `KHR_meshopt_compression` support and portable `LINE_LOOP` / `TRIANGLE_FAN` normalization from v4.4.5.
 

--- a/docs/whats-new.mdx
+++ b/docs/whats-new.mdx
@@ -11,7 +11,7 @@ v4.5 adds experimental Gaussian splat and TypeScript Parquet support, Chrome Tra
 - **@loaders.gl/splats** - New loaders for raw SPLAT, KSPLAT, SPZ, and Spark RAD Gaussian-splat data. `RADSourceLoader` supports progressive chunk loading for paged RAD scenes.
 - **@loaders.gl/parquet** - New experimental `ParquetJSLoader` makes the TypeScript Parquet backend available through an explicit loader import.
 - **@loaders.gl/traces** - New `ChromeTraceLoader` parses Chrome Trace Event JSON as normalized JSON or Arrow tables. Streaming helpers support incremental event, Arrow-batch, and file parsing.
-- **@loaders.gl/mvt** - New `MapStyleLoader` parses Mapbox/MapLibre style JSON, resolves relative source and TileJSON URLs, preserves metadata, and supports custom fetch and base URL options.
+- **@loaders.gl/mvt** - New [`MapStyleLoader`](/docs/modules/mvt/api-reference/map-style-loader) parses Mapbox/MapLibre style JSON, resolves relative source and TileJSON URLs, preserves metadata, and supports custom fetch and base URL options.
 - **@loaders.gl/gltf** - `KHR_texture_transform` now supports independent transforms on textures that share a UV attribute, and `GLTFLoader` selects `EXT_texture_avif` sources when AVIF is available.
 - **@loaders.gl/textures** - The experimental `CompressedTextureWriter` no longer installs `texture-compressor` for every consumer; applications that use the writer can opt in explicitly.
 

--- a/modules/traces/package.json
+++ b/modules/traces/package.json
@@ -4,7 +4,6 @@
   "description": "Trace format parsers for Chrome Trace and Perfetto Trace",
   "license": "MIT",
   "type": "module",
-  "private": true,
   "repository": {
     "type": "git",
     "url": "https://github.com/visgl/loaders.gl"


### PR DESCRIPTION
## Goals
- Finalize the v4.5 release notes for the September 7, 2026 release.
- Keep migration guidance aligned with the shipped and backported 4.5 capabilities.

## Changes
- Remove the alpha label and add the release date.
- Document splats, TypeScript Parquet, Chrome Trace, MapStyleLoader, glTF, and texture-compressor changes.
- Add v4.5 upgrade notes for the new packages and additive behavior.