### PR TITLE
feat(stac): support Portolan catalogs

### DIFF
--- a/docs/modules/stac/api-reference/stac-source-loader.md
+++ b/docs/modules/stac/api-reference/stac-source-loader.md
@@ -71,6 +71,9 @@ Returns the root Catalog or Collection, declared conformance classes, and the de
 
 The root document is fetched once and cached.
 
+When the root declares the Portolan publishing profile, the returned metadata also includes
+`portolanExtension` and `portolanVersion`.
+
 ### `getCollections(options?)`
 
 Returns Collections. For a STAC API it follows the Collections endpoint and `next` links. For a
@@ -101,10 +104,11 @@ Explicitly traverses `child` and `item` links in a static catalog. URLs are cycl
 bounded by `maxDepth` and `maxRequests`. The core `ids`, `collections`, `bbox`, and `datetime`
 constraints are evaluated locally before Items are yielded.
 
-### `getAssets(item, selection?)`
+### `getAssets(itemOrCollection, selection?)`
 
-Returns assets with URLs resolved against the Item document. Assets can be selected by `roles` and
-exact `mediaTypes`.
+Returns assets with URLs resolved against the Item or Collection document. Collection-level assets
+are useful for Portolan single-file collections. Assets can be selected by `roles` and exact
+`mediaTypes`.
 
 ## Options
 

--- a/docs/modules/stac/formats/stac.md
+++ b/docs/modules/stac/formats/stac.md
@@ -50,6 +50,24 @@ not prescribe how a GeoTIFF, GeoParquet file, Zarr store, PMTiles archive, or ot
 
 STAC extension fields are preserved by `@loaders.gl/stac` rather than discarded.
 
