### PR TITLE
feat(pmtiles): support MLT tile archives

### DIFF
--- a/docs/modules/pmtiles/formats/pmtiles.mdx
+++ b/docs/modules/pmtiles/formats/pmtiles.mdx
@@ -48,7 +48,7 @@ import {DocOrientation, ReferenceBoundary} from '@site/src/components/docs/desig
 
 PMTiles is a general format for storing tiled data addressed by Z/X/Y coordinates in a single (big) archive file. PMTiles is optimized for the cloud and can be hosted on commodity storage platforms like S3, enabling low-cost, zero-maintenance map applications, without requiring a server in the middle. PMTiles is structured to minimize overhead requests. The current V3 version of the format includes directories and tile data.
 
-PMTiles is commonly used for visualization (e.g. for cartographic basemap vector tiles), and then often contains vector data, where each tile data contained within the archive is encoded as a Mapbox Vector Tile (MVT), however it can also be used to store image tiles (in PNG and JPEG format) containing e.g. raster data or terrain mesh data.
+PMTiles is commonly used for visualization (e.g. for cartographic basemap vector tiles), and then often contains vector data, where each tile data contained within the archive is encoded as a Mapbox Vector Tile (MVT) or MapLibre Tile (MLT), however it can also be used to store image tiles (in PNG and JPEG format) containing e.g. raster data or terrain mesh data.
 
 A PMTiles archive replaces a big directory tree of thousands of individual tile files, allowing an entire tileset to be manipulated (uploaded, downloaded, served, analyzed) as a single file.
 
@@ -88,6 +88,7 @@ PMTiles is a container format and can in principle contain any type of quadtree-
 | `JPEG` | `'image/jpeg'`                         | `3`     |                                                     |
 | `WEBP` | `'image/webp'`                         | `4`     |                                                     |
 | `AVIF` | `'image/avif'`                         | `5`     |                                                     |
+| `MLT`  | `'application/vnd.maplibre-tile'`      | `6`     | [MapLibre Tile](/docs/modules/mlt/formats/mlt)      |
 | ...    | `'application/octet-stream'`           | ...     | Can be used for custom tile types                   |
 
 

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -102,6 +102,12 @@ See [Caching and memory](/docs/modules/3d-tiles/concepts/caching-and-memory) for
 - `load(url, SomeSourceLoader)` now returns the runtime `DataSource` instance created by that source loader instead of metadata or parsed payloads.
 - `parse()` and `parseSync()` no longer accept source loaders. Use `load()` for source loaders and keep `parse()` for parser loaders.
 
+**@loaders.gl/pmtiles**
+
+- PMTiles v3 archives with MapLibre Tile (MLT) payloads are supported through `@loaders.gl/mlt`.
+- The `pmtiles.shape: 'columnar-table'` option remains supported for MVT archives only. Passing it
+  for an MLT archive now throws; use `geojson-table`, `binary-geometry`, or `arrow-table` instead.
+
 **@loaders.gl/compression**
 
 - The compression package root now exports lightweight, library-neutral classes such as

--- a/modules/pmtiles/README.md
+++ b/modules/pmtiles/README.md
@@ -4,4 +4,8 @@
 
 This module contains loaders for the pmtiles format.
 
