### PR TITLE
fix(wkt): support async WKB parsing in shared worker

### DIFF
--- a/docs/modules/wkt/api-reference/wkb-loader.md
+++ b/docs/modules/wkt/api-reference/wkb-loader.md
@@ -86,9 +86,22 @@ import {load} from '@loaders.gl/core';
 const data = await load(url, WKBLoader);
 ```
 
+Asynchronous parsing uses the bundled worker automatically when workers are enabled. When
+bundling with Vite, the worker URL can be supplied explicitly:
+
+```typescript
+import WKT_WORKER_URL from '@loaders.gl/wkt/wkt-worker.js?url';
+import {parse} from '@loaders.gl/core';
+import {WKBLoader} from '@loaders.gl/wkt';
+
+const data = await parse(buffer, WKBLoader, {wkb: {workerUrl: WKT_WORKER_URL}});
+```
+
 ## Options
 
-N/A
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `wkb.workerUrl` | `string` | CDN URL | Override the shared WKT/WKB worker URL. |
 
 ## Format Summary
 

--- a/modules/loader-utils/src/lib/worker-loader-utils/create-loader-worker.ts
+++ b/modules/loader-utils/src/lib/worker-loader-utils/create-loader-worker.ts
@@ -11,13 +11,29 @@ import {createWorker} from '@loaders.gl/worker-utils';
 /**
  * Set up a WebWorkerGlobalScope to talk with the main thread
  * @param loader
+ * @param selectLoader Selects the parser used for each worker request.
  */
-export async function createLoaderWorker(loader: LoaderWithParser) {
+export async function createLoaderWorker(
+  loader: LoaderWithParser,
+  selectLoader: (options: {[key: string]: any}) => LoaderWithParser = () => loader
+) {
   await createWorker(
     (input, options, workerContext, loaderContext) =>
-      processLoaderWorkerData(loader, input, options, workerContext, loaderContext),
+      processLoaderWorkerData(
+        selectLoader(options || {}),
+        input,
+        options,
+        workerContext,
+        loaderContext
+      ),
     (inputIterator, options, workerContext, loaderContext) =>
-      processLoaderWorkerBatches(loader, inputIterator, options, workerContext, loaderContext)
+      processLoaderWorkerBatches(
+        selectLoader(options || {}),
+        inputIterator,
+        options,
+        workerContext,
+        loaderContext
+      )
   );
 }
 

--- a/modules/loader-utils/src/lib/worker-loader-utils/parse-with-worker.ts
+++ b/modules/loader-utils/src/lib/worker-loader-utils/parse-with-worker.ts
@@ -110,7 +110,7 @@ export async function parseWithWorker(
   const result = await processOnWorker(
     loader,
     data,
-    {...getWorkerOptions(options), signal: workerSignal},
+    {...getWorkerOptions(options, loader), signal: workerSignal},
     {
       process: async (input, processOptions, _workerContext, parseContext) => {
         if (!parseOnMainThread) {
@@ -215,10 +215,11 @@ function callParseOnMainThread(
 /**
  * Create worker options with deprecated top-level worker fields available to worker-utils.
  * @param options
+ * @param loader Loader whose parser will handle the worker request.
  */
-function getWorkerOptions(options: StrictLoaderOptions = {}) {
+function getWorkerOptions(options: StrictLoaderOptions = {}, loader?: Loader) {
   const serializedOptions = JSON.parse(JSON.stringify(options));
-  const workerOptions = {
+  const workerOptions: Record<string, any> = {
     ...serializedOptions.core,
     ...serializedOptions
   };
@@ -226,6 +227,9 @@ function getWorkerOptions(options: StrictLoaderOptions = {}) {
   // receive the established boolean form even when the caller selected `auto`.
   if (workerOptions.worker === 'auto') {
     workerOptions.worker = true;
+  }
+  if (loader) {
+    workerOptions._workerLoaderId = loader.id;
   }
   return workerOptions;
 }

--- a/modules/loader-utils/src/loader-types.ts
+++ b/modules/loader-utils/src/loader-types.ts
@@ -174,6 +174,8 @@ export type Loader<DataT = any, BatchT = any, LoaderOptionsT = StrictLoaderOptio
   version: string;
   /** A boolean, or a URL */
   worker?: string | boolean;
+  /** Browser worker filename when it differs from the loader id. */
+  workerFile?: string;
   /** Creates a built-in browser worker, typically using `type: 'module'`. */
   loadWorker?: LoadWorker;
   /**

--- a/modules/wkt/src/wkb-loader-with-parser.ts
+++ b/modules/wkt/src/wkb-loader-with-parser.ts
@@ -15,7 +15,9 @@ const {preload: _WKBLoaderPreload, ...WKBLoaderMetadataWithoutPreload} = WKBLoad
 export type WKBLoaderOptions = LoaderOptions & {
   wkb?: {
     /** Shape is deprecated, only geojson is supported */
-    shape: 'geojson-geometry';
+    shape?: 'geojson-geometry';
+    /** Override the URL to the shared WKT/WKB worker bundle. */
+    workerUrl?: string;
   };
 };
 

--- a/modules/wkt/src/wkb-loader.ts
+++ b/modules/wkt/src/wkb-loader.ts
@@ -10,7 +10,9 @@ import {WKBFormat} from './wkt-format';
 export type WKBLoaderOptions = LoaderOptions & {
   wkb?: {
     /** Shape is deprecated, only geojson is supported */
-    shape: 'geojson-geometry';
+    shape?: 'geojson-geometry';
+    /** Override the URL to the shared WKT/WKB worker bundle. */
+    workerUrl?: string;
   };
 };
 
@@ -31,6 +33,7 @@ export const WKBWorkerLoader = {
   ...WKBFormat,
   version: VERSION,
   worker: true,
+  workerFile: 'wkt-worker.js',
   options: {
     wkb: {
       shape: 'geojson-geometry'

--- a/modules/wkt/src/workers/wkt-worker.ts
+++ b/modules/wkt/src/workers/wkt-worker.ts
@@ -7,5 +7,5 @@ import {WKTLoaderWithParser} from '../wkt-loader-with-parser';
 import {WKBLoaderWithParser} from '../wkb-loader-with-parser';
 
 createLoaderWorker(WKTLoaderWithParser, options =>
-  options.wkb ? WKBLoaderWithParser : WKTLoaderWithParser
+  options._workerLoaderId === 'wkb' ? WKBLoaderWithParser : WKTLoaderWithParser
 );

--- a/modules/wkt/src/workers/wkt-worker.ts
+++ b/modules/wkt/src/workers/wkt-worker.ts
@@ -4,5 +4,8 @@
 
 import {createLoaderWorker} from '@loaders.gl/loader-utils';
 import {WKTLoaderWithParser} from '../wkt-loader-with-parser';
+import {WKBLoaderWithParser} from '../wkb-loader-with-parser';
 
-createLoaderWorker(WKTLoaderWithParser);
+createLoaderWorker(WKTLoaderWithParser, options =>
+  options.wkb ? WKBLoaderWithParser : WKTLoaderWithParser
+);

--- a/modules/wkt/test/wkb-loader.spec.ts
+++ b/modules/wkt/test/wkb-loader.spec.ts
@@ -55,7 +55,11 @@ test('WKBLoader#Z', async () => {
 
 test('WKBLoader#worker', async () => {
   const result = await parse(
-    new Uint8Array([1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 240, 63, 0, 0, 0, 0, 0, 0, 64]).buffer,
+    new Uint8Array([
+      1, 1, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 240, 63,
+      0, 0, 0, 0, 0, 0, 0, 64
+    ]).buffer,
     WKBLoader,
     {core: {worker: true, _workerType: 'test'}}
   );

--- a/modules/wkt/test/wkb-loader.spec.ts
+++ b/modules/wkt/test/wkb-loader.spec.ts
@@ -55,11 +55,7 @@ test('WKBLoader#Z', async () => {
 
 test('WKBLoader#worker', async () => {
   const result = await parse(
-    new Uint8Array([
-      1, 1, 0, 0, 0,
-      0, 0, 0, 0, 0, 0, 240, 63,
-      0, 0, 0, 0, 0, 0, 0, 64
-    ]).buffer,
+    new Uint8Array([1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 240, 63, 0, 0, 0, 0, 0, 0, 0, 64]).buffer,
     WKBLoader,
     {core: {worker: true, _workerType: 'test'}}
   );

--- a/modules/wkt/test/wkb-loader.spec.ts
+++ b/modules/wkt/test/wkb-loader.spec.ts
@@ -1,7 +1,7 @@
 import {expect, test} from 'vitest';
 import {fetchFile, parse, parseSync} from '@loaders.gl/core';
 import {isWKB} from '@loaders.gl/gis';
-import {WKBLoader} from '@loaders.gl/wkt/bundled';
+import {WKBLoader, WKTLoader} from '@loaders.gl/wkt/bundled';
 import {parseTestCases} from '@loaders.gl/gis/test/data/wkt/parse-test-cases';
 const WKB_2D_TEST_CASES = '@loaders.gl/gis/test/data/wkt/wkb-testdata2d.json';
 const WKB_Z_TEST_CASES = '@loaders.gl/gis/test/data/wkt/wkb-testdataZ.json';
@@ -64,4 +64,12 @@ test('WKBLoader#worker', async () => {
     {core: {worker: true, _workerType: 'test'}}
   );
   expect(result).toEqual({type: 'Point', coordinates: [1, 2]});
+});
+
+test('WKTLoader#worker with WKB options', async () => {
+  const result = await parse(new TextEncoder().encode('POINT (3 4)').buffer, WKTLoader, {
+    wkb: {workerUrl: 'unused'},
+    core: {worker: true, _workerType: 'test'}
+  });
+  expect(result).toEqual({type: 'Point', coordinates: [3, 4]});
 });

--- a/modules/wkt/test/wkb-loader.spec.ts
+++ b/modules/wkt/test/wkb-loader.spec.ts
@@ -1,5 +1,5 @@
 import {expect, test} from 'vitest';
-import {fetchFile, parseSync} from '@loaders.gl/core';
+import {fetchFile, parse, parseSync} from '@loaders.gl/core';
 import {isWKB} from '@loaders.gl/gis';
 import {WKBLoader} from '@loaders.gl/wkt/bundled';
 import {parseTestCases} from '@loaders.gl/gis/test/data/wkt/parse-test-cases';
@@ -51,4 +51,13 @@ test('WKBLoader#Z', async () => {
       expect(result, title).toEqual(testCase.geoJSON);
     }
   }
+});
+
+test('WKBLoader#worker', async () => {
+  const result = await parse(
+    new Uint8Array([1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 240, 63, 0, 0, 0, 0, 0, 0, 64]).buffer,
+    WKBLoader,
+    {core: {worker: true, _workerType: 'test'}}
+  );
+  expect(result).toEqual({type: 'Point', coordinates: [1, 2]});
 });

--- a/modules/worker-utils/src/lib/worker-api/get-worker-url.ts
+++ b/modules/worker-utils/src/lib/worker-api/get-worker-url.ts
@@ -35,7 +35,7 @@ export function getCustomWorkerURL(
   const workerOptions = options[worker.id] || {};
 
   const workerFile = isBrowser
-    ? `${worker.id}-worker.js`
+    ? worker.workerFile || `${worker.id}-worker.js`
     : worker.workerNode || `${worker.id}-worker-node.js`;
 
   let url = workerOptions.workerUrl;
@@ -90,7 +90,7 @@ export function getWorkerURL(worker: WorkerObject, options: WorkerOptions = {}):
  */
 export function getDefaultWorkerURL(worker: WorkerObject, warn: boolean = false): string {
   const workerFile = isBrowser
-    ? `${worker.id}-worker.js`
+    ? worker.workerFile || `${worker.id}-worker.js`
     : worker.workerNode || `${worker.id}-worker-node.js`;
   let version = worker.version;
   if (version === 'latest') {

--- a/modules/worker-utils/src/types.ts
+++ b/modules/worker-utils/src/types.ts
@@ -58,6 +58,8 @@ export type WorkerObject = {
   module: string;
   version: string;
   worker?: string | boolean;
+  /** Browser worker filename when it differs from the worker id. */
+  workerFile?: string;
   /** Creates a built-in browser worker, typically using `type: 'module'`. */
   loadWorker?: LoadWorker;
   /** Optional Node.js-specific worker filename (for example a `.cjs` asset). */

--- a/modules/worker-utils/test/lib/worker-api/get-worker-url.spec.ts
+++ b/modules/worker-utils/test/lib/worker-api/get-worker-url.spec.ts
@@ -44,6 +44,15 @@ test('getWorkerURL', () => {
       ? 'modules/worker-utils/dist/null-worker.js'
       : 'modules/worker-utils/src/workers/null-worker-node.ts'
   );
+  expect(
+    getWorkerURL(
+      {...NullWorker, id: 'wkb', module: 'wkt', workerFile: 'wkt-worker.js'},
+      {_workerType: 'test'}
+    ),
+    'test worker URL supports a shared worker filename'
+  ).toBe(
+    isBrowser ? 'modules/wkt/dist/wkt-worker.js' : 'modules/wkt/src/workers/wkb-worker-node.ts'
+  );
 });
 test('getWorkerURL#version fallback warning', () => {
   const warnings: string[] = [];


### PR DESCRIPTION
## Goals

- Fix async WKB parsing when workers are enabled.
- Keep WKT and WKB on one small browser worker bundle.

## Changes

- Route WKB worker requests through the existing `wkt-worker.js` bundle and select the WKB parser from request options.
- Allow a loader to declare a browser worker filename different from its loader id.
- Add regression coverage for worker parsing and worker URL resolution.
- Document the explicit Vite worker URL configuration.

Fixes #3962