### PR TITLE
Backport indexed Arrow views and public exports to 4.5

### DIFF
--- a/docs/docs-sidebar.json
+++ b/docs/docs-sidebar.json
@@ -270,7 +270,11 @@
       {
         "type": "category",
         "label": "@loaders.gl/arrow",
-        "items": ["modules/arrow/README"]
+        "items": [
+          "modules/arrow/README",
+          "modules/arrow/api-reference/indexed-arrow-table",
+          "modules/arrow/api-reference/mapped-arrow-table"
+        ]
       },
       {
         "type": "category",

--- a/docs/modules/arrow/README.md
+++ b/docs/modules/arrow/README.md
@@ -28,6 +28,11 @@ See [Using with Apache Arrow](/docs/developer-guide/apache-arrow) for practical 
 
 ## Additional APIs
 
+| API                                                                                                | Description                                                                                                  |
+| -------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| [`IndexedArrowTable`, `IndexedArrowVector`](/docs/modules/arrow/api-reference/indexed-arrow-table) | Readonly indexed views for filtering, sorting, slicing and reordering without eagerly copying Arrow columns. |
+| [`MappedArrowTable`](/docs/modules/arrow/api-reference/mapped-arrow-table)                         | String-keyed row lookup that preserves indexed table transforms.                                             |
+
 Arrow provides a rich JavaScript API for working with Arrow formatted data.
 Start with the [`ArrowJS API Reference`](/docs/arrowjs/api-reference).
 

--- a/docs/modules/arrow/api-reference/indexed-arrow-table.md
+++ b/docs/modules/arrow/api-reference/indexed-arrow-table.md
@@ -127,6 +127,8 @@ Returns a sorted indexed view over the same backing table.
 
 Concatenates this indexed view with other indexed views sharing an identical Arrow schema. The
 result owns a new backing Arrow table and preserves visible row order from each source view.
+Schema validation includes nested child fields, nullability, and metadata, not just top-level names
+and type strings.
 
 #### `find(predicate)` and `findIndex(predicate)`
 

--- a/docs/modules/arrow/api-reference/indexed-arrow-table.md
+++ b/docs/modules/arrow/api-reference/indexed-arrow-table.md
@@ -1,0 +1,169 @@
+# IndexedArrowTable
+
+`IndexedArrowTable` and `IndexedArrowVector` provide readonly indexed views over Apache Arrow JS
+tables and vectors.
+
+Use these classes when you want to filter, sort, slice, or reorder an Arrow table without copying
+column data immediately. The view stores row indexes and only copies values when you call
+`materializeArrowTable()`, `toArray()`, or iterate rows.
+
+## Concepts
+
+- A **raw row index** is the row position in the backing `arrow.Table`.
+- A **visible row index** is the row position in the indexed view.
+- Duplicate raw row indexes are preserved. This lets one backing Arrow row appear multiple times in
+  a view.
+- Indexes use signed 32-bit storage. Negative, fractional, out-of-bounds and larger-than-`0x7fffffff`
+  raw indexes throw `RangeError` instead of being truncated or wrapped.
+
+## Usage
+
+```typescript
+import * as arrow from 'apache-arrow';
+import {IndexedArrowTable} from '@loaders.gl/arrow';
+
+const table = new arrow.Table({
+  name: arrow.vectorFromArray(['alpha', 'beta', 'gamma'], new arrow.Utf8()),
+  score: arrow.vectorFromArray([10, 20, 30], new arrow.Float64())
+});
+
+const indexedTable = new IndexedArrowTable(table, [2, 0]);
+
+indexedTable.get(0)?.name; // 'gamma'
+indexedTable.getValue(1, 'score'); // 10
+indexedTable.getChild('name')?.toArray(); // ['gamma', 'alpha']
+```
+
+## Filtering and Sorting
+
+Predicates and comparators receive visible row indexes. Use `getValue()` to read column values
+without materializing row objects.
+
+```typescript
+const filteredTable = new IndexedArrowTable(table).filter(
+  (currentTable, rowIndex) => (currentTable.getValue(rowIndex, 'score') ?? 0) >= 20
+);
+
+const sortedTable = filteredTable.sort(
+  (currentTable, leftRowIndex, rightRowIndex) =>
+    (currentTable.getValue(rightRowIndex, 'score') ?? 0) -
+    (currentTable.getValue(leftRowIndex, 'score') ?? 0)
+);
+```
+
+## `IndexedArrowTable`
+
+### Constructor
+
+```typescript
+new IndexedArrowTable(table, indexes);
+```
+
+Parameters:
+
+- `table`: backing `arrow.Table` in raw row order.
+- `indexes`: optional raw row indexes to expose. When omitted, the view exposes all rows in raw
+  order.
+
+### Static Methods
+
+#### `IndexedArrowTable.fromOwnedIndexes(table, indexes)`
+
+Builds an indexed table from an owned `Int32Array` without copying it. Do not mutate the index
+array after passing ownership to the table.
+
+### Properties
+
+- `table`: backing `arrow.Table`.
+- `schema`: backing `arrow.Schema`.
+- `indexes`: `Int32Array` of raw row indexes in visible order.
+- `numRows`: number of visible rows.
+- `numCols`: number of columns in the backing table.
+
+### Methods
+
+#### `getRawIndex(rowIndex)`
+
+Returns the raw backing-table row index for a visible row index, or `null` for an invalid visible
+index.
+
+#### `get(rowIndex)`
+
+Returns a materialized Arrow row for a visible row index, or `null` for an invalid visible index.
+
+#### `getTemporaryRow(rowIndex)`
+
+Returns a reusable scratch row object for a visible row index. The same object is mutated by the
+next `getTemporaryRow()` call on the same indexed table, so copy values you need to retain.
+Arrow null values are preserved; a missing child vector produces `undefined`.
+
+#### `at(rowIndex)`
+
+Reads a row using `Array.prototype.at` semantics. Negative indexes count backward from the end of
+the visible view.
+
+#### `getValue(rowIndex, columnName)`
+
+Returns a typed column value for a visible row, or `null` when the row index or column is not
+available.
+
+#### `getChild(columnName)`
+
+Returns an `IndexedArrowVector` view for a backing column, or `null` when the column is missing.
+
+#### `slice(begin, end)`
+
+Returns a sliced indexed view over the same backing table.
+
+#### `filter(predicate)`
+
+Returns a filtered indexed view over the same backing table.
+
+#### `sort(compare)`
+
+Returns a sorted indexed view over the same backing table.
+
+#### `concat(...others)`
+
+Concatenates this indexed view with other indexed views sharing an identical Arrow schema. The
+result owns a new backing Arrow table and preserves visible row order from each source view.
+
+#### `find(predicate)` and `findIndex(predicate)`
+
+Array-like search helpers over visible rows.
+
+#### `materializeArrowTable()`
+
+Copies the visible rows into a new concrete Arrow table. Visible row order and duplicate indexes are
+preserved.
+
+#### `toArray()` and `[Symbol.iterator]()`
+
+Materialize or iterate visible rows in indexed order.
+
+## `IndexedArrowVector`
+
+`IndexedArrowVector` is the column-vector equivalent of `IndexedArrowTable`. It wraps one
+`arrow.Vector` and an index array.
+
+```typescript
+const nameColumn = indexedTable.getChild('name');
+
+nameColumn?.get(0); // 'gamma'
+nameColumn?.at(-1); // 'alpha'
+nameColumn?.slice(1).toArray(); // ['alpha']
+```
+
+Properties:
+
+- `vector`: backing `arrow.Vector`.
+- `indexes`: `Int32Array` of raw row indexes.
+- `length`: number of visible values.
+
+Methods:
+
+- `get(rowIndex)`
+- `at(rowIndex)`
+- `slice(begin, end)`
+- `toArray()`
+- `[Symbol.iterator]()`

--- a/docs/modules/arrow/api-reference/mapped-arrow-table.md
+++ b/docs/modules/arrow/api-reference/mapped-arrow-table.md
@@ -1,0 +1,104 @@
+# MappedArrowTable
+
+`MappedArrowTable` is a readonly string-keyed row lookup view over an `IndexedArrowTable`.
+
+Use it when an Arrow table has a stable application-level key, such as an id column, and you want
+fast keyed row lookup while still preserving indexed-table operations such as filtering, sorting,
+slicing, and concatenation.
+
+## Key Semantics
+
+- `rowKeys` stores keys in visible row order.
+- Duplicate keys are preserved in visible row order.
+- Keyed lookups are **last-wins**. If the same key appears multiple times, `getRowIndex(key)` and
+  `getByKey(key)` resolve to the last visible occurrence.
+
+## Usage
+
+```typescript
+import {MappedArrowTable} from '@loaders.gl/arrow';
+
+const rowIndexMap = new Map([
+  ['gamma', 2],
+  ['alpha', 0]
+]);
+
+const mappedTable = new MappedArrowTable(table, rowIndexMap);
+
+mappedTable.getByKey('gamma')?.name; // 'gamma'
+mappedTable.getRowIndex('alpha'); // 0
+mappedTable.getRowKey(1); // 'alpha'
+```
+
+## Filtering and Sorting
+
+Mapped transforms preserve key entries instead of collapsing them into a plain indexed table.
+
+```typescript
+const filteredTable = mappedTable.filter(
+  (currentTable, rowIndex) => (currentTable.getValue(rowIndex, 'score') ?? 0) >= 20
+);
+
+const sortedTable = filteredTable.sort(
+  (currentTable, leftRowIndex, rightRowIndex) =>
+    (currentTable.getValue(rightRowIndex, 'score') ?? 0) -
+    (currentTable.getValue(leftRowIndex, 'score') ?? 0)
+);
+```
+
+## Constructor
+
+```typescript
+new MappedArrowTable(table, rowIndexMap);
+```
+
+Parameters:
+
+- `table`: backing `arrow.Table` in raw row order.
+- `rowIndexMap`: string-key-to-raw-row mapping to expose through this mapped view.
+
+## Properties
+
+- `rowIndexMap`: string-key-to-raw-row lookup map. Duplicate keys use last-wins semantics.
+- `rowKeys`: string keys in visible mapped-row order. Duplicate keys are preserved.
+- All `IndexedArrowTable` properties are also available.
+
+## Methods
+
+### `getRowIndex(rowKey)`
+
+Returns the raw backing-table row index for a mapped key, or `null` when the key is absent.
+
+### `getRowKey(rowIndex)`
+
+Returns the mapped key for a visible row index, or `null` when the index is invalid.
+
+### `getByKey(rowKey)`
+
+Returns a materialized Arrow row for a mapped key, or `null` when the key is absent.
+
+### `atMapped(rowIndex)`
+
+Reads a mapped row using `Array.prototype.at` semantics. Negative indexes count backward from the
+end of the visible mapped view.
+
+### `slice(begin, end)`
+
+Returns a sliced mapped view over the same backing table and preserves mapped key entries.
+
+### `filter(predicate)`
+
+Returns a filtered mapped view over the same backing table and preserves mapped key entries.
+
+### `sort(compare)`
+
+Returns a sorted mapped view over the same backing table and preserves mapped key entries.
+
+### `concat(...others)`
+
+Concatenates this mapped view with other mapped views sharing an identical Arrow schema. The result
+owns a new backing Arrow table, preserves visible mapped-row order including duplicate keys, and
+keeps last-wins keyed lookup behavior.
+
+All other `IndexedArrowTable` methods, including `getValue()`, `getChild()`,
+`materializeArrowTable()`, `toArray()`, and iteration, are inherited.

--- a/docs/modules/arrow/api-reference/mapped-arrow-table.md
+++ b/docs/modules/arrow/api-reference/mapped-arrow-table.md
@@ -100,5 +100,10 @@ Concatenates this mapped view with other mapped views sharing an identical Arrow
 owns a new backing Arrow table, preserves visible mapped-row order including duplicate keys, and
 keeps last-wins keyed lookup behavior.
 
+Plain `IndexedArrowTable` inputs are also accepted, including calls through the base class. If any
+input is not mapped, the result is a plain `IndexedArrowTable` preserving every visible row in
+order; no mapped keys are invented for unkeyed rows. With only mapped inputs (or no arguments), the
+result remains a `MappedArrowTable`.
+
 All other `IndexedArrowTable` methods, including `getValue()`, `getChild()`,
 `materializeArrowTable()`, `toArray()`, and iteration, are inherited.

--- a/docs/whats-new.mdx
+++ b/docs/whats-new.mdx
@@ -1,5 +1,13 @@
 # What's New
 
+## Next v4.5 patch
+
+- **@loaders.gl/arrow** - Backport public `IndexedArrowTable`, `IndexedArrowVector`,
+  `MappedArrowTable` and their callback types. These readonly views support filtering, sorting,
+  slicing and keyed lookup without eagerly copying the backing columns. See
+  [indexed views](/docs/modules/arrow/api-reference/indexed-arrow-table) and
+  [mapped views](/docs/modules/arrow/api-reference/mapped-arrow-table).
+
 ## v4.5
 
 Release Date: Sep 7, 2026

--- a/modules/arrow/src/index.ts
+++ b/modules/arrow/src/index.ts
@@ -22,6 +22,20 @@ export {GeoArrowLoader} from './geoarrow-loader';
 // EXPERIMENTAL
 
 // Arrow Utils
+export {IndexedArrowVector} from './lib/utils/indexed-arrow-vector';
+export {
+  IndexedArrowTable,
+  type IndexedArrowTableComparator,
+  type IndexedArrowTableFindPredicate,
+  type IndexedArrowTablePredicate,
+  type IndexedArrowTableRow
+} from './lib/utils/indexed-arrow-table';
+export {
+  MappedArrowTable,
+  type MappedArrowTableComparator,
+  type MappedArrowTablePredicate
+} from './lib/utils/mapped-arrow-table';
+
 // getGeometryColumnsFromArrowTable,
 // getGeoArrowEncoding
 

--- a/modules/arrow/src/lib/utils/indexed-arrow-helpers.ts
+++ b/modules/arrow/src/lib/utils/indexed-arrow-helpers.ts
@@ -1,0 +1,69 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+/**
+ * Returns the raw row index for one view-local access if it is a valid integer index.
+ */
+export function getIndexedAccessRow(indexes: Int32Array, rowIndex: number): number | null {
+  if (!Number.isInteger(rowIndex) || rowIndex < 0 || rowIndex >= indexes.length) {
+    return null;
+  }
+
+  return indexes[rowIndex] ?? null;
+}
+
+/**
+ * Returns the normalized row index for one relative `.at()`-style access.
+ */
+export function getIndexedRelativeAccessRow(length: number, rowIndex: number): number | null {
+  if (!Number.isInteger(rowIndex)) {
+    return null;
+  }
+
+  const normalizedIndex = rowIndex >= 0 ? rowIndex : length + rowIndex;
+  if (normalizedIndex < 0 || normalizedIndex >= length) {
+    return null;
+  }
+
+  return normalizedIndex;
+}
+
+/**
+ * Normalizes raw Arrow row indexes into an owned `Int32Array`.
+ * Validates the table bounds and signed Int32 range before converting any values.
+ *
+ * @param indexes - Raw Arrow row indexes to validate and normalize.
+ * @param maxExclusive - Exclusive upper bound for valid raw row indexes.
+ * @param copy - When `false`, reuses an owned `Int32Array` input after validation instead of
+ * copying it into a new typed array.
+ * @returns Validated row indexes in a typed array.
+ */
+export function normalizeIndexedArrowIndexes(
+  indexes: readonly number[] | Int32Array,
+  maxExclusive: number,
+  copy = true
+): Int32Array {
+  const indexCount = indexes.length;
+  for (let rowIndex = 0; rowIndex < indexCount; rowIndex++) {
+    const rawIndex = indexes[rowIndex];
+    if (!Number.isInteger(rawIndex) || rawIndex < 0 || rawIndex >= maxExclusive) {
+      throw new RangeError(
+        `Indexed Arrow row index ${String(rawIndex)} at position ${rowIndex} is out of range for table length ${maxExclusive}.`
+      );
+    }
+    if (rawIndex > 0x7fffffff) {
+      throw new RangeError(
+        `Indexed Arrow row index ${String(rawIndex)} at position ${rowIndex} is outside signed Int32 range.`
+      );
+    }
+  }
+
+  const normalizedIndexes =
+    !copy && indexes instanceof Int32Array ? indexes : Int32Array.from(indexes);
+  if (normalizedIndexes.length !== indexCount) {
+    throw new RangeError('Indexed Arrow row indexes must be finite integers.');
+  }
+
+  return normalizedIndexes;
+}

--- a/modules/arrow/src/lib/utils/indexed-arrow-table.ts
+++ b/modules/arrow/src/lib/utils/indexed-arrow-table.ts
@@ -423,22 +423,42 @@ function areArrowSchemasCompatible<T extends arrow.TypeMap>(
     return false;
   }
 
-  return left.fields.every((field, fieldIndex) => {
-    const otherField = right.fields[fieldIndex];
-    return (
-      otherField !== null &&
-      otherField !== undefined &&
-      field.name === otherField.name &&
-      field.nullable === otherField.nullable &&
-      field.typeId === otherField.typeId &&
-      String(field.type) === String(otherField.type) &&
-      areArrowMetadataMapsEqual(field.metadata, otherField.metadata)
-    );
-  });
+  return left.fields.every((field, fieldIndex) =>
+    areArrowFieldsCompatible(field, right.fields[fieldIndex])
+  );
 }
 
 /**
- * Returns whether two Arrow metadata maps contain the same ordered key/value pairs.
+ * Compares complete Arrow fields, including nested child nullability and metadata.
+ */
+function areArrowFieldsCompatible(left: arrow.Field, right: arrow.Field): boolean {
+  if (left === right) {
+    return true;
+  }
+
+  if (
+    !right ||
+    left.name !== right.name ||
+    left.nullable !== right.nullable ||
+    left.typeId !== right.typeId ||
+    String(left.type) !== String(right.type) ||
+    !areArrowMetadataMapsEqual(left.metadata, right.metadata)
+  ) {
+    return false;
+  }
+
+  const leftChildren = left.type.children ?? [];
+  const rightChildren = right.type.children ?? [];
+  return (
+    leftChildren.length === rightChildren.length &&
+    leftChildren.every((field, fieldIndex) =>
+      areArrowFieldsCompatible(field, rightChildren[fieldIndex])
+    )
+  );
+}
+
+/**
+ * Returns whether two Arrow metadata maps contain the same key/value pairs.
  */
 function areArrowMetadataMapsEqual(
   left: ReadonlyMap<string, string>,

--- a/modules/arrow/src/lib/utils/indexed-arrow-table.ts
+++ b/modules/arrow/src/lib/utils/indexed-arrow-table.ts
@@ -1,0 +1,487 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import * as arrow from 'apache-arrow';
+
+import {
+  getIndexedAccessRow,
+  getIndexedRelativeAccessRow,
+  normalizeIndexedArrowIndexes
+} from './indexed-arrow-helpers';
+import {IndexedArrowVector} from './indexed-arrow-vector';
+
+const indexedArrowTableInitSymbol = Symbol('indexed-arrow-table-init');
+
+/**
+ * Arrow row type preserved by one indexed Arrow table view.
+ *
+ * @typeParam T - Backing Arrow column map shared with the source table.
+ */
+export type IndexedArrowTableRow<T extends arrow.TypeMap> = arrow.Struct<T>['TValue'];
+
+/**
+ * Predicate evaluated against one indexed Arrow table view row.
+ *
+ * @typeParam T - Backing Arrow column map shared with the source table.
+ * @param table - Indexed table view currently being filtered.
+ * @param rowIndex - Visible row index within the indexed view.
+ * @returns `true` when the visible row should remain in the filtered view.
+ */
+export type IndexedArrowTablePredicate<T extends arrow.TypeMap> = (
+  table: IndexedArrowTable<T>,
+  rowIndex: number
+) => boolean;
+
+/**
+ * Comparator evaluated against two indexed Arrow table view rows.
+ *
+ * @typeParam T - Backing Arrow column map shared with the source table.
+ * @param table - Indexed table view currently being sorted.
+ * @param leftRowIndex - Left visible row index within the indexed view.
+ * @param rightRowIndex - Right visible row index within the indexed view.
+ * @returns Negative when the left row should sort first, positive when the right row should sort
+ * first, or zero to preserve their current relative order.
+ */
+export type IndexedArrowTableComparator<T extends arrow.TypeMap> = (
+  table: IndexedArrowTable<T>,
+  leftRowIndex: number,
+  rightRowIndex: number
+) => number;
+
+/**
+ * Predicate evaluated against one indexed Arrow table row for array-like search helpers.
+ *
+ * @typeParam T - Backing Arrow column map shared with the source table.
+ * @param row - Materialized visible row at the current indexed position.
+ * @param rowIndex - Visible row index within the indexed view.
+ * @param table - Indexed table view currently being searched.
+ * @returns `true` when the current visible row matches the requested condition.
+ */
+export type IndexedArrowTableFindPredicate<T extends arrow.TypeMap> = (
+  row: IndexedArrowTableRow<T> | null,
+  rowIndex: number,
+  table: IndexedArrowTable<T>
+) => boolean;
+
+/**
+ * Readonly indexed row and column view over one backing Arrow table.
+ *
+ * A visible row index is the row position inside this view. A raw row index is the row position in
+ * the backing Arrow table. The view stores raw row indexes and does not copy table data until
+ * callers materialize a table or array.
+ *
+ * @typeParam T - Backing Arrow column map shared with the source table.
+ */
+export class IndexedArrowTable<T extends arrow.TypeMap> {
+  /** Backing Arrow table in raw row order. */
+  readonly table: arrow.Table<T>;
+  /** Backing Arrow schema shared across all indexed views of the same table. */
+  readonly schema: arrow.Schema<T>;
+  /** Raw row indexes exposed by this indexed view. Duplicate indexes are preserved. */
+  readonly indexes: Int32Array;
+  /** Scratch row object reused by `getTemporaryRow(...)` to avoid repeated row allocations. */
+  private temporaryRow?: IndexedArrowTableRow<T>;
+
+  /**
+   * Builds one indexed Arrow table view from an owned typed index buffer without copying it.
+   *
+   * Callers must not mutate `indexes` after handing ownership to the indexed table.
+   *
+   * @typeParam T - Backing Arrow column map shared with the source table.
+   * @param table - Backing Arrow table in raw row order.
+   * @param indexes - Owned typed raw-row indexes to expose through this view.
+   * @returns Indexed view adopting the provided typed index buffer.
+   */
+  static fromOwnedIndexes<T extends arrow.TypeMap>(
+    table: arrow.Table<T>,
+    indexes: Int32Array
+  ): IndexedArrowTable<T> {
+    return new IndexedArrowTable(table, indexes, indexedArrowTableInitSymbol);
+  }
+
+  /**
+   * Builds one indexed Arrow table view.
+   *
+   * @param table - Backing Arrow table in raw row order.
+   * @param indexes - Optional raw-row indexes to expose through this view. When omitted, the view
+   * acts as a full passthrough over every raw row.
+   * @param init - Internal marker enabling adoption of owned typed indexes without copying them.
+   */
+  constructor(table: arrow.Table<T>, indexes?: readonly number[] | Int32Array);
+  constructor(table: arrow.Table<T>, indexes: Int32Array, init: typeof indexedArrowTableInitSymbol);
+  constructor(
+    table: arrow.Table<T>,
+    indexes?: readonly number[] | Int32Array,
+    init?: typeof indexedArrowTableInitSymbol
+  ) {
+    this.table = table;
+    this.schema = table.schema;
+    this.indexes =
+      indexes === undefined
+        ? Int32Array.from({length: table.numRows}, (_, rowIndex) => rowIndex)
+        : normalizeIndexedArrowIndexes(
+            indexes,
+            table.numRows,
+            init !== indexedArrowTableInitSymbol
+          );
+  }
+
+  /**
+   * Number of visible rows exposed through this indexed table.
+   *
+   * @returns Count of visible rows in the indexed view.
+   */
+  get numRows(): number {
+    return this.indexes.length;
+  }
+
+  /**
+   * Number of columns exposed through the backing Arrow schema.
+   *
+   * @returns Count of schema columns shared with the backing Arrow table.
+   */
+  get numCols(): number {
+    return this.table.numCols;
+  }
+
+  /**
+   * Resolves one raw backing-table row index by view-local row index.
+   *
+   * @param rowIndex - Visible row index within the indexed view.
+   * @returns Raw row index in the backing table, or `null` when the visible index is invalid.
+   */
+  getRawIndex(rowIndex: number): number | null {
+    return getIndexedAccessRow(this.indexes, rowIndex);
+  }
+
+  /**
+   * Resolves one row object by view-local row index.
+   *
+   * @param rowIndex - Visible row index within the indexed view.
+   * @returns Materialized Arrow row for the visible row index, or `null` when the index is invalid.
+   */
+  get(rowIndex: number): IndexedArrowTableRow<T> | null {
+    const rawIndex = this.getRawIndex(rowIndex);
+    return rawIndex === null ? null : this.table.get(rawIndex);
+  }
+
+  /**
+   * Resolves one visible row into a reusable scratch object owned by this indexed table.
+   *
+   * The returned object is mutated in place and reused by the next `getTemporaryRow(...)` call on
+   * the same indexed view. Callers must copy any values they need to retain beyond the immediate
+   * read. Arrow null values are preserved; absent child vectors produce `undefined`.
+   *
+   * @param rowIndex - Visible row index within the indexed view.
+   * @returns Reusable scratch row for the visible row index, or `null` when the index is invalid.
+   */
+  getTemporaryRow(rowIndex: number): IndexedArrowTableRow<T> | null {
+    const rawIndex = this.getRawIndex(rowIndex);
+    if (rawIndex === null) {
+      return null;
+    }
+
+    const temporaryRow =
+      this.temporaryRow ??
+      ((this.temporaryRow = Object.create(null) as IndexedArrowTableRow<T>), this.temporaryRow);
+    const mutableTemporaryRow = temporaryRow as Record<keyof T & string, unknown>;
+
+    for (const field of this.schema.fields) {
+      const columnName = field.name as keyof T & string;
+      const childVector = getCachedRawChildVector(this.table, columnName);
+      mutableTemporaryRow[columnName] = childVector ? childVector.get(rawIndex) : undefined;
+    }
+
+    return temporaryRow;
+  }
+
+  /**
+   * Resolves one row object by relative view-local row index.
+   *
+   * @param rowIndex - Relative visible row index using `Array.prototype.at` semantics.
+   * @returns Materialized Arrow row for the resolved visible row index, or `null` when the index is
+   * invalid.
+   */
+  at(rowIndex: number): IndexedArrowTableRow<T> | null {
+    const normalizedIndex = getIndexedRelativeAccessRow(this.numRows, rowIndex);
+    return normalizedIndex === null ? null : this.get(normalizedIndex);
+  }
+
+  /**
+   * Resolves one typed column value by view-local row index.
+   *
+   * @typeParam P - Column name being read from the backing Arrow schema.
+   * @param rowIndex - Visible row index within the indexed view.
+   * @param columnName - Backing Arrow column name to read.
+   * @returns Typed column value for the visible row, or `null` when the row index or column is not
+   * available.
+   */
+  getValue<P extends keyof T & string>(rowIndex: number, columnName: P): T[P]['TValue'] | null {
+    const rawIndex = this.getRawIndex(rowIndex);
+    if (rawIndex === null) {
+      return null;
+    }
+
+    const childVector = getCachedRawChildVector(this.table, columnName);
+    return childVector ? (childVector.get(rawIndex) ?? null) : null;
+  }
+
+  /**
+   * Resolves one indexed child-column view.
+   *
+   * @typeParam P - Column name being read from the backing Arrow schema.
+   * @param columnName - Backing Arrow column name to expose as an indexed child-vector view.
+   * @returns Indexed child-vector view for the requested column, or `null` when the column is not
+   * present on the backing table.
+   */
+  getChild<P extends keyof T & string>(columnName: P): IndexedArrowVector<T[P]> | null {
+    let childViewCache = indexedChildVectorCache.get(this);
+    if (!childViewCache) {
+      childViewCache = new Map();
+      indexedChildVectorCache.set(this, childViewCache);
+    }
+
+    if (!childViewCache.has(columnName)) {
+      const childVector = getCachedRawChildVector(this.table, columnName);
+      childViewCache.set(
+        columnName,
+        childVector ? new IndexedArrowVector(childVector, this.indexes) : null
+      );
+    }
+
+    return (childViewCache.get(columnName) as IndexedArrowVector<T[P]> | null | undefined) ?? null;
+  }
+
+  /**
+   * Returns one sliced indexed view over the same backing Arrow table.
+   *
+   * @param begin - Optional inclusive visible-row start index.
+   * @param end - Optional exclusive visible-row end index.
+   * @returns New indexed view sharing the same backing Arrow table over the sliced visible rows.
+   */
+  slice(begin?: number, end?: number): IndexedArrowTable<T> {
+    return IndexedArrowTable.fromOwnedIndexes(this.table, this.indexes.slice(begin, end));
+  }
+
+  /**
+   * Returns one filtered indexed view over the same backing Arrow table.
+   *
+   * @param predicate - Visible-row predicate evaluated against this indexed view.
+   * @returns New indexed view containing only rows whose predicate result is `true`.
+   */
+  filter(predicate: IndexedArrowTablePredicate<T>): IndexedArrowTable<T> {
+    const nextIndexes: number[] = [];
+
+    for (let rowIndex = 0; rowIndex < this.numRows; rowIndex++) {
+      if (predicate(this, rowIndex)) {
+        nextIndexes.push(this.indexes[rowIndex]);
+      }
+    }
+
+    return new IndexedArrowTable(this.table, nextIndexes);
+  }
+
+  /**
+   * Returns one sorted indexed view over the same backing Arrow table.
+   *
+   * @param compare - Visible-row comparator evaluated against this indexed view.
+   * @returns New indexed view whose visible rows follow the comparator order.
+   */
+  sort(compare: IndexedArrowTableComparator<T>): IndexedArrowTable<T> {
+    const rowIndexes = Array.from({length: this.numRows}, (_, rowIndex) => rowIndex);
+    rowIndexes.sort((leftRowIndex, rightRowIndex) => compare(this, leftRowIndex, rightRowIndex));
+
+    return new IndexedArrowTable(
+      this.table,
+      rowIndexes.map((rowIndex) => this.indexes[rowIndex])
+    );
+  }
+
+  /**
+   * Concatenates this indexed view with other indexed views sharing the same Arrow schema.
+   *
+   * The returned view owns a new backing Arrow table assembled from the input tables' record
+   * batches while preserving each input view's visible row order.
+   *
+   * @param others - Additional indexed views to append after this view.
+   * @returns Indexed view over a concatenated backing Arrow table with appended visible indexes.
+   */
+  concat(...others: IndexedArrowTable<T>[]): IndexedArrowTable<T> {
+    const sourceTables = [this, ...others];
+
+    for (const sourceTable of sourceTables.slice(1)) {
+      if (!areArrowSchemasCompatible(this.schema, sourceTable.schema)) {
+        throw new Error('IndexedArrowTable.concat requires identical Arrow schemas.');
+      }
+    }
+
+    const concatenatedTable = this.table.concat(...others.map((sourceTable) => sourceTable.table));
+    const concatenatedIndexes = new Int32Array(
+      sourceTables.reduce((count, sourceTable) => count + sourceTable.numRows, 0)
+    );
+
+    let viewOffset = 0;
+    let tableRowOffset = 0;
+    for (const sourceTable of sourceTables) {
+      for (let rowIndex = 0; rowIndex < sourceTable.numRows; rowIndex++) {
+        concatenatedIndexes[viewOffset + rowIndex] = sourceTable.indexes[rowIndex] + tableRowOffset;
+      }
+      viewOffset += sourceTable.numRows;
+      tableRowOffset += sourceTable.table.numRows;
+    }
+
+    return IndexedArrowTable.fromOwnedIndexes(concatenatedTable, concatenatedIndexes);
+  }
+
+  /**
+   * Finds the first visible row that matches the supplied predicate.
+   *
+   * @param predicate - Search predicate evaluated against visible rows in indexed order.
+   * @returns First matching visible row, or `undefined` when no visible row matches.
+   */
+  find(predicate: IndexedArrowTableFindPredicate<T>): IndexedArrowTableRow<T> | undefined {
+    const rowIndex = this.findIndex(predicate);
+    return rowIndex === -1 ? undefined : (this.get(rowIndex) ?? undefined);
+  }
+
+  /**
+   * Finds the first visible row index that matches the supplied predicate.
+   *
+   * @param predicate - Search predicate evaluated against visible rows in indexed order.
+   * @returns First matching visible row index, or `-1` when no visible row matches.
+   */
+  findIndex(predicate: IndexedArrowTableFindPredicate<T>): number {
+    for (let rowIndex = 0; rowIndex < this.numRows; rowIndex++) {
+      if (predicate(this.get(rowIndex), rowIndex, this)) {
+        return rowIndex;
+      }
+    }
+
+    return -1;
+  }
+
+  /**
+   * Materializes the visible indexed rows into one concrete Arrow table snapshot.
+   *
+   * @returns Arrow table containing the current visible rows in indexed order, including duplicate
+   * rows when duplicate indexes are present.
+   */
+  materializeArrowTable(): arrow.Table<T> {
+    const materializedColumns = Object.fromEntries(
+      this.schema.fields.map((field) => {
+        const columnName = field.name as keyof T & string;
+        const childView = this.getChild(columnName);
+        if (!childView) {
+          throw new Error(`Missing Arrow child vector for column "${field.name}"`);
+        }
+
+        return [field.name, arrow.vectorFromArray(childView.toArray(), field.type)] as const;
+      })
+    );
+
+    return new (arrow.Table as any)(this.schema, materializedColumns) as arrow.Table<T>;
+  }
+
+  /**
+   * Materializes the visible indexed rows into a JavaScript array.
+   *
+   * @returns Array of materialized visible rows in indexed order.
+   */
+  toArray(): Array<IndexedArrowTableRow<T> | null> {
+    return Array.from(this);
+  }
+
+  /**
+   * Iterates over visible rows in indexed row order.
+   *
+   * @returns Iterator over materialized visible rows in indexed row order.
+   */
+  *[Symbol.iterator](): IterableIterator<IndexedArrowTableRow<T> | null> {
+    for (let rowIndex = 0; rowIndex < this.numRows; rowIndex++) {
+      yield this.get(rowIndex);
+    }
+  }
+}
+
+/**
+ * Returns whether two Arrow schemas are compatible for batch-level concatenation.
+ */
+function areArrowSchemasCompatible<T extends arrow.TypeMap>(
+  left: arrow.Schema<T>,
+  right: arrow.Schema<T>
+): boolean {
+  if (left === right) {
+    return true;
+  }
+
+  if (
+    left.fields.length !== right.fields.length ||
+    left.metadataVersion !== right.metadataVersion ||
+    !areArrowMetadataMapsEqual(left.metadata, right.metadata)
+  ) {
+    return false;
+  }
+
+  return left.fields.every((field, fieldIndex) => {
+    const otherField = right.fields[fieldIndex];
+    return (
+      otherField !== null &&
+      otherField !== undefined &&
+      field.name === otherField.name &&
+      field.nullable === otherField.nullable &&
+      field.typeId === otherField.typeId &&
+      String(field.type) === String(otherField.type) &&
+      areArrowMetadataMapsEqual(field.metadata, otherField.metadata)
+    );
+  });
+}
+
+/**
+ * Returns whether two Arrow metadata maps contain the same ordered key/value pairs.
+ */
+function areArrowMetadataMapsEqual(
+  left: ReadonlyMap<string, string>,
+  right: ReadonlyMap<string, string>
+): boolean {
+  if (left.size !== right.size) {
+    return false;
+  }
+
+  for (const [key, value] of left.entries()) {
+    if (right.get(key) !== value) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+const rawChildVectorCache = new WeakMap<object, Map<string, arrow.Vector<arrow.DataType> | null>>();
+const indexedChildVectorCache = new WeakMap<
+  object,
+  Map<string, IndexedArrowVector<arrow.DataType> | null>
+>();
+
+/**
+ * Resolves and caches one raw Arrow child vector by column name.
+ */
+function getCachedRawChildVector<T extends arrow.TypeMap, P extends keyof T & string>(
+  table: arrow.Table<T>,
+  columnName: P
+): arrow.Vector<T[P]> | null {
+  let tableCache = rawChildVectorCache.get(table);
+  if (!tableCache) {
+    tableCache = new Map();
+    rawChildVectorCache.set(table, tableCache);
+  }
+
+  if (!tableCache.has(columnName)) {
+    tableCache.set(
+      columnName,
+      (table.getChild(columnName) as arrow.Vector<arrow.DataType> | null) ?? null
+    );
+  }
+
+  return (tableCache.get(columnName) as arrow.Vector<T[P]> | null | undefined) ?? null;
+}

--- a/modules/arrow/src/lib/utils/indexed-arrow-vector.ts
+++ b/modules/arrow/src/lib/utils/indexed-arrow-vector.ts
@@ -1,0 +1,99 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import * as arrow from 'apache-arrow';
+
+import {
+  getIndexedAccessRow,
+  getIndexedRelativeAccessRow,
+  normalizeIndexedArrowIndexes
+} from './indexed-arrow-helpers';
+
+/**
+ * Readonly indexed view over one Apache Arrow vector.
+ *
+ * The view stores raw row indexes only. It does not copy vector values until callers iterate or call
+ * `toArray()`.
+ *
+ * @typeParam T - Backing Arrow data type.
+ */
+export class IndexedArrowVector<T extends arrow.DataType> {
+  /** Backing Arrow vector in raw row order. */
+  readonly vector: arrow.Vector<T>;
+  /** Raw row indexes exposed by this indexed view. */
+  readonly indexes: Int32Array;
+
+  /**
+   * Builds one indexed Arrow vector view.
+   *
+   * @param vector - Backing Arrow vector in raw row order.
+   * @param indexes - Raw vector indexes to expose through this view.
+   */
+  constructor(vector: arrow.Vector<T>, indexes: readonly number[] | Int32Array) {
+    this.vector = vector;
+    this.indexes = normalizeIndexedArrowIndexes(indexes, vector.length);
+  }
+
+  /**
+   * Number of visible values exposed through this indexed vector.
+   *
+   * @returns Count of visible values in the indexed view.
+   */
+  get length(): number {
+    return this.indexes.length;
+  }
+
+  /**
+   * Resolves one value by view-local row index.
+   *
+   * @param rowIndex - Visible row index within this indexed vector.
+   * @returns Value at the requested visible row index, or `null` when the index is invalid.
+   */
+  get(rowIndex: number): T['TValue'] | null {
+    const rawIndex = getIndexedAccessRow(this.indexes, rowIndex);
+    return rawIndex === null ? null : this.vector.get(rawIndex);
+  }
+
+  /**
+   * Resolves one value by relative view-local row index.
+   *
+   * @param rowIndex - Relative visible row index using `Array.prototype.at` semantics.
+   * @returns Value at the resolved visible row index, or `null` when the index is invalid.
+   */
+  at(rowIndex: number): T['TValue'] | null {
+    const normalizedIndex = getIndexedRelativeAccessRow(this.length, rowIndex);
+    return normalizedIndex === null ? null : this.get(normalizedIndex);
+  }
+
+  /**
+   * Returns one sliced indexed view over the same backing Arrow vector.
+   *
+   * @param begin - Optional inclusive visible-row start index.
+   * @param end - Optional exclusive visible-row end index.
+   * @returns New indexed vector view over the sliced visible values.
+   */
+  slice(begin?: number, end?: number): IndexedArrowVector<T> {
+    return new IndexedArrowVector(this.vector, this.indexes.slice(begin, end));
+  }
+
+  /**
+   * Materializes the visible indexed values into a JavaScript array.
+   *
+   * @returns Array of visible values in indexed row order.
+   */
+  toArray(): Array<T['TValue'] | null> {
+    return Array.from(this);
+  }
+
+  /**
+   * Iterates over visible values in indexed row order.
+   *
+   * @returns Iterator over visible values in indexed row order.
+   */
+  *[Symbol.iterator](): IterableIterator<T['TValue'] | null> {
+    for (let rowIndex = 0; rowIndex < this.length; rowIndex++) {
+      yield this.get(rowIndex);
+    }
+  }
+}

--- a/modules/arrow/src/lib/utils/mapped-arrow-table.ts
+++ b/modules/arrow/src/lib/utils/mapped-arrow-table.ts
@@ -1,0 +1,304 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import * as arrow from 'apache-arrow';
+
+import {getIndexedRelativeAccessRow, normalizeIndexedArrowIndexes} from './indexed-arrow-helpers';
+import {IndexedArrowTable} from './indexed-arrow-table';
+
+import type {IndexedArrowTableRow} from './indexed-arrow-table';
+
+const mappedArrowTableInitSymbol = Symbol('mapped-arrow-table-init');
+
+/** One mapped string key and its raw backing-table row index. */
+type MappedArrowTableEntry = readonly [rowKey: string, rowIndex: number];
+/** Internal construction state preserving duplicate mapped keys in derived views. */
+type MappedArrowTableInit = {
+  /** Ordered mapped entries to preserve instead of rebuilding them from unique map keys. */
+  [mappedArrowTableInitSymbol]: ReadonlyArray<MappedArrowTableEntry>;
+};
+
+/**
+ * Predicate evaluated against one mapped Arrow table view row.
+ *
+ * @typeParam T - Backing Arrow column map shared with the source table.
+ * @param table - Mapped table view currently being filtered.
+ * @param rowIndex - Visible mapped-row index within the mapped view.
+ * @returns `true` when the visible mapped row should remain in the filtered view.
+ */
+export type MappedArrowTablePredicate<T extends arrow.TypeMap> = (
+  table: MappedArrowTable<T>,
+  rowIndex: number
+) => boolean;
+
+/**
+ * Comparator evaluated against two mapped Arrow table view rows.
+ *
+ * @typeParam T - Backing Arrow column map shared with the source table.
+ * @param table - Mapped table view currently being sorted.
+ * @param leftRowIndex - Left visible mapped-row index within the mapped view.
+ * @param rightRowIndex - Right visible mapped-row index within the mapped view.
+ * @returns Negative when the left mapped row should sort first, positive when the right mapped row
+ * should sort first, or zero to preserve their current relative order.
+ */
+export type MappedArrowTableComparator<T extends arrow.TypeMap> = (
+  table: MappedArrowTable<T>,
+  leftRowIndex: number,
+  rightRowIndex: number
+) => number;
+
+/**
+ * Readonly string-keyed row lookup view layered on top of one indexed Arrow table.
+ *
+ * Duplicate keys are preserved in visible row order. Keyed lookups use last-wins semantics, so
+ * `getByKey(key)` resolves to the last visible row with that key.
+ *
+ * @typeParam T - Backing Arrow column map shared with the source table.
+ */
+export class MappedArrowTable<T extends arrow.TypeMap> extends IndexedArrowTable<T> {
+  /** Stable string-to-raw-row lookup map owned by this mapped view. */
+  readonly rowIndexMap: Map<string, number>;
+  /** String keys exposed in the current visible mapped-row order. Duplicate keys are preserved. */
+  readonly rowKeys: string[];
+
+  /**
+   * Builds one string-keyed mapped Arrow table view.
+   *
+   * @param table - Backing Arrow table in raw row order.
+   * @param rowIndexMap - Stable string-key-to-raw-row mapping to expose through this mapped view.
+   * @param init - Internal marker preserving duplicate mapped entries when creating derived views.
+   */
+  constructor(
+    table: arrow.Table<T>,
+    rowIndexMap: ReadonlyMap<string, number>,
+    init?: MappedArrowTableInit
+  ) {
+    const normalizedEntries = normalizeMappedArrowEntries(
+      init?.[mappedArrowTableInitSymbol] ?? Array.from(rowIndexMap.entries()),
+      table.numRows
+    );
+
+    super(
+      table,
+      normalizeIndexedArrowIndexes(
+        normalizedEntries.map(([, rowIndex]) => rowIndex),
+        table.numRows
+      )
+    );
+
+    this.rowIndexMap = buildMappedArrowRowIndexMap(normalizedEntries);
+    this.rowKeys = normalizedEntries.map(([rowKey]) => rowKey);
+  }
+
+  /**
+   * Resolves one raw backing-table row index by mapped string key.
+   *
+   * @param rowKey - Stable mapped key owned by this view.
+   * @returns Raw row index in the backing table, or `null` when the key is not present.
+   */
+  getRowIndex(rowKey: string): number | null {
+    return this.rowIndexMap.get(rowKey) ?? null;
+  }
+
+  /**
+   * Resolves one mapped key by view-local row index.
+   *
+   * @param rowIndex - Visible mapped-row index within this view.
+   * @returns Mapped key for the visible row index, or `null` when the index is invalid.
+   */
+  getRowKey(rowIndex: number): string | null {
+    if (!Number.isInteger(rowIndex) || rowIndex < 0 || rowIndex >= this.rowKeys.length) {
+      return null;
+    }
+
+    return this.rowKeys[rowIndex] ?? null;
+  }
+
+  /**
+   * Resolves one row object by mapped string key.
+   *
+   * @param rowKey - Stable mapped key owned by this view.
+   * @returns Materialized Arrow row for the mapped key, or `null` when the key is not present.
+   */
+  getByKey(rowKey: string): IndexedArrowTableRow<T> | null {
+    const rowIndex = this.getRowIndex(rowKey);
+    return rowIndex === null ? null : this.table.get(rowIndex);
+  }
+
+  /**
+   * Resolves one row object by relative mapped-row index.
+   *
+   * @param rowIndex - Relative mapped-row index using `Array.prototype.at` semantics.
+   * @returns Materialized Arrow row for the resolved mapped-row index, or `null` when the index is
+   * invalid.
+   */
+  atMapped(rowIndex: number): IndexedArrowTableRow<T> | null {
+    const normalizedIndex = getIndexedRelativeAccessRow(this.numRows, rowIndex);
+    return normalizedIndex === null ? null : this.get(normalizedIndex);
+  }
+
+  /**
+   * Returns one sliced mapped view over the same backing Arrow table.
+   *
+   * @param begin - Optional inclusive mapped-row start index.
+   * @param end - Optional exclusive mapped-row end index.
+   * @returns New mapped view sharing the same backing Arrow table over the sliced mapped rows.
+   */
+  override slice(begin?: number, end?: number): MappedArrowTable<T> {
+    return createMappedArrowTableFromEntries(
+      this.table,
+      getMappedEntriesSlice(this.rowKeys, this.indexes, begin, end)
+    );
+  }
+
+  /**
+   * Returns one filtered mapped view over the same backing Arrow table.
+   *
+   * @param predicate - Visible mapped-row predicate evaluated against this mapped view.
+   * @returns New mapped view containing only rows whose predicate result is `true`.
+   */
+  override filter(predicate: MappedArrowTablePredicate<T>): MappedArrowTable<T> {
+    return createMappedArrowTableFromEntries(this.table, getFilteredMappedEntries(this, predicate));
+  }
+
+  /**
+   * Returns one sorted mapped view over the same backing Arrow table.
+   *
+   * @param compare - Visible mapped-row comparator evaluated against this mapped view.
+   * @returns New mapped view whose visible rows follow the comparator order.
+   */
+  override sort(compare: MappedArrowTableComparator<T>): MappedArrowTable<T> {
+    return createMappedArrowTableFromEntries(this.table, getSortedMappedEntries(this, compare));
+  }
+
+  /**
+   * Concatenates this mapped view with other mapped views sharing the same Arrow schema.
+   *
+   * The returned view owns a new backing Arrow table assembled from the input tables' record
+   * batches, preserves visible mapped-row order including duplicate keys, and resolves keyed
+   * lookups to the last visible occurrence.
+   *
+   * @param others - Additional mapped views to append after this view.
+   * @returns Mapped view over a concatenated backing Arrow table.
+   */
+  override concat(...others: MappedArrowTable<T>[]): MappedArrowTable<T> {
+    const concatenatedIndexedTable = super.concat(...others);
+    return createMappedArrowTableFromEntries(
+      concatenatedIndexedTable.table,
+      getConcatenatedMappedEntries([this, ...others])
+    );
+  }
+}
+
+/**
+ * Builds one mapped Arrow table from visible mapped-row entries without collapsing duplicate keys.
+ */
+function createMappedArrowTableFromEntries<T extends arrow.TypeMap>(
+  table: arrow.Table<T>,
+  entries: ReadonlyArray<MappedArrowTableEntry>
+): MappedArrowTable<T> {
+  const rowIndexMap = buildMappedArrowRowIndexMap(entries);
+  return new MappedArrowTable(table, rowIndexMap, {
+    [mappedArrowTableInitSymbol]: entries
+  });
+}
+
+/**
+ * Builds a last-wins row-index map from visible mapped-row entries.
+ */
+function buildMappedArrowRowIndexMap(
+  entries: ReadonlyArray<MappedArrowTableEntry>
+): Map<string, number> {
+  const rowIndexMap = new Map<string, number>();
+
+  for (const [rowKey, rowIndex] of entries) {
+    rowIndexMap.set(rowKey, rowIndex);
+  }
+
+  return rowIndexMap;
+}
+
+/**
+ * Returns the mapped entries that remain after filtering one mapped Arrow table view.
+ */
+function getFilteredMappedEntries<T extends arrow.TypeMap>(
+  table: MappedArrowTable<T>,
+  predicate: MappedArrowTablePredicate<T>
+): Array<[string, number]> {
+  const nextEntries: Array<[string, number]> = [];
+
+  for (let rowIndex = 0; rowIndex < table.numRows; rowIndex++) {
+    if (predicate(table, rowIndex)) {
+      const rowKey = table.rowKeys[rowIndex];
+      const rawIndex = table.indexes[rowIndex];
+      nextEntries.push([rowKey, rawIndex]);
+    }
+  }
+
+  return nextEntries;
+}
+
+/**
+ * Returns the mapped entries that remain after sorting one mapped Arrow table view.
+ */
+function getSortedMappedEntries<T extends arrow.TypeMap>(
+  table: MappedArrowTable<T>,
+  compare: MappedArrowTableComparator<T>
+): Array<[string, number]> {
+  const rowIndexes = Array.from({length: table.numRows}, (_, rowIndex) => rowIndex);
+  rowIndexes.sort((leftRowIndex, rightRowIndex) => compare(table, leftRowIndex, rightRowIndex));
+
+  return rowIndexes.map((rowIndex) => [table.rowKeys[rowIndex], table.indexes[rowIndex]] as const);
+}
+
+/**
+ * Returns one owned slice of mapped entries in visible mapped-row order.
+ */
+function getMappedEntriesSlice(
+  rowKeys: readonly string[],
+  rowIndexes: Int32Array,
+  begin?: number,
+  end?: number
+): Array<MappedArrowTableEntry> {
+  const slicedRowKeys = rowKeys.slice(begin, end);
+  const slicedRowIndexes = rowIndexes.slice(begin, end);
+  return slicedRowKeys.map((rowKey, rowIndex) => [rowKey, slicedRowIndexes[rowIndex]] as const);
+}
+
+/**
+ * Returns concatenated mapped entries with backing-table row offsets applied per input view.
+ */
+function getConcatenatedMappedEntries<T extends arrow.TypeMap>(
+  tables: readonly MappedArrowTable<T>[]
+): Array<MappedArrowTableEntry> {
+  const concatenatedEntries: Array<MappedArrowTableEntry> = [];
+  let tableRowOffset = 0;
+
+  for (const table of tables) {
+    for (let rowIndex = 0; rowIndex < table.numRows; rowIndex++) {
+      concatenatedEntries.push([table.rowKeys[rowIndex], table.indexes[rowIndex] + tableRowOffset]);
+    }
+    tableRowOffset += table.table.numRows;
+  }
+
+  return concatenatedEntries;
+}
+
+/**
+ * Normalizes one list of mapped raw row-index entries into owned entries.
+ */
+function normalizeMappedArrowEntries(
+  entries: ReadonlyArray<MappedArrowTableEntry>,
+  maxExclusive: number
+): Array<MappedArrowTableEntry> {
+  const normalizedEntries = Array.from(entries);
+  const normalizedIndexes = normalizeIndexedArrowIndexes(
+    normalizedEntries.map(([, rowIndex]) => rowIndex),
+    maxExclusive
+  );
+
+  return normalizedEntries.map(
+    ([rowKey], rowIndex) => [rowKey, normalizedIndexes[rowIndex]] as const
+  );
+}

--- a/modules/arrow/src/lib/utils/mapped-arrow-table.ts
+++ b/modules/arrow/src/lib/utils/mapped-arrow-table.ts
@@ -173,17 +173,24 @@ export class MappedArrowTable<T extends arrow.TypeMap> extends IndexedArrowTable
   }
 
   /**
-   * Concatenates this mapped view with other mapped views sharing the same Arrow schema.
+   * Concatenates this mapped view with indexed views sharing the same Arrow schema.
    *
    * The returned view owns a new backing Arrow table assembled from the input tables' record
-   * batches, preserves visible mapped-row order including duplicate keys, and resolves keyed
-   * lookups to the last visible occurrence.
+   * batches and preserves visible row order. When every input is mapped, duplicate keys are
+   * preserved and keyed lookups resolve to the last visible occurrence. A plain indexed input
+   * produces a plain indexed result because it has no mapped keys to preserve.
    *
-   * @param others - Additional mapped views to append after this view.
-   * @returns Mapped view over a concatenated backing Arrow table.
+   * @param others - Additional indexed or mapped views to append after this view.
+   * @returns Mapped view when every input is mapped, or a plain indexed view for mixed inputs.
    */
-  override concat(...others: MappedArrowTable<T>[]): MappedArrowTable<T> {
+  override concat(...others: MappedArrowTable<T>[]): MappedArrowTable<T>;
+  override concat(...others: IndexedArrowTable<T>[]): IndexedArrowTable<T>;
+  override concat(...others: IndexedArrowTable<T>[]): IndexedArrowTable<T> {
     const concatenatedIndexedTable = super.concat(...others);
+    if (!others.every((table): table is MappedArrowTable<T> => table instanceof MappedArrowTable)) {
+      return concatenatedIndexedTable;
+    }
+
     return createMappedArrowTableFromEntries(
       concatenatedIndexedTable.table,
       getConcatenatedMappedEntries([this, ...others])

--- a/modules/arrow/test/index.ts
+++ b/modules/arrow/test/index.ts
@@ -4,5 +4,6 @@
 
 import './arrow-loader.spec';
 import './arrow-writer.spec';
+import './indexed-arrow-utils.spec';
 
 import './triangulate-on-worker.spec';

--- a/modules/arrow/test/indexed-arrow-utils.spec.ts
+++ b/modules/arrow/test/indexed-arrow-utils.spec.ts
@@ -1,0 +1,640 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import test from 'tape-promise/tape';
+import * as arrow from 'apache-arrow';
+
+import {IndexedArrowVector, IndexedArrowTable, MappedArrowTable} from '@loaders.gl/arrow';
+import {normalizeIndexedArrowIndexes} from '../src/lib/utils/indexed-arrow-helpers';
+
+import type {
+  IndexedArrowTableComparator,
+  IndexedArrowTableFindPredicate,
+  IndexedArrowTablePredicate,
+  IndexedArrowTableRow,
+  MappedArrowTableComparator,
+  MappedArrowTablePredicate
+} from '@loaders.gl/arrow';
+
+/** Arrow column types used by the generic indexed and mapped view fixtures. */
+type TestArrowColumns = {
+  /** Human-readable record label. */
+  name: arrow.Utf8;
+  /** Numeric value used to filter and order records. */
+  score: arrow.Float64;
+  /** Whether a record participates in the filtered view. */
+  active: arrow.Bool;
+  /** Small binary payload retained in the backing Arrow table. */
+  payload: arrow.Binary;
+  /** Category used to verify derived column views. */
+  group: arrow.Utf8;
+};
+
+/** One synthetic record used to construct the generic Arrow test tables. */
+type TestArrowRow = {
+  /** Human-readable record label. */
+  name: string;
+  /** Numeric value used to filter and order records. */
+  score: number;
+  /** Whether a record participates in the filtered view. */
+  active: boolean;
+  /** Small binary payload retained in the backing Arrow table. */
+  payload: Uint8Array;
+  /** Category used to verify derived column views. */
+  group: string;
+};
+
+test('ArrowUtils#IndexedArrowVector exposes indexed vector values', (t) => {
+  const vector = arrow.vectorFromArray(['zero', 'one', 'two'], new arrow.Utf8());
+  const typedIndexes = Int32Array.from([2, 0, 2]);
+  const indexedVector = new IndexedArrowVector(vector, typedIndexes);
+
+  t.notEqual(indexedVector.indexes, typedIndexes, 'copies typed indexes by default');
+  t.equal(indexedVector.length, 3, 'has visible value count');
+  t.equal(indexedVector.get(0), 'two', 'gets visible value');
+  t.equal(indexedVector.get(3), null, 'returns null for out-of-range value access');
+  t.equal(indexedVector.get(0.5), null, 'returns null for fractional value access');
+  t.equal(indexedVector.at(-1), 'two', 'gets relative value');
+  t.equal(indexedVector.at(-4), null, 'returns null for relative value access before start');
+  t.deepEqual(indexedVector.slice(1).toArray(), ['zero', 'two'], 'slices indexed values');
+  t.deepEqual(Array.from(indexedVector), ['two', 'zero', 'two'], 'iterates indexed values');
+
+  t.throws(() => new IndexedArrowVector(vector, [-1]), RangeError, 'rejects negative indexes');
+  t.throws(() => new IndexedArrowVector(vector, [3]), RangeError, 'rejects out-of-range indexes');
+  t.throws(() => new IndexedArrowVector(vector, [0.5]), RangeError, 'rejects fractional indexes');
+  t.throws(
+    () => new IndexedArrowVector(vector, [Infinity]),
+    RangeError,
+    'rejects infinite indexes'
+  );
+  t.end();
+});
+
+test('ArrowUtils#IndexedArrowTable normalizes indexes and resolves rows and columns', (t) => {
+  const table = createTestTable();
+  const indexedTable = new IndexedArrowTable(table, [2, 0, 1]);
+
+  t.deepEqual(Array.from(indexedTable.indexes), [2, 0, 1], 'normalizes row indexes');
+  t.equal(indexedTable.numRows, 3, 'has visible row count');
+  t.equal(indexedTable.numCols, 5, 'has column count');
+  t.equal(indexedTable.getRawIndex(1), 0, 'resolves raw row index');
+  t.equal(indexedTable.getRawIndex(99), null, 'returns null for invalid raw row lookup');
+  t.equal(indexedTable.getRawIndex(0.5), null, 'returns null for fractional raw row lookup');
+  t.equal(indexedTable.get(0)?.name, 'gamma', 'gets visible row');
+  t.equal(indexedTable.get(3), null, 'returns null for out-of-range row access');
+  t.equal(indexedTable.at(-1)?.name, 'beta', 'gets relative row');
+  t.equal(indexedTable.at(-4), null, 'returns null for relative row access before start');
+  t.equal(indexedTable.getValue(0, 'score'), 30, 'gets typed column value');
+  t.equal(indexedTable.getValue(0.5, 'score'), null, 'returns null for fractional value access');
+  t.equal(indexedTable.getValue(0, 'missing' as never), null, 'returns null for missing columns');
+  t.deepEqual(
+    indexedTable.getChild('name')?.toArray(),
+    ['gamma', 'alpha', 'beta'],
+    'gets child view'
+  );
+  t.equal(indexedTable.getChild('name'), indexedTable.getChild('name'), 'caches child views');
+  t.equal(indexedTable.getChild('missing' as never), null, 'returns null for missing child view');
+  t.end();
+});
+
+test('ArrowUtils#IndexedArrowTable validates and adopts indexes', (t) => {
+  const table = createTestTable();
+
+  const passthroughTable = new IndexedArrowTable(table);
+  t.deepEqual(Array.from(passthroughTable.indexes), [0, 1, 2], 'defaults to all rows in raw order');
+
+  const indexes = Int32Array.from([2, 0, 1]);
+  const ownedIndexTable = IndexedArrowTable.fromOwnedIndexes(table, indexes);
+  t.equal(ownedIndexTable.indexes, indexes, 'adopts owned typed row indexes');
+
+  t.throws(() => new IndexedArrowTable(table, [0, 3]), RangeError, 'rejects out-of-range indexes');
+  t.throws(() => new IndexedArrowTable(table, [0, 0.5]), RangeError, 'rejects fractional indexes');
+  t.end();
+});
+
+test('ArrowUtils#index normalization rejects values beyond signed Int32 range', (t) => {
+  const maximumIndex = 2 ** 31 - 1;
+  const indexes = Int32Array.from([0, maximumIndex]);
+
+  t.deepEqual(
+    Array.from(normalizeIndexedArrowIndexes([maximumIndex], maximumIndex + 1)),
+    [maximumIndex],
+    'accepts the maximum signed Int32 index without a large allocation'
+  );
+  t.equal(
+    normalizeIndexedArrowIndexes(indexes, maximumIndex + 1, false),
+    indexes,
+    'still adopts validated owned indexes without copying'
+  );
+  t.throws(
+    () => normalizeIndexedArrowIndexes([maximumIndex + 1], maximumIndex + 2),
+    RangeError,
+    'rejects a valid table index that would wrap to a negative Int32 value'
+  );
+  t.throws(
+    () => normalizeIndexedArrowIndexes([2 ** 32], 2 ** 32 + 1),
+    RangeError,
+    'rejects a valid table index that would wrap to zero'
+  );
+  t.end();
+});
+
+test('ArrowUtils#temporary rows preserve Arrow nulls and missing-child behavior', (t) => {
+  const table = new arrow.Table({
+    name: arrow.vectorFromArray([null, 'βeta'], new arrow.Utf8()),
+    missing: arrow.vectorFromArray(['unused', 'unused'], new arrow.Utf8())
+  });
+  const getChild = table.getChild.bind(table);
+  table.getChild = (columnName) => (columnName === 'missing' ? null : getChild(columnName));
+  const indexedTable = new IndexedArrowTable(table, [1, 0]);
+
+  const first = indexedTable.getTemporaryRow(0);
+  t.equal(first?.name, 'βeta', 'reads the non-null value before scratch-row reuse');
+  t.equal(first?.missing, undefined, 'returns undefined when no child vector exists');
+
+  const second = indexedTable.getTemporaryRow(1);
+  t.equal(second, first, 'reuses the same scratch-row object');
+  t.equal(indexedTable.get(1)?.name, null, 'the backing Arrow row contains null');
+  t.equal(second?.name, null, 'preserves null when replacing a previous non-null value');
+  t.equal(second?.missing, undefined, 'keeps missing child vectors distinct from Arrow nulls');
+  t.end();
+});
+
+test('ArrowUtils#IndexedArrowTable supports temporary rows and array-like transforms', (t) => {
+  const table = createTestTable();
+  const indexedTable = new IndexedArrowTable(table);
+
+  const firstTemporaryRow = indexedTable.getTemporaryRow(2);
+  const secondTemporaryRow = indexedTable.getTemporaryRow(0);
+  t.equal(secondTemporaryRow, firstTemporaryRow, 'reuses the same temporary row object');
+  t.equal(secondTemporaryRow?.name, 'alpha', 'updates temporary row values');
+  t.deepEqual(secondTemporaryRow?.payload, new Uint8Array([1, 2, 3]), 'updates binary row values');
+  t.equal(indexedTable.getTemporaryRow(99), null, 'returns null for invalid temporary row');
+
+  const filteredTable = indexedTable.filter(
+    (currentTable, rowIndex) => currentTable.getValue(rowIndex, 'active') ?? false
+  );
+  const sortedTable = filteredTable.sort(
+    (currentTable, leftRowIndex, rightRowIndex) =>
+      (currentTable.getValue(rightRowIndex, 'score') ?? 0) -
+      (currentTable.getValue(leftRowIndex, 'score') ?? 0)
+  );
+
+  t.deepEqual(Array.from(filteredTable.indexes), [0, 2], 'filters rows by indexed column value');
+  t.deepEqual(Array.from(sortedTable.indexes), [2, 0], 'sorts visible rows');
+  t.equal(indexedTable.find((row) => row?.name === 'alpha')?.score, 10, 'finds matching row');
+  t.equal(
+    indexedTable.findIndex((row) => row?.active === false),
+    1,
+    'finds matching row index'
+  );
+  t.equal(
+    indexedTable.find((row) => row?.name === 'missing'),
+    undefined,
+    'find returns undefined'
+  );
+  t.equal(
+    indexedTable.findIndex((row) => row?.name === 'missing'),
+    -1,
+    'findIndex returns -1'
+  );
+  t.deepEqual(
+    indexedTable
+      .slice(1)
+      .toArray()
+      .map((row) => row?.name),
+    ['beta', 'gamma'],
+    'slices and materializes visible rows'
+  );
+  t.end();
+});
+
+test('ArrowUtils#IndexedArrowTable concatenates and materializes indexed views', (t) => {
+  const leftTable = createTestTable();
+  const rightTable = createTestTableFromRows([
+    {
+      name: 'delta',
+      score: 40,
+      active: false,
+      payload: new Uint8Array([10, 11, 12]),
+      group: 'cool'
+    },
+    {
+      name: 'epsilon',
+      score: 50,
+      active: true,
+      payload: new Uint8Array([13, 14, 15]),
+      group: 'warm'
+    }
+  ]);
+
+  const concatenated = new IndexedArrowTable(leftTable, [2, 0]).concat(
+    new IndexedArrowTable(rightTable, [1, 0])
+  );
+
+  t.equal(concatenated.table.numRows, 5, 'concatenates backing tables');
+  t.deepEqual(Array.from(concatenated.indexes), [2, 0, 4, 3], 'preserves visible row indexes');
+  t.deepEqual(
+    Array.from(concatenated, (row) => row?.name),
+    ['gamma', 'alpha', 'epsilon', 'delta'],
+    'iterates concatenated rows'
+  );
+
+  const sameTableConcatenated = new IndexedArrowTable(leftTable, [2]).concat(
+    new IndexedArrowTable(leftTable, [0, 1])
+  );
+  t.equal(sameTableConcatenated.table.numRows, 6, 'duplicates same backing table batches');
+  t.deepEqual(
+    Array.from(sameTableConcatenated.indexes),
+    [2, 3, 4],
+    'offsets same-table concat indexes'
+  );
+  t.deepEqual(
+    Array.from(sameTableConcatenated, (row) => row?.name),
+    ['gamma', 'alpha', 'beta'],
+    'keeps same-table concat row access'
+  );
+
+  const emptyConcatenated = new IndexedArrowTable(leftTable, [1]).concat();
+  t.deepEqual(
+    Array.from(emptyConcatenated, (row) => row?.name),
+    ['beta'],
+    'supports empty concat'
+  );
+
+  const materializedTable = new IndexedArrowTable(leftTable, [2, 0, 2]).materializeArrowTable();
+  t.deepEqual(
+    Array.from(materializedTable, (row) => row.name),
+    ['gamma', 'alpha', 'gamma'],
+    'materializes indexed row order and duplicate indexes'
+  );
+  t.deepEqual(
+    Array.from(materializedTable.getChild('score') ?? []),
+    [30, 10, 30],
+    'materializes child column values'
+  );
+
+  const incompatibleTable = createArrowTable(
+    new arrow.Schema([new arrow.Field('name', new arrow.Utf8(), false)]),
+    {name: arrow.vectorFromArray(['delta'], new arrow.Utf8())}
+  );
+  t.throws(
+    () => new IndexedArrowTable(leftTable).concat(new IndexedArrowTable(incompatibleTable as any)),
+    /identical Arrow schemas/,
+    'rejects incompatible schemas'
+  );
+
+  const incompatibleNullabilityTable = createArrowTable(
+    new arrow.Schema<TestArrowColumns>([
+      new arrow.Field('name', new arrow.Utf8(), true),
+      new arrow.Field('score', new arrow.Float64(), false),
+      new arrow.Field('active', new arrow.Bool(), false),
+      new arrow.Field('payload', new arrow.Binary(), false),
+      new arrow.Field('group', new arrow.Utf8(), false)
+    ]),
+    {
+      name: arrow.vectorFromArray(['delta'], new arrow.Utf8()),
+      score: arrow.vectorFromArray([40], new arrow.Float64()),
+      active: arrow.vectorFromArray([true], new arrow.Bool()),
+      payload: arrow.vectorFromArray([new Uint8Array([10])], new arrow.Binary()),
+      group: arrow.vectorFromArray(['warm'], new arrow.Utf8())
+    }
+  );
+  t.throws(
+    () =>
+      new IndexedArrowTable(leftTable).concat(new IndexedArrowTable(incompatibleNullabilityTable)),
+    /identical Arrow schemas/,
+    'rejects schemas with incompatible nullability'
+  );
+  t.end();
+});
+
+test('ArrowUtils#IndexedArrowTable concatenates filtered and sliced indexed views', (t) => {
+  const leftView = new IndexedArrowTable(createTestTable()).filter(
+    (table, rowIndex) => table.getValue(rowIndex, 'active') ?? false
+  );
+  const rightView = new IndexedArrowTable(
+    createTestTableFromRows([
+      {
+        name: 'delta',
+        score: 40,
+        active: true,
+        payload: new Uint8Array([10, 11, 12]),
+        group: 'warm'
+      },
+      {
+        name: 'epsilon',
+        score: 50,
+        active: false,
+        payload: new Uint8Array([13, 14, 15]),
+        group: 'cool'
+      },
+      {
+        name: 'zeta',
+        score: 60,
+        active: true,
+        payload: new Uint8Array([16, 17, 18]),
+        group: 'warm'
+      }
+    ])
+  ).slice(1);
+
+  const concatenated = leftView.concat(rightView);
+
+  t.deepEqual(Array.from(concatenated.indexes), [0, 2, 4, 5], 'offsets derived view indexes');
+  t.equal(concatenated.get(2)?.name, 'epsilon', 'gets row after derived concat');
+  t.equal(concatenated.getValue(3, 'score'), 60, 'gets column value after derived concat');
+  t.deepEqual(
+    concatenated.getChild('group')?.toArray(),
+    ['warm', 'warm', 'cool', 'warm'],
+    'gets indexed child column after derived concat'
+  );
+  t.end();
+});
+
+test('ArrowUtils#MappedArrowTable supports keyed lookup and mapped transforms', (t) => {
+  const leftTable = createTestTableFromRows([
+    {
+      name: 'alpha-dup',
+      score: 10,
+      active: true,
+      payload: new Uint8Array([1]),
+      group: 'warm'
+    },
+    {
+      name: 'alpha-left',
+      score: 20,
+      active: true,
+      payload: new Uint8Array([2]),
+      group: 'cool'
+    }
+  ]);
+  const rightTable = createTestTableFromRows([
+    {
+      name: 'beta-dup',
+      score: 30,
+      active: false,
+      payload: new Uint8Array([3]),
+      group: 'cool'
+    },
+    {
+      name: 'beta-right',
+      score: 40,
+      active: true,
+      payload: new Uint8Array([4]),
+      group: 'warm'
+    }
+  ]);
+
+  const concatenated = new MappedArrowTable(
+    leftTable,
+    new Map([
+      ['dup', 0],
+      ['left', 1]
+    ])
+  ).concat(
+    new MappedArrowTable(
+      rightTable,
+      new Map([
+        ['dup', 0],
+        ['right', 1]
+      ])
+    )
+  );
+
+  t.deepEqual(concatenated.rowKeys, ['dup', 'left', 'dup', 'right'], 'preserves duplicate keys');
+  t.deepEqual(Array.from(concatenated.indexes), [0, 1, 2, 3], 'offsets raw row indexes');
+  t.equal(concatenated.getRowIndex('dup'), 2, 'uses last-wins keyed lookup');
+  t.equal(concatenated.getRowIndex('missing'), null, 'returns null for missing key index');
+  t.equal(concatenated.getByKey('dup')?.name, 'beta-dup', 'gets row by key');
+  t.equal(concatenated.getByKey('missing'), null, 'returns null for missing keyed row');
+  t.equal(concatenated.getRowKey(99), null, 'returns null for invalid key lookup');
+  t.equal(concatenated.getRowKey(0.5), null, 'returns null for fractional key lookup');
+  t.equal(concatenated.atMapped(-1)?.name, 'beta-right', 'supports relative mapped access');
+  t.equal(concatenated.atMapped(-5), null, 'returns null for invalid relative mapped access');
+
+  const sliced = concatenated.slice(1, 3);
+  const filtered = concatenated.filter((table, rowIndex) => table.getRowKey(rowIndex) === 'dup');
+  const sorted = concatenated.sort(
+    (table, leftRowIndex, rightRowIndex) =>
+      (table.getValue(rightRowIndex, 'score') ?? 0) - (table.getValue(leftRowIndex, 'score') ?? 0)
+  );
+
+  t.deepEqual(sliced.rowKeys, ['left', 'dup'], 'preserves mapped entries through slice');
+  t.equal(sliced.getByKey('dup')?.name, 'beta-dup', 'keeps sliced keyed lookup');
+  t.deepEqual(filtered.rowKeys, ['dup', 'dup'], 'preserves duplicate mapped keys through filter');
+  t.deepEqual(
+    Array.from(filtered, (row) => row?.name),
+    ['alpha-dup', 'beta-dup'],
+    'keeps filtered row order'
+  );
+  t.deepEqual(sorted.rowKeys, ['right', 'dup', 'left', 'dup'], 'sorts mapped row entries');
+  t.equal(sorted.getByKey('dup')?.name, 'alpha-dup', 'keeps last-wins lookup after sort');
+
+  t.throws(
+    () => new MappedArrowTable(leftTable, new Map([['bad', 2]])),
+    RangeError,
+    'rejects out-of-range mapped indexes'
+  );
+  t.end();
+});
+
+test('ArrowUtils#MappedArrowTable inherits indexed table materialization', (t) => {
+  const table = createTestTable();
+  const mappedTable = new MappedArrowTable(
+    table,
+    new Map([
+      ['gamma', 2],
+      ['alpha', 0]
+    ])
+  );
+
+  const materializedTable = mappedTable.materializeArrowTable();
+
+  t.deepEqual(
+    Array.from(materializedTable, (row) => row.name),
+    ['gamma', 'alpha'],
+    'materializes mapped row order'
+  );
+  t.deepEqual(
+    Array.from(materializedTable.getChild('group') ?? []),
+    ['warm', 'warm'],
+    'materializes mapped child column'
+  );
+  t.end();
+});
+
+test('ArrowUtils#indexed and mapped callback types are available at the public entrypoint', (t) => {
+  const table = createTestTable();
+  const indexedTable = new IndexedArrowTable(table);
+  const predicate: IndexedArrowTablePredicate<TestArrowColumns> = (view, rowIndex) =>
+    view.getValue(rowIndex, 'active') ?? false;
+  const comparator: IndexedArrowTableComparator<TestArrowColumns> = (view, left, right) =>
+    (view.getValue(right, 'score') ?? 0) - (view.getValue(left, 'score') ?? 0);
+  const findPredicate: IndexedArrowTableFindPredicate<TestArrowColumns> = (row) =>
+    row?.name === 'gamma';
+  const row: IndexedArrowTableRow<TestArrowColumns> | undefined = indexedTable
+    .filter(predicate)
+    .sort(comparator)
+    .find(findPredicate);
+
+  t.equal(row?.score, 30, 'retains typed row values after indexed transforms');
+
+  const mappedTable = new MappedArrowTable(
+    table,
+    new Map([
+      ['first', 0],
+      ['last', 2]
+    ])
+  );
+  const mappedPredicate: MappedArrowTablePredicate<TestArrowColumns> = (view, rowIndex) =>
+    view.getRowKey(rowIndex) !== null;
+  const mappedComparator: MappedArrowTableComparator<TestArrowColumns> = (view, left, right) =>
+    (view.getValue(right, 'score') ?? 0) - (view.getValue(left, 'score') ?? 0);
+
+  t.deepEqual(
+    mappedTable.filter(mappedPredicate).sort(mappedComparator).rowKeys,
+    ['last', 'first'],
+    'retains typed mapped callbacks and keyed order'
+  );
+  t.end();
+});
+
+test('ArrowUtils#indexed column transforms preserve backing buffers without materializing rows', (t) => {
+  const table = createTestTable();
+  const getRow = table.get.bind(table);
+  let materializedRowCount = 0;
+  table.get = (rowIndex) => {
+    materializedRowCount++;
+    return getRow(rowIndex);
+  };
+
+  const indexedTable = new IndexedArrowTable(table, [2, 0, 1]);
+  const transformed = indexedTable
+    .filter((view, rowIndex) => view.getValue(rowIndex, 'active') ?? false)
+    .sort(
+      (view, left, right) =>
+        (view.getValue(left, 'score') ?? 0) - (view.getValue(right, 'score') ?? 0)
+    );
+  const child = transformed.getChild('score');
+
+  t.equal(transformed.table, table, 'keeps the exact backing table');
+  t.equal(transformed.schema, table.schema, 'keeps the exact backing schema');
+  t.equal(
+    child?.vector.data[0].values.buffer,
+    table.getChild('score')?.data[0].values.buffer,
+    'keeps the backing column value buffer'
+  );
+  t.deepEqual(child?.toArray(), [10, 30], 'reads the transformed column in visible order');
+  t.equal(materializedRowCount, 0, 'does not call the backing table row accessor');
+  t.end();
+});
+
+test('ArrowUtils#indexed views preserve nullable Unicode and 64-bit values across batches', (t) => {
+  const schema = new arrow.Schema([
+    new arrow.Field('name', new arrow.Utf8(), true),
+    new arrow.Field('value', new arrow.Int64(), true)
+  ]);
+  // A synthetic integer beyond the safe Number range verifies lossless 64-bit access.
+  const largeValue = BigInt(Number.MAX_SAFE_INTEGER) + 2n;
+  const first = createArrowTable(schema, {
+    name: arrow.vectorFromArray(['βeta', null], new arrow.Utf8()),
+    value: arrow.vectorFromArray([largeValue, null], new arrow.Int64())
+  });
+  const second = createArrowTable(schema, {
+    name: arrow.vectorFromArray(['🙂', 'alpha'], new arrow.Utf8()),
+    value: arrow.vectorFromArray([largeValue + 1n, 0n], new arrow.Int64())
+  });
+  const table = first.concat(second);
+  const indexedTable = new IndexedArrowTable(table, [2, 1, 0, 3, 2]);
+
+  t.equal(table.batches.length, 2, 'uses multiple backing record batches');
+  t.deepEqual(
+    indexedTable.getChild('name')?.toArray(),
+    ['🙂', null, 'βeta', 'alpha', '🙂'],
+    'preserves Unicode, nulls and duplicate indexes'
+  );
+  t.deepEqual(
+    indexedTable.getChild('value')?.toArray(),
+    [largeValue + 1n, null, largeValue, 0n, largeValue + 1n],
+    'preserves 64-bit values without Number conversion'
+  );
+  t.end();
+});
+
+/**
+ * Builds one small Arrow table used by indexed and mapped view tests.
+ */
+function createTestTable(): arrow.Table<TestArrowColumns> {
+  return createTestTableFromRows([
+    {
+      name: 'alpha',
+      score: 10,
+      active: true,
+      payload: new Uint8Array([1, 2, 3]),
+      group: 'warm'
+    },
+    {
+      name: 'beta',
+      score: 20,
+      active: false,
+      payload: new Uint8Array([4, 5, 6]),
+      group: 'cool'
+    },
+    {
+      name: 'gamma',
+      score: 30,
+      active: true,
+      payload: new Uint8Array([7, 8, 9]),
+      group: 'warm'
+    }
+  ]);
+}
+
+/**
+ * Builds one small Arrow table from explicit row objects for concat-oriented tests.
+ */
+function createTestTableFromRows(rows: ReadonlyArray<TestArrowRow>): arrow.Table<TestArrowColumns> {
+  return createArrowTable(
+    new arrow.Schema<TestArrowColumns>([
+      new arrow.Field('name', new arrow.Utf8(), false),
+      new arrow.Field('score', new arrow.Float64(), false),
+      new arrow.Field('active', new arrow.Bool(), false),
+      new arrow.Field('payload', new arrow.Binary(), false),
+      new arrow.Field('group', new arrow.Utf8(), false)
+    ]),
+    {
+      name: arrow.vectorFromArray(
+        rows.map((row) => row.name),
+        new arrow.Utf8()
+      ),
+      score: arrow.vectorFromArray(
+        rows.map((row) => row.score),
+        new arrow.Float64()
+      ),
+      active: arrow.vectorFromArray(
+        rows.map((row) => row.active),
+        new arrow.Bool()
+      ),
+      payload: arrow.vectorFromArray(
+        rows.map((row) => row.payload),
+        new arrow.Binary()
+      ),
+      group: arrow.vectorFromArray(
+        rows.map((row) => row.group),
+        new arrow.Utf8()
+      )
+    }
+  );
+}
+
+/**
+ * Builds an Arrow table with an explicit schema and column vector map.
+ */
+function createArrowTable<T extends arrow.TypeMap>(
+  schema: arrow.Schema<T>,
+  columns: {[P in keyof T]: arrow.Vector<T[P]>}
+): arrow.Table<T> {
+  return new (arrow.Table as any)(schema, columns) as arrow.Table<T>;
+}

--- a/modules/arrow/test/indexed-arrow-utils.spec.ts
+++ b/modules/arrow/test/indexed-arrow-utils.spec.ts
@@ -353,6 +353,70 @@ test('ArrowUtils#IndexedArrowTable concatenates filtered and sliced indexed view
   t.end();
 });
 
+test('ArrowUtils#IndexedArrowTable validates nested field nullability and metadata', (t) => {
+  const field = new arrow.Field(
+    'value',
+    new arrow.Int32(),
+    false,
+    new Map([
+      ['unit', 'count'],
+      ['label', 'sample']
+    ])
+  );
+  const matchingField = new arrow.Field(
+    'value',
+    new arrow.Int32(),
+    false,
+    new Map([
+      ['label', 'sample'],
+      ['unit', 'count']
+    ])
+  );
+  const nullableField = new arrow.Field('value', new arrow.Int32(), true, field.metadata);
+  const differentMetadataField = new arrow.Field(
+    'value',
+    new arrow.Int32(),
+    false,
+    new Map([
+      ['unit', 'seconds'],
+      ['label', 'sample']
+    ])
+  );
+  const matchingTypes = createNestedTestTypes(matchingField);
+  const nullableTypes = createNestedTestTypes(nullableField);
+  const differentMetadataTypes = createNestedTestTypes(differentMetadataField);
+
+  for (const [name, type] of Object.entries(createNestedTestTypes(field))) {
+    const view = new IndexedArrowTable(createEmptyNestedTable(type));
+    t.doesNotThrow(
+      () => view.concat(new IndexedArrowTable(createEmptyNestedTable(matchingTypes[name]))),
+      `${name}: accepts equivalent nested fields with reordered metadata entries`
+    );
+    t.equal(
+      String(type),
+      String(nullableTypes[name]),
+      `${name}: type strings alone do not capture child nullability`
+    );
+    t.throws(
+      () => view.concat(new IndexedArrowTable(createEmptyNestedTable(nullableTypes[name]))),
+      /identical Arrow schemas/,
+      `${name}: rejects different nested nullability`
+    );
+    t.equal(
+      String(type),
+      String(differentMetadataTypes[name]),
+      `${name}: type strings alone do not capture child metadata`
+    );
+    t.throws(
+      () =>
+        view.concat(new IndexedArrowTable(createEmptyNestedTable(differentMetadataTypes[name]))),
+      /identical Arrow schemas/,
+      `${name}: rejects different nested metadata`
+    );
+  }
+  t.end();
+});
+
 test('ArrowUtils#MappedArrowTable supports keyed lookup and mapped transforms', (t) => {
   const leftTable = createTestTableFromRows([
     {
@@ -436,6 +500,55 @@ test('ArrowUtils#MappedArrowTable supports keyed lookup and mapped transforms', 
     () => new MappedArrowTable(leftTable, new Map([['bad', 2]])),
     RangeError,
     'rejects out-of-range mapped indexes'
+  );
+  t.end();
+});
+
+test('ArrowUtils#MappedArrowTable preserves the indexed concat contract for mixed inputs', (t) => {
+  const table = createTestTable();
+  const mappedView = new MappedArrowTable(
+    table,
+    new Map([
+      ['last', 2],
+      ['first', 0]
+    ])
+  );
+  const indexedView = new IndexedArrowTable(table, [1, 1]);
+  const lastMappedView = new MappedArrowTable(table, new Map([['last', 2]]));
+  const baseView: IndexedArrowTable<TestArrowColumns> = mappedView;
+  const mixedFromBase: IndexedArrowTable<TestArrowColumns> = baseView.concat(indexedView);
+  const mixed: IndexedArrowTable<TestArrowColumns> = mappedView.concat(indexedView, lastMappedView);
+
+  t.equal(mixedFromBase.constructor, IndexedArrowTable, 'base-typed calls produce an indexed view');
+  t.deepEqual(
+    Array.from(mixedFromBase, (row) => row?.name),
+    ['gamma', 'alpha', 'beta', 'beta'],
+    'base-typed calls preserve selected row order and duplicate indexes'
+  );
+  t.equal(mixed.constructor, IndexedArrowTable, 'a mixed call does not invent mapped keys');
+  t.deepEqual(Array.from(mixed.indexes), [2, 0, 4, 4, 8], 'offsets all mixed input indexes');
+  t.deepEqual(
+    mixed.getChild('name')?.toArray(),
+    ['gamma', 'alpha', 'beta', 'beta', 'gamma'],
+    'preserves mixed input order and duplicate rows'
+  );
+  t.equal(mixed.table.numRows, 9, 'retains all backing batches');
+  t.deepEqual(mappedView.rowKeys, ['last', 'first'], 'does not mutate the mapped source keys');
+
+  const allMapped: MappedArrowTable<TestArrowColumns> = mappedView.concat(lastMappedView);
+  t.equal(allMapped.constructor, MappedArrowTable, 'mapped-only overload retains the mapped type');
+  t.deepEqual(allMapped.rowKeys, ['last', 'first', 'last'], 'preserves duplicate mapped keys');
+  t.equal(allMapped.getRowIndex('last'), 5, 'keeps last-wins mapped-key lookup');
+  const noArguments: MappedArrowTable<TestArrowColumns> = mappedView.concat();
+  t.deepEqual(noArguments.rowKeys, mappedView.rowKeys, 'empty concat remains mapped');
+
+  const incompatibleView = new IndexedArrowTable(
+    new arrow.Table({different: arrow.vectorFromArray([1], new arrow.Int32())})
+  );
+  t.throws(
+    () => baseView.concat(incompatibleView as unknown as IndexedArrowTable<TestArrowColumns>),
+    /identical Arrow schemas/,
+    'mixed concat still validates schemas'
   );
   t.end();
 });
@@ -562,6 +675,22 @@ test('ArrowUtils#indexed views preserve nullable Unicode and 64-bit values acros
   );
   t.end();
 });
+
+/** Builds nested type variants that must retain their complete child field contracts. */
+function createNestedTestTypes(field: arrow.Field): Record<string, arrow.DataType> {
+  return {
+    struct: new arrow.Struct([field]),
+    list: new arrow.List(field),
+    fixedSizeList: new arrow.FixedSizeList(2, field),
+    nestedList: new arrow.List(new arrow.Field('item', new arrow.Struct([field]), false)),
+    dictionary: new arrow.Dictionary(new arrow.Struct([field]), new arrow.Int32(), 17)
+  };
+}
+
+/** Builds an empty table to exercise nested schema validation without materializing rows. */
+function createEmptyNestedTable(type: arrow.DataType): arrow.Table<{nested: arrow.DataType}> {
+  return new arrow.Table(new arrow.Schema([new arrow.Field('nested', type, true)]));
+}
 
 /**
  * Builds one small Arrow table used by indexed and mapped view tests.


### PR DESCRIPTION
## Goal

Expose reusable, readonly indexed Arrow views on the 4.5 release line: applications can filter, reorder and look up rows while retaining the backing columns.

## Review surface

Backports the four indexed/mapped utility files from [#3343](https://github.com/visgl/loaders.gl/pull/3343) (source commit `00bf91b3bbfcefdd1379ff96e0f0f1fb67bc9531`), plus public exports, documentation and tests.

- Export `IndexedArrowTable`, `IndexedArrowVector`, `MappedArrowTable` and six supporting callback/row types from `@loaders.gl/arrow`.
- Preserve duplicate row order, last-wins mapped-key lookup, owned-index adoption and explicit materialization.
- Correct two inherited edge cases: preserve Arrow nulls in scratch rows, and reject indexes outside signed Int32 range before conversion.
- Preserve the base `concat` contract for mixed mapped/indexed inputs, and validate nested child-field nullability and metadata before concatenation.
- Document the APIs and add them to the Arrow sidebar and next-patch notes.

Arrow transport, schema conversion changes, new dependencies and package-version changes are **not included**.

## Validation

Passed:

- 15 focused cases / 135 assertions on both Apache Arrow **17.0.0** and **21.1.0**.
- ESM/CJS module compilation; Arrow worker and browser-bundle builds.
- Public ESM/CJS entrypoints and strict TypeScript consumer checks using the built modules.
- Lint/format checks, including normal commit/push hooks; unchanged lockfile.
- Website build; it still reports existing broken-link/anchor warnings outside these pages.
- Changed-file size and neutral-fixture checks.

Full local validation still has environment limits. The reused installation contains Zod **3.23.8**, while the manifests require **^4.1.12**. The same Node suite run without its failing pretty-output pipe passes **8,210 / 8,211** assertions; only the existing invalid-TileJSON test differs on Zod 4's error wording. The previously observed aggregate Splats worker-generation limitation is unchanged. A fresh headless-browser rerun could not launch under the local OS sandbox; no post-fix browser runtime pass is claimed.

The original hosted CI run passed. [Hosted CI for the review-fix commit](https://github.com/visgl/loaders.gl/actions/runs/34242263623) is running.