+The loader supports PMTiles specification version 3 archives, including MVT, raster, and MapLibre
+Tile (MLT) tile types. MLT tiles are decoded through `@loaders.gl/mlt` when requested from a
+`PMTilesTileSource`.
+
 For documentation please visit the [website](https://loaders.gl).

--- a/modules/pmtiles/README.md
+++ b/modules/pmtiles/README.md
@@ -8,4 +8,7 @@ The loader supports PMTiles specification version 3 archives, including MVT, ras
 Tile (MLT) tile types. MLT tiles are decoded through `@loaders.gl/mlt` when requested from a
 `PMTilesTileSource`.
 
+MLT tiles support the MLT decoder's `geojson-table`, `binary-geometry`, and `arrow-table` shapes;
+the PMTiles `columnar-table` shape remains available for MVT tiles only.
+
 For documentation please visit the [website](https://loaders.gl).

--- a/modules/pmtiles/package.json
+++ b/modules/pmtiles/package.json
@@ -56,9 +56,10 @@
   "dependencies": {
     "@loaders.gl/images": "5.0.0-alpha.5",
     "@loaders.gl/loader-utils": "5.0.0-alpha.5",
+    "@loaders.gl/mlt": "5.0.0-alpha.5",
     "@loaders.gl/mvt": "5.0.0-alpha.5",
     "@loaders.gl/schema": "5.0.0-alpha.5",
-    "pmtiles": "^4.4.1"
+    "pmtiles": "^4.5.0"
   },
   "peerDependencies": {
     "@loaders.gl/core": "~5.0.0-alpha.0"

--- a/modules/pmtiles/src/lib/parse-pmtiles.ts
+++ b/modules/pmtiles/src/lib/parse-pmtiles.ts
@@ -18,6 +18,7 @@ export type PMTilesMetadata = {
   /** MIME type for tile contents. Unknown tile types will return 'application/octet-stream */
   tileMIMEType:
     | 'application/vnd.mapbox-vector-tile'
+    | 'application/vnd.maplibre-tile'
     | 'image/png'
     | 'image/jpeg'
     | 'image/webp'
@@ -123,6 +124,7 @@ function decodeTileType(
   tileType: pmtiles.TileType
 ):
   | 'application/vnd.mapbox-vector-tile'
+  | 'application/vnd.maplibre-tile'
   | 'image/png'
   | 'image/jpeg'
   | 'image/webp'
@@ -131,6 +133,8 @@ function decodeTileType(
   switch (tileType) {
     case TileType.Mvt:
       return 'application/vnd.mapbox-vector-tile';
+    case TileType.Mlt:
+      return 'application/vnd.maplibre-tile';
     case TileType.Png:
       return 'image/png';
     case TileType.Jpeg:

--- a/modules/pmtiles/src/pmtiles-format.ts
+++ b/modules/pmtiles/src/pmtiles-format.ts
@@ -14,6 +14,6 @@ export const PMTilesFormat = {
   encoding: 'binary',
   format: 'pmtiles',
   extensions: ['pmtiles'],
-  mimeTypes: ['application/octet-stream'],
+  mimeTypes: ['application/vnd.pmtiles', 'application/octet-stream'],
   tests: ['PMTiles']
 } as const satisfies Format;

--- a/modules/pmtiles/src/pmtiles-loader-with-parser.ts
+++ b/modules/pmtiles/src/pmtiles-loader-with-parser.ts
@@ -44,6 +44,7 @@ async function parseFileAsPMTiles(
   const {layers = []} = tilejson;
   switch (tileMIMEType) {
     case 'application/vnd.mapbox-vector-tile':
+    case 'application/vnd.maplibre-tile':
       return {
         shape: 'vector-source',
         layers: layers.map(layer => ({name: layer.name, schema: layer.schema})),

--- a/modules/pmtiles/src/pmtiles-source-loader.ts
+++ b/modules/pmtiles/src/pmtiles-source-loader.ts
@@ -16,6 +16,7 @@ import type {
 } from '@loaders.gl/loader-utils';
 import {DataSource, DataSourceOptions, resolvePath} from '@loaders.gl/loader-utils';
 import {ImageBitmapLoader, ImageBitmapLoaderOptions} from '@loaders.gl/images';
+import {MLTLoader, MLTLoaderOptions} from '@loaders.gl/mlt';
 import {MVTLoader, MVTLoaderOptions, TileJSONLoaderOptions} from '@loaders.gl/mvt';
 import {PMTilesFormat} from './pmtiles-format';
 
@@ -39,7 +40,10 @@ export type PMTilesSourceLoaderOptions = DataSourceOptions & {
   /** Preferred encoding for Arrow geometry output. */
   geoarrow?: {encodingPreference?: GeoArrowEncodingPreference};
   core?: DataSourceOptions['core'] & {
-    loadOptions?: TileJSONLoaderOptions & MVTLoaderOptions & ImageBitmapLoaderOptions;
+    loadOptions?: TileJSONLoaderOptions &
+      MLTLoaderOptions &
+      MVTLoaderOptions &
+      ImageBitmapLoaderOptions;
   };
   pmtiles?: {
     /** Shape of returned vector tile data. */
@@ -162,6 +166,7 @@ export class PMTilesTileSource
     const metadata = await this.metadata;
     switch (metadata.tileMIMEType) {
       case 'application/vnd.mapbox-vector-tile':
+      case 'application/vnd.maplibre-tile':
         return await this.getVectorTile({x, y, z, layers: []});
       default:
         return await this.getImageTile({x, y, z, layers: []});
@@ -189,6 +194,34 @@ export class PMTilesTileSource
 
   async getVectorTile(tileParams: GetTileParameters): Promise<VectorTile | null> {
     const arrayBuffer = await this.getTile(tileParams);
+    const metadata = this.metadata ? await this.metadata : undefined;
+    const tileMIMEType = this.mimeType || metadata?.tileMIMEType;
+
+    if (tileMIMEType === 'application/vnd.maplibre-tile') {
+      const inheritedMLTOptions = (this.loadOptions as MLTLoaderOptions)?.mlt;
+      const loadOptions: MLTLoaderOptions = {
+        ...this.loadOptions,
+        mlt: {
+          ...inheritedMLTOptions,
+          shape:
+            normalizeMLTShape(this.options.pmtiles?.shape) ||
+            inheritedMLTOptions?.shape ||
+            'geojson-table',
+          coordinates: 'wgs84',
+          tileIndex: {x: tileParams.x, y: tileParams.y, z: tileParams.z},
+          layers: normalizeTileLayers(tileParams.layers) || inheritedMLTOptions?.layers,
+          geoarrow:
+            (this.options as PMTilesSourceLoaderOptions).geoarrow ||
+            this.options.pmtiles?.geoarrow ||
+            inheritedMLTOptions?.geoarrow
+        }
+      };
+
+      return arrayBuffer
+        ? ((await this.coreApi.parse(arrayBuffer, MLTLoader, loadOptions)) as VectorTile)
+        : null;
+    }
+
     const inheritedMVTOptions = (this.loadOptions as MVTLoaderOptions)?.mvt;
     const selectedLayers = normalizeTileLayers(tileParams.layers) || inheritedMVTOptions?.layers;
     const loadOptions: MVTLoaderOptions = {
@@ -258,6 +291,13 @@ export class PMTilesTileSource
 function normalizeTileLayers(layers?: string | string[]): string[] | undefined {
   const normalizedLayers = typeof layers === 'string' ? [layers] : layers;
   return normalizedLayers?.length ? normalizedLayers : undefined;
+}
+
+/** Maps the shared PMTiles shape options to shapes supported by the MLT decoder. */
+function normalizeMLTShape(
+  shape?: NonNullable<PMTilesSourceLoaderOptions['pmtiles']>['shape']
+): NonNullable<MLTLoaderOptions['mlt']>['shape'] | undefined {
+  return shape === 'columnar-table' ? 'geojson-table' : shape;
 }
 
 type PendingTileRequest = {

--- a/modules/pmtiles/src/pmtiles-source-loader.ts
+++ b/modules/pmtiles/src/pmtiles-source-loader.ts
@@ -204,7 +204,7 @@ export class PMTilesTileSource
         mlt: {
           ...inheritedMLTOptions,
           shape:
-            normalizeMLTShape(this.options.pmtiles?.shape) ||
+            getMLTShape(this.options.pmtiles?.shape) ||
             inheritedMLTOptions?.shape ||
             'geojson-table',
           coordinates: 'wgs84',
@@ -293,11 +293,14 @@ function normalizeTileLayers(layers?: string | string[]): string[] | undefined {
   return normalizedLayers?.length ? normalizedLayers : undefined;
 }
 
-/** Maps the shared PMTiles shape options to shapes supported by the MLT decoder. */
-function normalizeMLTShape(
+/** Returns a shape supported by the MLT decoder. */
+function getMLTShape(
   shape?: NonNullable<PMTilesSourceLoaderOptions['pmtiles']>['shape']
 ): NonNullable<MLTLoaderOptions['mlt']>['shape'] | undefined {
-  return shape === 'columnar-table' ? 'geojson-table' : shape;
+  if (shape === 'columnar-table') {
+    throw new Error('PMTilesTileSource: columnar-table shape is not supported for MLT tiles');
+  }
+  return shape;
 }
 
 type PendingTileRequest = {

--- a/modules/pmtiles/test/pmtiles-metadata.spec.ts
+++ b/modules/pmtiles/test/pmtiles-metadata.spec.ts
@@ -39,8 +39,8 @@ test.each([
   [3, 'image/jpeg'],
   [4, 'image/webp'],
   [5, 'image/avif'],
-  [0, 'application/octet-stream'],
-  [6, 'application/octet-stream']
+  [6, 'application/vnd.maplibre-tile'],
+  [0, 'application/octet-stream']
 ])('parsePMTilesHeader#decodes tile type %s', (tileType, tileMIMEType) => {
   const metadata = parsePMTilesHeader(createHeader(tileType as TileType), null);
 

--- a/modules/pmtiles/test/pmtiles-source-layers.spec.ts
+++ b/modules/pmtiles/test/pmtiles-source-layers.spec.ts
@@ -5,7 +5,9 @@
 import {afterEach, describe, expect, test, vi} from 'vitest';
 import type {Header} from 'pmtiles';
 import type {CoreAPI} from '@loaders.gl/loader-utils';
+import {MLTLoader} from '@loaders.gl/mlt';
 import type {MVTLoaderOptions} from '@loaders.gl/mvt';
+import {MVTLoader} from '@loaders.gl/mvt';
 import {PMTilesTileSource} from '../src/pmtiles-source-loader';
 
 /** Creates a valid compact PMTiles header for source metadata tests. */
@@ -46,11 +48,13 @@ afterEach(() => {
 
 test('PMTilesTileSource#getVectorTile forwards requested layers to the decoder', async () => {
   const receivedOptions: MVTLoaderOptions[] = [];
+  const receivedLoaders: unknown[] = [];
   const source = Object.assign(Object.create(PMTilesTileSource.prototype), {
     options: {pmtiles: {shape: 'arrow-table'}},
     loadOptions: {mvt: {layerProperty: 'sourceLayer', layers: ['fallback']}},
     coreApi: {
-      async parse(_data: unknown, _loaders: unknown, options: MVTLoaderOptions) {
+      async parse(_data: unknown, loaders: unknown, options: MVTLoaderOptions) {
+        receivedLoaders.push(loaders);
         receivedOptions.push(options);
         return {shape: 'arrow-table'};
       }
@@ -71,6 +75,40 @@ test('PMTilesTileSource#getVectorTile forwards requested layers to the decoder',
     layers: ['roads']
   });
   expect(receivedOptions[1].mvt?.layers).toEqual(['fallback']);
+  expect(receivedLoaders).toEqual([MVTLoader, MVTLoader]);
+});
+
+test('PMTilesTileSource#getVectorTile uses the MLT decoder for MLT archives', async () => {
+  let receivedLoader: unknown;
+  let receivedOptions: unknown;
+  const source = Object.assign(Object.create(PMTilesTileSource.prototype), {
+    options: {pmtiles: {shape: 'arrow-table'}},
+    loadOptions: {mlt: {layers: ['fallback']}},
+    mimeType: null,
+    metadata: Promise.resolve({tileMIMEType: 'application/vnd.maplibre-tile'}),
+    coreApi: {
+      async parse(_data: unknown, loaders: unknown, options: unknown) {
+        receivedLoader = loaders;
+        receivedOptions = options;
+        return {shape: 'arrow-table'};
+      }
+    } as unknown as CoreAPI,
+    async getTile() {
+      return new ArrayBuffer(1);
+    }
+  }) as PMTilesTileSource;
+
+  await source.getVectorTile({x: 2, y: 1, z: 3, layers: ['roads']});
+
+  expect(receivedLoader).toBe(MLTLoader);
+  expect(receivedOptions).toMatchObject({
+    mlt: {
+      shape: 'arrow-table',
+      coordinates: 'wgs84',
+      tileIndex: {x: 2, y: 1, z: 3},
+      layers: ['roads']
+    }
+  });
 });
 
 describe('PMTilesTileSource runtime paths', () => {

--- a/modules/pmtiles/test/pmtiles-source-layers.spec.ts
+++ b/modules/pmtiles/test/pmtiles-source-layers.spec.ts
@@ -111,6 +111,23 @@ test('PMTilesTileSource#getVectorTile uses the MLT decoder for MLT archives', as
   });
 });
 
+test('PMTilesTileSource#getVectorTile rejects columnar-table output for MLT archives', async () => {
+  const source = Object.assign(Object.create(PMTilesTileSource.prototype), {
+    options: {pmtiles: {shape: 'columnar-table'}},
+    loadOptions: {},
+    mimeType: null,
+    metadata: Promise.resolve({tileMIMEType: 'application/vnd.maplibre-tile'}),
+    coreApi: {} as CoreAPI,
+    async getTile() {
+      return new ArrayBuffer(1);
+    }
+  }) as PMTilesTileSource;
+
+  await expect(source.getVectorTile({x: 2, y: 1, z: 3, layers: ['roads']})).rejects.toThrow(
+    'columnar-table shape is not supported for MLT tiles'
+  );
+});
+
 describe('PMTilesTileSource runtime paths', () => {
   test('loads schema and normalized metadata', async () => {
     const source = Object.assign(Object.create(PMTilesTileSource.prototype), {

--- a/modules/pmtiles/tsconfig.json
+++ b/modules/pmtiles/tsconfig.json
@@ -11,6 +11,7 @@
     {"path": "../loader-utils"},
     {"path": "../schema"},
     {"path": "../images"},
-    {"path": "../mvt"}
+    {"path": "../mvt"},
+    {"path": "../mlt"}
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5588,7 +5588,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@loaders.gl/mlt@workspace:*, @loaders.gl/mlt@workspace:modules/mlt":
+"@loaders.gl/mlt@npm:5.0.0-alpha.5, @loaders.gl/mlt@workspace:*, @loaders.gl/mlt@workspace:modules/mlt":
   version: 0.0.0-use.local
   resolution: "@loaders.gl/mlt@workspace:modules/mlt"
   dependencies:
@@ -5719,9 +5719,10 @@ __metadata:
   dependencies:
     "@loaders.gl/images": "npm:5.0.0-alpha.5"
     "@loaders.gl/loader-utils": "npm:5.0.0-alpha.5"
+    "@loaders.gl/mlt": "npm:5.0.0-alpha.5"
     "@loaders.gl/mvt": "npm:5.0.0-alpha.5"
     "@loaders.gl/schema": "npm:5.0.0-alpha.5"
-    pmtiles: "npm:^4.4.1"
+    pmtiles: "npm:^4.5.0"
   peerDependencies:
     "@loaders.gl/core": ~5.0.0-alpha.0
   languageName: unknown
@@ -26929,12 +26930,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pmtiles@npm:^4.4.1":
-  version: 4.4.1
-  resolution: "pmtiles@npm:4.4.1"
+"pmtiles@npm:^4.5.0":
+  version: 4.5.0
+  resolution: "pmtiles@npm:4.5.0"
   dependencies:
     fflate: "npm:^0.8.2"
-  checksum: 10c0/39a14d9ce64230ddf3586d1c402375c42c5234095915a649fb14800a95155953f13315974f181faf53e6a3e0c55d86003e281482f5e10c56565018b065ba457e
+  checksum: 10c0/4f698991c1ace17447567e05f5793f9f192f085377cb1ba94e85e67461a01848096b6cf72972479abb698e171f3e8b61547d3d7a309f7cfa3ece2d545c618dc0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Goals

- Upgrade the PMTiles JavaScript dependency to the latest available release in the v4 line.
- Support PMTiles v3 archives whose tiles are encoded as MapLibre Tile (MLT).

## Changes

- Upgrade `pmtiles` from `4.4.1` to `4.5.0`.
- Recognize `application/vnd.pmtiles` archives.
- Decode PMTiles tile type `6` as `application/vnd.maplibre-tile`.
- Dispatch MLT tiles through `@loaders.gl/mlt`, forwarding shape, layer, coordinate, tile-index, and GeoArrow options.
- Update PMTiles documentation and add focused metadata and source-loader coverage.

The MLT tile type is defined by the [PMTiles v3 specification](https://github.com/protomaps/PMTiles/blob/main/spec/v3/spec.md#tile-type-tt). The [MapLibre implementation status](https://maplibre.org/maplibre-tile-spec/implementation-status/) lists PMTiles storage and Planetiler generation support. No large external archive is added as a test fixture.

## Validation

- `yarn vitest --project browser --run modules/pmtiles/test` — 23 passed
- `yarn test-audit` — passed
- `yarn lint fix` — passed
