### PR TITLE
fix(wkt): support async WKB parsing in shared worker

### DIFF
--- a/docs/modules/wkt/api-reference/wkb-loader.md
+++ b/docs/modules/wkt/api-reference/wkb-loader.md
@@ -63,8 +63,8 @@ const data = await parse(buffer, WKBLoader, {wkb: {workerUrl: WKT_WORKER_URL}});
 
 ## Options
 
-| Option | Type | Default | Description |
-| --- | --- | --- | --- |
+| Option          | Type     | Default | Description                             |
+| --------------- | -------- | ------- | --------------------------------------- |
 | `wkb.workerUrl` | `string` | CDN URL | Override the shared WKT/WKB worker URL. |
 
 ## Format Summary

--- a/docs/modules/wkt/api-reference/wkb-loader.md
+++ b/docs/modules/wkt/api-reference/wkb-loader.md
@@ -50,9 +50,22 @@ import {load} from '@loaders.gl/core';
 const data = await load(url, WKBLoader);
 ```
 
+Asynchronous parsing uses the bundled worker automatically when workers are enabled. When
+bundling with Vite, the worker URL can be supplied explicitly:
+
+```typescript
+import WKT_WORKER_URL from '@loaders.gl/wkt/wkt-worker.js?url';
+import {parse} from '@loaders.gl/core';
+import {WKBLoader} from '@loaders.gl/wkt';
+
+const data = await parse(buffer, WKBLoader, {wkb: {workerUrl: WKT_WORKER_URL}});
+```
+
 ## Options
 
-N/A
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `wkb.workerUrl` | `string` | CDN URL | Override the shared WKT/WKB worker URL. |
 
 ## Format Summary
 

--- a/modules/loader-utils/src/lib/worker-loader-utils/create-loader-worker.ts
+++ b/modules/loader-utils/src/lib/worker-loader-utils/create-loader-worker.ts
@@ -8,8 +8,12 @@ let requestId = 0;
 /**
  * Set up a WebWorkerGlobalScope to talk with the main thread
  * @param loader
+ * @param selectLoader Selects the parser used for each worker request.
  */
-export async function createLoaderWorker(loader: LoaderWithParser) {
+export async function createLoaderWorker(
+  loader: LoaderWithParser,
+  selectLoader: (options: {[key: string]: any}) => LoaderWithParser = () => loader
+) {
   // Check that we are actually in a worker thread
   if (!(await WorkerBody.inWorkerThread())) {
     return;
@@ -23,8 +27,9 @@ export async function createLoaderWorker(loader: LoaderWithParser) {
 
           const {input, options = {}, context = {}} = payload;
 
+          const selectedLoader = selectLoader(options);
           const result = await parseData({
-            loader,
+            loader: selectedLoader,
             arrayBuffer: input,
             options,
             // @ts-expect-error fetch missing

--- a/modules/loader-utils/src/lib/worker-loader-utils/parse-with-worker.ts
+++ b/modules/loader-utils/src/lib/worker-loader-utils/parse-with-worker.ts
@@ -48,7 +48,8 @@ export async function parseWithWorker(
   // options.log object contains functions which cannot be transferred
   // context.fetch & context.parse functions cannot be transferred
   // TODO - decide how to handle logging on workers
-  options = JSON.parse(JSON.stringify(options));
+  options = JSON.parse(JSON.stringify(options || {}));
+  (options as {[key: string]: any})._workerLoaderId = loader.id;
   context = JSON.parse(JSON.stringify(context || {}));
 
   const job = await workerPool.startJob(

--- a/modules/loader-utils/src/loader-types.ts
+++ b/modules/loader-utils/src/loader-types.ts
@@ -154,6 +154,8 @@ export type Loader<DataT = any, BatchT = any, LoaderOptionsT = StrictLoaderOptio
   version: string;
   /** A boolean, or a URL */
   worker?: string | boolean;
+  /** Browser worker filename when it differs from the loader id. */
+  workerFile?: string;
   // end Worker
 
   /** Human readable name */

--- a/modules/wkt/src/wkb-loader.ts
+++ b/modules/wkt/src/wkb-loader.ts
@@ -10,7 +10,9 @@ import {VERSION} from './lib/version';
 export type WKBLoaderOptions = LoaderOptions & {
   wkb?: {
     /** Shape is deprecated, only geojson is supported */
-    shape: 'geojson-geometry';
+    shape?: 'geojson-geometry';
+    /** Override the URL to the shared WKT/WKB worker bundle. */
+    workerUrl?: string;
   };
 };
 
@@ -25,6 +27,7 @@ export const WKBWorkerLoader = {
   module: 'wkt',
   version: VERSION,
   worker: true,
+  workerFile: 'wkt-worker.js',
   category: 'geometry',
   extensions: ['wkb'],
   mimeTypes: [],

--- a/modules/wkt/src/workers/wkt-worker.ts
+++ b/modules/wkt/src/workers/wkt-worker.ts
@@ -6,6 +6,6 @@ import {createLoaderWorker} from '@loaders.gl/loader-utils';
 import {WKTLoader} from '../wkt-loader';
 import {WKBLoader} from '../wkb-loader';
 
-createLoaderWorker(WKTLoader, options =>
+createLoaderWorker(WKTLoader, (options) =>
   options._workerLoaderId === 'wkb' ? WKBLoader : WKTLoader
 );

--- a/modules/wkt/src/workers/wkt-worker.ts
+++ b/modules/wkt/src/workers/wkt-worker.ts
@@ -6,4 +6,6 @@ import {createLoaderWorker} from '@loaders.gl/loader-utils';
 import {WKTLoader} from '../wkt-loader';
 import {WKBLoader} from '../wkb-loader';
 
-createLoaderWorker(WKTLoader, options => (options.wkb ? WKBLoader : WKTLoader));
+createLoaderWorker(WKTLoader, options =>
+  options._workerLoaderId === 'wkb' ? WKBLoader : WKTLoader
+);

--- a/modules/wkt/src/workers/wkt-worker.ts
+++ b/modules/wkt/src/workers/wkt-worker.ts
@@ -4,5 +4,6 @@
 
 import {createLoaderWorker} from '@loaders.gl/loader-utils';
 import {WKTLoader} from '../wkt-loader';
+import {WKBLoader} from '../wkb-loader';
 
-createLoaderWorker(WKTLoader);
+createLoaderWorker(WKTLoader, options => (options.wkb ? WKBLoader : WKTLoader));

--- a/modules/wkt/test/wkb-loader.spec.ts
+++ b/modules/wkt/test/wkb-loader.spec.ts
@@ -74,13 +74,9 @@ test('WKBLoader#Z', async (t) => {
   t.end();
 });
 
-test('WKBLoader#worker', async (t) => {
+test('WKBLoader#worker', async t => {
   const result = await parse(
-    new Uint8Array([
-      1, 1, 0, 0, 0,
-      0, 0, 0, 0, 0, 0, 240, 63,
-      0, 0, 0, 0, 0, 0, 0, 64
-    ]).buffer,
+    new Uint8Array([1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 240, 63, 0, 0, 0, 0, 0, 0, 0, 64]).buffer,
     WKBLoader,
     {core: {worker: true, _workerType: 'test'}}
   );
@@ -88,7 +84,7 @@ test('WKBLoader#worker', async (t) => {
   t.end();
 });
 
-test('WKTLoader#worker with WKB options', async (t) => {
+test('WKTLoader#worker with WKB options', async t => {
   const result = await parse(new TextEncoder().encode('POINT (3 4)').buffer, WKTLoader, {
     wkb: {workerUrl: 'unused'},
     core: {worker: true, _workerType: 'test'}

--- a/modules/wkt/test/wkb-loader.spec.ts
+++ b/modules/wkt/test/wkb-loader.spec.ts
@@ -5,7 +5,7 @@
 /* eslint-disable no-continue */
 
 import test from 'tape-promise/tape';
-import {fetchFile, parseSync} from '@loaders.gl/core';
+import {fetchFile, parse, parseSync} from '@loaders.gl/core';
 import {isWKB} from '@loaders.gl/gis';
 import {WKBLoader} from '@loaders.gl/wkt';
 import {parseTestCases} from '@loaders.gl/gis/test/data/wkt/parse-test-cases';
@@ -71,5 +71,15 @@ test('WKBLoader#Z', async (t) => {
     // }
   }
 
+  t.end();
+});
+
+test('WKBLoader#worker', async (t) => {
+  const result = await parse(
+    new Uint8Array([1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 240, 63, 0, 0, 0, 0, 0, 0, 64]).buffer,
+    WKBLoader,
+    {core: {worker: true, _workerType: 'test'}}
+  );
+  t.deepEqual(result, {type: 'Point', coordinates: [1, 2]});
   t.end();
 });

--- a/modules/wkt/test/wkb-loader.spec.ts
+++ b/modules/wkt/test/wkb-loader.spec.ts
@@ -76,7 +76,11 @@ test('WKBLoader#Z', async (t) => {
 
 test('WKBLoader#worker', async (t) => {
   const result = await parse(
-    new Uint8Array([1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 240, 63, 0, 0, 0, 0, 0, 0, 64]).buffer,
+    new Uint8Array([
+      1, 1, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 240, 63,
+      0, 0, 0, 0, 0, 0, 0, 64
+    ]).buffer,
     WKBLoader,
     {core: {worker: true, _workerType: 'test'}}
   );

--- a/modules/wkt/test/wkb-loader.spec.ts
+++ b/modules/wkt/test/wkb-loader.spec.ts
@@ -7,7 +7,7 @@
 import test from 'tape-promise/tape';
 import {fetchFile, parse, parseSync} from '@loaders.gl/core';
 import {isWKB} from '@loaders.gl/gis';
-import {WKBLoader} from '@loaders.gl/wkt';
+import {WKBLoader, WKTLoader} from '@loaders.gl/wkt';
 import {parseTestCases} from '@loaders.gl/gis/test/data/wkt/parse-test-cases';
 
 const WKB_2D_TEST_CASES = '@loaders.gl/gis/test/data/wkt/wkb-testdata2d.json';
@@ -85,5 +85,14 @@ test('WKBLoader#worker', async (t) => {
     {core: {worker: true, _workerType: 'test'}}
   );
   t.deepEqual(result, {type: 'Point', coordinates: [1, 2]});
+  t.end();
+});
+
+test('WKTLoader#worker with WKB options', async (t) => {
+  const result = await parse(new TextEncoder().encode('POINT (3 4)').buffer, WKTLoader, {
+    wkb: {workerUrl: 'unused'},
+    core: {worker: true, _workerType: 'test'}
+  });
+  t.deepEqual(result, {type: 'Point', coordinates: [3, 4]});
   t.end();
 });

--- a/modules/wkt/test/wkb-loader.spec.ts
+++ b/modules/wkt/test/wkb-loader.spec.ts
@@ -74,7 +74,7 @@ test('WKBLoader#Z', async (t) => {
   t.end();
 });
 
-test('WKBLoader#worker', async t => {
+test('WKBLoader#worker', async (t) => {
   const result = await parse(
     new Uint8Array([1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 240, 63, 0, 0, 0, 0, 0, 0, 0, 64]).buffer,
     WKBLoader,
@@ -84,7 +84,7 @@ test('WKBLoader#worker', async t => {
   t.end();
 });
 
-test('WKTLoader#worker with WKB options', async t => {
+test('WKTLoader#worker with WKB options', async (t) => {
   const result = await parse(new TextEncoder().encode('POINT (3 4)').buffer, WKTLoader, {
     wkb: {workerUrl: 'unused'},
     core: {worker: true, _workerType: 'test'}

--- a/modules/worker-utils/src/lib/worker-api/get-worker-url.ts
+++ b/modules/worker-utils/src/lib/worker-api/get-worker-url.ts
@@ -30,7 +30,9 @@ export function getWorkerName(worker: WorkerObject): string {
 export function getWorkerURL(worker: WorkerObject, options: WorkerOptions = {}): string {
   const workerOptions = options[worker.id] || {};
 
-  const workerFile = isBrowser ? `${worker.id}-worker.js` : `${worker.id}-worker-node.js`;
+  const workerFile = isBrowser
+    ? worker.workerFile || `${worker.id}-worker.js`
+    : `${worker.id}-worker-node.js`;
 
   let url = workerOptions.workerUrl;
 

--- a/modules/worker-utils/src/types.ts
+++ b/modules/worker-utils/src/types.ts
@@ -39,6 +39,8 @@ export type WorkerObject = {
   module: string;
   version: string;
   worker?: string | boolean;
+  /** Browser worker filename when it differs from the worker id. */
+  workerFile?: string;
   options: {[key: string]: any};
   deprecatedOptions?: object;
 

--- a/modules/worker-utils/test/lib/worker-api/get-worker-url.spec.ts
+++ b/modules/worker-utils/test/lib/worker-api/get-worker-url.spec.ts
@@ -29,5 +29,16 @@ test('getWorkerURL', (t) => {
     'worker url with _useLocalWorkers options'
   );
 
+  t.equals(
+    getWorkerURL(
+      {...NullWorker, id: 'wkb', module: 'wkt', workerFile: 'wkt-worker.js'},
+      {_workerType: 'test'}
+    ),
+    isBrowser
+      ? 'modules/wkt/dist/wkt-worker.js'
+      : 'modules/wkt/src/workers/wkb-worker-node.ts',
+    'test worker URL supports a shared worker filename'
+  );
+
   t.end();
 });

--- a/modules/worker-utils/test/lib/worker-api/get-worker-url.spec.ts
+++ b/modules/worker-utils/test/lib/worker-api/get-worker-url.spec.ts
@@ -34,9 +34,7 @@ test('getWorkerURL', (t) => {
       {...NullWorker, id: 'wkb', module: 'wkt', workerFile: 'wkt-worker.js'},
       {_workerType: 'test'}
     ),
-    isBrowser
-      ? 'modules/wkt/dist/wkt-worker.js'
-      : 'modules/wkt/src/workers/wkb-worker-node.ts',
+    isBrowser ? 'modules/wkt/dist/wkt-worker.js' : 'modules/wkt/src/workers/wkb-worker-node.ts',
     'test worker URL supports a shared worker filename'
   );
 


### PR DESCRIPTION
## Goals

- Backport the async WKB worker fix to the 4.5 release line.
- Keep WKT and WKB on one small browser worker bundle.

## Changes

- Route WKB worker requests through the existing `wkt-worker.js` bundle and select the WKB parser from request options.
- Allow a loader to declare a browser worker filename different from its loader id.
- Add regression coverage for worker parsing and worker URL resolution.
- Document the explicit Vite worker URL configuration.

Fixes #3962