+## Portolan catalogs
+
+[Portolan](https://www.portolan-sdi.org/) is a STAC publishing profile for static, cloud-native
+geospatial catalogs. A Portolan catalog identifies itself with a versioned schema URI in
+`stac_extensions`, for example:
+
+```json
+{
+  "stac_extensions": [
+    "https://schemas.portolan-sdi.org/portolan/v0.2.0/schema.json"
+  ]
+}
+```
+
+`STACSource.getMetadata()` exposes the declared URI as `portolanExtension` and the semantic
+version as `portolanVersion`. Portolan collections may also publish data assets directly on the
+Collection, which can be selected with `source.getAssets(collection, selection)`.
+
 <ReferenceBoundary
   title="STAC objects and access modes"
   description="The sections below compare catalogs and APIs, explain composition with native format sources, and document browser access constraints."

--- a/examples/website/overture-parquet/README.md
+++ b/examples/website/overture-parquet/README.md
@@ -1,7 +1,8 @@
 # Overture Parquet browser query
 
 This example discovers the latest Overture Maps places release through STAC and queries its remote
-GeoParquet assets entirely in the browser. `ParquetDatasetSource` selects files and coordinates
+GeoParquet assets entirely in the browser. It also inspects the Overture STAC hierarchy for a
+declared Portolan profile. `ParquetDatasetSource` selects files and coordinates
 range-backed `ParquetSource` reads; Arrow batches render directly through `GeoArrowLayer`.
 
 ```bash

--- a/examples/website/overture-parquet/app.tsx
+++ b/examples/website/overture-parquet/app.tsx
@@ -22,7 +22,7 @@ import type {Table as ArrowTable} from 'apache-arrow';
 import maplibregl from 'maplibre-gl';
 import {Map} from 'react-map-gl';
 
-import {OverturePlacesCatalog} from './overture-catalog';
+import {OverturePlacesCatalog, type OverturePortolanInfo} from './overture-catalog';
 import './style.css';
 import 'maplibre-gl/dist/maplibre-gl.css';
 
@@ -37,7 +37,7 @@ const INITIAL_VIEW_STATE: MapViewState = {
   longitude: -71.064,
   latitude: 42.357,
   zoom: 12.2,
-  minZoom: 9,
+  minZoom: 3,
   maxZoom: 18,
   pitch: 25,
   bearing: 0
@@ -80,6 +80,7 @@ export default function App(props: AppProps = {}) {
   const [resultBatches, setResultBatches] = useState<ResultBatch[]>([]);
   const [telemetry, setTelemetry] = useState<ParquetDatasetTelemetry | null>(null);
   const [summary, setSummary] = useState<QuerySummary | null>(null);
+  const [portolanInfo, setPortolanInfo] = useState<OverturePortolanInfo | null>(null);
   const [status, setStatus] = useState('Ready to query the current map view');
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
@@ -111,6 +112,7 @@ export default function App(props: AppProps = {}) {
 
     try {
       const release = await catalog.getRelease();
+      setPortolanInfo(release.portolan);
       setStatus(`Reading Overture ${release.id} GeoParquet ranges…`);
       let batchIndex = 0;
       for await (const batch of source.read({
@@ -227,6 +229,19 @@ export default function App(props: AppProps = {}) {
             />
           </a>
           <div className="overture-eyebrow">STAC → ParquetDatasetSource → Arrow → deck.gl</div>
+          {portolanInfo ? (
+            <div className="overture-portolan">
+              <span>Portolan catalog</span>
+              <a
+                href={portolanInfo.catalogUrl}
+                target="_blank"
+                rel="noreferrer"
+                title={portolanInfo.extension}
+              >
+                {portolanInfo.version ? `v${portolanInfo.version}` : 'declared'}
+              </a>
+            </div>
+          ) : null}
           <h1>Query 73 million Overture places from your browser</h1>
           <p className="overture-copy">
             Move the map, then query the viewport. The browser discovers the latest release,

--- a/examples/website/overture-parquet/overture-catalog.ts
+++ b/examples/website/overture-parquet/overture-catalog.ts
@@ -10,12 +10,24 @@ import type {
   STACLink
 } from '@loaders.gl/stac';
 import type {
+  ParquetDatasetBoundingBox,
   ParquetDatasetFile,
   ParquetDatasetFileQuery
 } from '@loaders.gl/parquet/parquet-dataset-source';
+import type {STACBoundingBox} from '@loaders.gl/stac';
 
 const OVERTURE_STAC_ROOT = 'https://stac.overturemaps.org/catalog.json';
 const PARQUET_MEDIA_TYPE = 'application/vnd.apache.parquet';
+
+/** Portolan profile metadata declared by the Overture STAC hierarchy. */
+export type OverturePortolanInfo = {
+  /** Public Portolan catalog URL. */
+  catalogUrl: string;
+  /** Portolan profile schema URI declared by the catalog. */
+  extension: string;
+  /** Portolan profile version declared by the catalog. */
+  version: string | null;
+};
 
 /** Resolved Overture release metadata used by the example panel and file provider. */
 export type OvertureRelease = {
@@ -23,6 +35,8 @@ export type OvertureRelease = {
   id: string;
   /** STAC Collection containing partitioned place assets. */
   collectionSource: STACSource;
+  /** Portolan metadata declared by the Overture STAC hierarchy. */
+  portolan: OverturePortolanInfo | null;
 };
 
 /**
@@ -50,7 +64,7 @@ export class OverturePlacesCatalog {
   async *getFiles(query: ParquetDatasetFileQuery): AsyncIterable<ParquetDatasetFile> {
     const release = await this.getRelease(query.signal);
     for await (const item of release.collectionSource.traverse({
-      bbox: query.bbox,
+      bbox: toSTACBoundingBox(query.bbox),
       signal: query.signal,
       maxDepth: 1,
       maxRequests: 32
@@ -84,11 +98,46 @@ export class OverturePlacesCatalog {
     const placesSource = new STACSource(placesLink.href, {});
     const placesCatalog = await placesSource.getRoot({signal});
     const collectionLink = getChildLink(placesCatalog, 'place');
+    const collectionSource = new STACSource(collectionLink.href, {});
     return {
       id: getReleaseId(root, releaseCatalog, releaseLink),
-      collectionSource: new STACSource(collectionLink.href, {})
+      collectionSource,
+      portolan: await getPortolanInfo(
+        [rootSource, releaseSource, placesSource, collectionSource],
+        signal
+      )
     };
   }
+}
+
+/** Adapts Parquet's optional Z/M dimensions to the two-dimensional STAC query contract. */
+function toSTACBoundingBox(bbox?: ParquetDatasetBoundingBox): STACBoundingBox | undefined {
+  if (!bbox) {
+    return undefined;
+  }
+  if (bbox.length === 8) {
+    return [bbox[0], bbox[1], bbox[4], bbox[5]];
+  }
+  return bbox;
+}
+
+/** Reads Portolan metadata declared by one of the Overture STAC hierarchy documents. */
+async function getPortolanInfo(
+  sources: STACSource[],
+  signal?: AbortSignal
+): Promise<OverturePortolanInfo | null> {
+  for (const source of sources) {
+    const metadata = await source.getMetadata({signal});
+    if (!metadata.portolanExtension) {
+      continue;
+    }
+    return {
+      catalogUrl: source.url,
+      extension: metadata.portolanExtension,
+      version: metadata.portolanVersion
+    };
+  }
+  return null;
 }
 
 /** Selects the CORS-enabled AWS HTTPS asset from one Overture Item. */

--- a/examples/website/overture-parquet/style.css
+++ b/examples/website/overture-parquet/style.css
@@ -50,6 +50,30 @@
   text-transform: uppercase;
 }
 
+.overture-portolan {
+  display: flex;
+  width: fit-content;
+  align-items: center;
+  gap: 8px;
+  margin-top: 10px;
+  padding: 5px 8px;
+  border: 1px solid rgba(255, 183, 165, 0.25);
+  border-radius: 999px;
+  background: rgba(255, 111, 76, 0.1);
+  color: var(--muted);
+  font-size: 0.68rem;
+}
+
+.overture-portolan span {
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.overture-portolan a {
+  color: #ffb7a5;
+  font-weight: 750;
+}
+
 .overture-panel h1 {
   margin: 8px 0 10px;
   color: var(--text);

--- a/modules/stac/src/index.ts
+++ b/modules/stac/src/index.ts
@@ -4,6 +4,12 @@
 
 export {STACSourceLoader} from './stac-source-loader-types';
 export type {STACSourceLoaderOptions} from './stac-source-loader-types';
+export {
+  PORTOLAN_EXTENSION_URL_PREFIX,
+  getPortolanExtension,
+  getPortolanVersion,
+  isPortolanObject
+} from './portolan-extension';
 export type {
   STACAsset,
   STACAssetSelection,

--- a/modules/stac/src/portolan-extension.ts
+++ b/modules/stac/src/portolan-extension.ts
@@ -1,0 +1,27 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+/** Prefix used by versioned Portolan STAC profile schema URIs. */
+export const PORTOLAN_EXTENSION_URL_PREFIX = 'https://schemas.portolan-sdi.org/portolan/';
+
+const PORTOLAN_EXTENSION_URL_PATTERN =
+  /^https:\/\/schemas\.portolan-sdi\.org\/portolan\/v(\d+\.\d+\.\d+)\/schema\.json$/;
+
+/** Returns the Portolan profile schema URI declared by a STAC object, if any. */
+export function getPortolanExtension(stacExtensions?: readonly string[]): string | null {
+  return (
+    stacExtensions?.find(extension => extension.startsWith(PORTOLAN_EXTENSION_URL_PREFIX)) || null
+  );
+}
+
+/** Returns the semantic version declared by a Portolan profile schema URI, if it is versioned. */
+export function getPortolanVersion(stacExtensions?: readonly string[]): string | null {
+  const extension = getPortolanExtension(stacExtensions);
+  return extension ? (extension.match(PORTOLAN_EXTENSION_URL_PATTERN)?.[1] ?? null) : null;
+}
+
+/** Tests whether a STAC object declares the Portolan profile. */
+export function isPortolanObject(object: {stac_extensions?: readonly string[]}): boolean {
+  return Boolean(getPortolanExtension(object.stac_extensions));
+}

--- a/modules/stac/src/stac-source-loader-types.ts
+++ b/modules/stac/src/stac-source-loader-types.ts
@@ -51,7 +51,9 @@ export const STACSourceLoader = {
     }
   },
   testURL: (url: string): boolean =>
-    /(?:^|[/_.-])stac(?:[/_.?#-]|$)|\/(?:catalog|collection)\.json(?:$|[?#])/i.test(url),
+    /(?:^|[/_.-])(?:stac|portolan)(?:[/_.?#-]|$)|\/(?:catalog|collection)\.json(?:$|[?#])/i.test(
+      url
+    ),
   preload: preloadSTACSourceLoader,
   createDataSource(
     _data: string | Blob,

--- a/modules/stac/src/stac-source.ts
+++ b/modules/stac/src/stac-source.ts
@@ -12,6 +12,7 @@ import {DataSource} from '@loaders.gl/loader-utils';
 
 import {STACSourceLoader as STACSourceLoaderMetadata} from './stac-source-loader-types';
 import type {STACSourceLoaderOptions} from './stac-source-loader-types';
+import {getPortolanExtension, getPortolanVersion} from './portolan-extension';
 import type {
   STACAssetSelection,
   STACBoundingBox,
@@ -127,7 +128,9 @@ export class STACSource
     return {
       root,
       mode: findLink(root.links, 'search') || conformsTo.length > 0 ? 'api' : 'static',
-      conformsTo
+      conformsTo,
+      portolanExtension: getPortolanExtension(root.stac_extensions),
+      portolanVersion: getPortolanVersion(root.stac_extensions)
     };
   }
 
@@ -236,13 +239,22 @@ export class STACSource
     }
   }
 
-  /** Returns matching Item assets with document-relative URLs resolved to absolute URLs. */
-  getAssets(item: STACItem, selection: STACAssetSelection = {}): STACResolvedAsset[] {
-    const baseUrl = this.documentUrls.get(item) || this.url;
+  /**
+   * Returns matching Item or Collection assets with document-relative URLs resolved to absolute
+   * URLs.
+   *
+   * Collection-level assets are especially useful for Portolan single-file collections, which do
+   * not need an Item document around their data asset.
+   */
+  getAssets(
+    object: STACItem | STACCollection,
+    selection: STACAssetSelection = {}
+  ): STACResolvedAsset[] {
+    const baseUrl = this.documentUrls.get(object) || this.url;
     const requiredRoles = new Set(selection.roles || []);
     const requiredMediaTypes = new Set(selection.mediaTypes || []);
 
-    return Object.entries(item.assets)
+    return Object.entries(object.assets || {})
       .filter(([, asset]) => {
         const matchesRole =
           requiredRoles.size === 0 || asset.roles?.some(role => requiredRoles.has(role));

--- a/modules/stac/src/stac-types.ts
+++ b/modules/stac/src/stac-types.ts
@@ -187,6 +187,10 @@ export type STACSourceMetadata = {
   mode: STACMode;
   /** Declared API conformance classes. */
   conformsTo: readonly string[];
+  /** Portolan profile schema URI declared by the root, if any. */
+  portolanExtension: string | null;
+  /** Portolan profile version declared by the root, if it is versioned. */
+  portolanVersion: string | null;
 };
 
 /** Standard STAC API Item Search parameters supported without extensions. */

--- a/modules/stac/test/stac-source.spec.ts
+++ b/modules/stac/test/stac-source.spec.ts
@@ -6,7 +6,12 @@ import {describe, expect, test, vi} from 'vitest';
 
 import {STACSource, STACSourceLoaderWithParser} from '../src/stac-source';
 import {STACSourceLoader} from '../src/stac-source-loader-types';
-import type {STACItem} from '../src/stac-types';
+import {
+  getPortolanExtension,
+  getPortolanVersion,
+  isPortolanObject
+} from '../src/portolan-extension';
+import type {STACCatalog, STACCollection, STACItem} from '../src/stac-types';
 
 const ROOT_URL = 'https://example.test/catalog.json';
 
@@ -15,6 +20,7 @@ describe('STACSource metadata loader', () => {
     expect(STACSourceLoader.fromUrl).toBe(true);
     expect(STACSourceLoader.fromBlob).toBe(false);
     expect(STACSourceLoader.testURL(ROOT_URL)).toBe(true);
+    expect(STACSourceLoader.testURL('https://example.test/portolan/')).toBe(true);
     expect(STACSourceLoaderWithParser.createDataSource).toBeTypeOf('function');
     expect(STACSourceLoaderWithParser.createDataSource(ROOT_URL, {})).toBeInstanceOf(STACSource);
     await expect(STACSourceLoader.preload()).resolves.toBe(STACSourceLoaderWithParser);
@@ -23,9 +29,58 @@ describe('STACSource metadata loader', () => {
       /catalog URL/
     );
   });
+
+  test('recognizes Portolan profile schema URIs', () => {
+    const extensions = [
+      'https://stac-extensions.github.io/table/v1.2.0/schema.json',
+      'https://schemas.portolan-sdi.org/portolan/v0.2.0/schema.json'
+    ];
+    expect(getPortolanExtension(extensions)).toBe(extensions[1]);
+    expect(getPortolanVersion(extensions)).toBe('0.2.0');
+    expect(isPortolanObject({stac_extensions: extensions})).toBe(true);
+    expect(getPortolanExtension(['https://example.test/portolan/v0.2.0/schema.json'])).toBeNull();
+    expect(
+      getPortolanVersion(['https://schemas.portolan-sdi.org/portolan/schema.json'])
+    ).toBeNull();
+  });
 });
 
 describe('STACSource static catalogs', () => {
+  test('exposes Portolan metadata and collection-level assets', async () => {
+    const portolanExtension = 'https://schemas.portolan-sdi.org/portolan/v0.2.0/schema.json';
+    const collection = createCollection('roads', []);
+    collection.stac_extensions = [portolanExtension];
+    collection.assets = {
+      data: {
+        href: './roads.parquet',
+        type: 'application/vnd.apache.parquet',
+        roles: ['data']
+      }
+    };
+    const root = createCatalog('root', [{rel: 'child', href: 'roads/collection.json'}]);
+    root.stac_extensions = [portolanExtension];
+    const source = createSource(
+      ROOT_URL,
+      createFetch({
+        [ROOT_URL]: root,
+        'https://example.test/roads/collection.json': collection
+      })
+    );
+
+    await expect(source.getMetadata()).resolves.toMatchObject({
+      mode: 'static',
+      portolanExtension,
+      portolanVersion: '0.2.0'
+    });
+    const collections = await source.getCollections();
+    expect(source.getAssets(collections[0], {roles: ['data']})).toEqual([
+      expect.objectContaining({
+        key: 'data',
+        href: 'https://example.test/roads/roads.parquet'
+      })
+    ]);
+  });
+
   test('traverses relative links, avoids cycles, filters Items, and resolves assets', async () => {
     const documents: Record<string, unknown> = {
       [ROOT_URL]: createCatalog('root', [
@@ -406,7 +461,7 @@ function jsonResponse(value: unknown): Response {
   });
 }
 
-function createCatalog(id: string, links: Array<Record<string, unknown>>) {
+function createCatalog(id: string, links: Array<Record<string, unknown>>): STACCatalog {
   return {
     type: 'Catalog' as const,
     stac_version: '1.1.0',
@@ -416,7 +471,7 @@ function createCatalog(id: string, links: Array<Record<string, unknown>>) {
   };
 }
 
-function createCollection(id: string, links: Array<Record<string, unknown>>) {
+function createCollection(id: string, links: Array<Record<string, unknown>>): STACCollection {
   return {
     ...createCatalog(id, links),
     type: 'Collection' as const,

--- a/modules/worker-utils/src/lib/worker-utils/get-loadable-worker-url.ts
+++ b/modules/worker-utils/src/lib/worker-utils/get-loadable-worker-url.ts
@@ -47,9 +47,29 @@ function getLoadableWorkerURLFromURL(url: string): string {
     return url;
   }
 
+  // Same-origin absolute URLs can also be initialized directly. Wrapping one
+  // in a Blob worker changes the request origin to an opaque origin, which
+  // requires CORS even when the script is served by the current host.
+  if (isSameOrigin(url)) {
+    return url;
+  }
+
   // A remote script, we need to use `importScripts` to load from different origin
   const workerSource = buildScriptSource(url);
   return getLoadableWorkerURLFromSource(workerSource);
+}
+
+/** Returns whether a worker URL is served by the current browser origin. */
+function isSameOrigin(url: string): boolean {
+  if (typeof location === 'undefined') {
+    return false;
+  }
+
+  try {
+    return new URL(url, location.href).origin === location.origin;
+  } catch {
+    return false;
+  }
 }
 
 /**

--- a/modules/worker-utils/test/lib/worker-utils/get-loadable-worker-url.spec.ts
+++ b/modules/worker-utils/test/lib/worker-utils/get-loadable-worker-url.spec.ts
@@ -21,6 +21,13 @@ test('getLoadableWorkerURL', () => {
   expect(workerURL.startsWith('blob:'), 'Worker source generates Object URL').toBeTruthy();
   workerURL = getLoadableWorkerURL({url: LOCAL_WORKER_URL});
   expect(workerURL, 'Local worker URL is returned unchanged').toBe(LOCAL_WORKER_URL);
+  if (typeof location !== 'undefined') {
+    const sameOriginWorkerURL = `${location.origin}/modules/worker-utils/dist/null-worker.js`;
+    workerURL = getLoadableWorkerURL({url: sameOriginWorkerURL});
+    expect(workerURL, 'Same-origin absolute worker URL is returned unchanged').toBe(
+      sameOriginWorkerURL
+    );
+  }
   workerURL = getLoadableWorkerURL({url: REMOTE_WORKER_URL});
   expect(workerURL.startsWith('blob:'), 'Remote worker URL generates Object URL').toBeTruthy();
   expect(

--- a/website/src/examples/geospatial/overture-parquet.mdx
+++ b/website/src/examples/geospatial/overture-parquet.mdx
@@ -13,6 +13,8 @@ import {ParquetScanLiveExample} from '@site/src/components/docs/parquet-scan-liv
     [**`ParquetDatasetSource`**](/docs/modules/parquet/api-reference/parquet-source-loader#multi-file-datasets) combines live STAC discovery, selective GeoParquet range reads, Arrow batches, and deck.gl rendering without a server-side query runtime.
 
     Overture's ZSTD pages decode in the Parquet source worker using native `DecompressionStream` support when available and a lightweight JavaScript fallback otherwise.
+
+    The panel inspects the Overture STAC hierarchy and shows its declared Portolan profile version when one is present.
   </ClientExample>
 </div>
 


### PR DESCRIPTION
## Goals

Support Portolan as a STAC publishing profile and demonstrate the metadata path in the browser-based Overture example.

## Changes

- Add Portolan profile detection and version extraction to `@loaders.gl/stac`.
- Expose Portolan metadata from `STACSource.getMetadata()`.
- Support collection-level assets for Portolan single-file collections.
- Update STAC URL detection and documentation.
- Inspect the Overture STAC hierarchy for a Portolan declaration in the Overture example.
- Load same-origin absolute worker URLs directly so Vite localhost workers do not require a Blob `importScripts()` wrapper.

## Validation

- `yarn lint fix`
- `yarn test-audit`
- `yarn test-headless modules/stac/test/stac-source.spec.ts modules/worker-utils/test/lib/worker-utils/get-loadable-worker-url.spec.ts`
- `yarn build`
- `cd examples/website/overture-parquet && yarn build`

The current authoritative Overture STAC catalog does not declare Portolan, so the example only displays profile metadata when Overture publishes it.