### PR TITLE
fix(tile-converter): preserve zero-valued material factors

### DIFF
--- a/apps/tile-converter/src/i3s-converter/helpers/geometry-converter.ts
+++ b/apps/tile-converter/src/i3s-converter/helpers/geometry-converter.ts
@@ -1056,7 +1056,7 @@ async function mergeMaterials(
  * @param sourceMaterial - material object
  * @returns I3S material definition and texture
  */
-function convertMaterial(sourceMaterial: GLTFMaterialPostprocessed): I3SMaterialWithTexture {
+export function convertMaterial(sourceMaterial: GLTFMaterialPostprocessed): I3SMaterialWithTexture {
   const material: I3SMaterialDefinition = {
     doubleSided: sourceMaterial.doubleSided,
     emissiveFactor: sourceMaterial.emissiveFactor?.map(c => Math.round(c * 255)) as [
@@ -1069,9 +1069,9 @@ function convertMaterial(sourceMaterial: GLTFMaterialPostprocessed): I3SMaterial
     alphaMode: convertAlphaMode(sourceMaterial.alphaMode),
     pbrMetallicRoughness: {
       roughnessFactor:
-        sourceMaterial?.pbrMetallicRoughness?.roughnessFactor || DEFAULT_ROUGHNESS_FACTOR,
+        sourceMaterial?.pbrMetallicRoughness?.roughnessFactor ?? DEFAULT_ROUGHNESS_FACTOR,
       metallicFactor:
-        sourceMaterial?.pbrMetallicRoughness?.metallicFactor || DEFAULT_METALLIC_FACTOR
+        sourceMaterial?.pbrMetallicRoughness?.metallicFactor ?? DEFAULT_METALLIC_FACTOR
     }
   };
 
@@ -1095,6 +1095,8 @@ function convertMaterial(sourceMaterial: GLTFMaterialPostprocessed): I3SMaterial
     // Should use default baseColorFactor if it is not present in source material
     // https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#reference-pbrmetallicroughness
     const baseColorFactor = sourceMaterial?.pbrMetallicRoughness?.baseColorFactor;
+    // This converter's I3S storage path uses byte-style color values; the I3S loader normalizes
+    // them when creating the glTF-compatible material consumed by deck/luma.
     material.pbrMetallicRoughness.baseColorFactor =
       ((baseColorFactor && baseColorFactor.map(c => Math.round(c * 255))) as [
         number,

--- a/apps/tile-converter/tsconfig.json
+++ b/apps/tile-converter/tsconfig.json
@@ -8,17 +8,17 @@
     "outDir": "dist"
   },
   "references": [
-    {"path": "../3d-tiles"},
-    {"path": "../crypto"},
-    {"path": "../draco"},
-    {"path": "../gltf"},
-    {"path": "../i3s"},
-    {"path": "../images"},
-    {"path": "../loader-utils"},
-    {"path": "../polyfills"},
-    {"path": "../tiles"},
-    {"path": "../worker-utils"},
-    {"path": "../zip"},
-    {"path": "../core"}
+    {"path": "../../modules/3d-tiles"},
+    {"path": "../../modules/crypto"},
+    {"path": "../../modules/draco"},
+    {"path": "../../modules/gltf"},
+    {"path": "../../modules/i3s"},
+    {"path": "../../modules/images"},
+    {"path": "../../modules/loader-utils"},
+    {"path": "../../modules/polyfills"},
+    {"path": "../../modules/tiles"},
+    {"path": "../../modules/worker-utils"},
+    {"path": "../../modules/zip"},
+    {"path": "../../modules/core"}
   ]
 }

--- a/test/tile-converter-materials.node.spec.ts
+++ b/test/tile-converter-materials.node.spec.ts
@@ -1,0 +1,40 @@
+import {expect, test} from 'vitest';
+
+import type {GLTFMaterialPostprocessed} from '@loaders.gl/gltf';
+import {convertMaterial} from '../apps/tile-converter/src/i3s-converter/helpers/geometry-converter';
+
+function createMaterial(
+  pbrMetallicRoughness: GLTFMaterialPostprocessed['pbrMetallicRoughness']
+): GLTFMaterialPostprocessed {
+  return {
+    id: 'material',
+    alphaMode: 'OPAQUE',
+    pbrMetallicRoughness
+  };
+}
+
+test('tile-converter(i3s) preserves zero metallic and roughness factors', () => {
+  const convertedMaterial = convertMaterial(
+    createMaterial({metallicFactor: 0, roughnessFactor: 0, baseColorFactor: [0, 0, 0, 1]})
+  );
+
+  expect(convertedMaterial.material.pbrMetallicRoughness).toMatchObject({
+    metallicFactor: 0,
+    roughnessFactor: 0,
+    baseColorFactor: [0, 0, 0, 255]
+  });
+});
+
+test('tile-converter(i3s) writes base color factors in the I3S byte range', () => {
+  const convertedMaterial = convertMaterial(
+    createMaterial({
+      metallicFactor: 1,
+      roughnessFactor: 1,
+      baseColorFactor: [0.25, 0.5, 0.75, 1]
+    })
+  );
+
+  expect(convertedMaterial.material.pbrMetallicRoughness.baseColorFactor).toEqual([
+    64, 128, 191, 255
+  ]);
+});


### PR DESCRIPTION
Goals:

- Preserve explicit zero values for I3S metallic and roughness material factors.
- Keep the existing I3S byte-style color storage intentional and documented for the loader path consumed by deck/luma.

Changes:

- Replace truthiness fallbacks with nullish fallbacks for metallicFactor and roughnessFactor.
- Add regression coverage for zero-valued factors and byte-style baseColorFactor conversion.
- Document why baseColorFactor remains converted from normalized glTF values to 0-255 I3S storage values.

Validation:

- yarn lint fix
- yarn build
- yarn test-apps

Fixes #3688. Related to #3689; this PR does not change the existing byte-color storage contract.