### PR TITLE
fix: preserve local Draco module overrides in workers

### DIFF
--- a/modules/loader-utils/src/lib/worker-loader-utils/create-loader-worker.ts
+++ b/modules/loader-utils/src/lib/worker-loader-utils/create-loader-worker.ts
@@ -113,10 +113,15 @@ async function parseData({
     throw new Error(`Could not load data with ${loader.name} loader`);
   }
 
-  // TODO - proper merge in of loader options...
+  // Preserve worker-supplied module overrides (for example a caller-provided
+  // Draco URL) while still applying the loader's defaults. Functions cannot be
+  // structured-cloned, but URL strings and other serializable options can.
   options = {
     ...options,
-    modules: (loader && loader.options && loader.options.modules) || {},
+    modules: {
+      ...((loader && loader.options && loader.options.modules) || {}),
+      ...(options.modules || {})
+    },
     core: {
       ...options.core,
       worker: false

--- a/modules/loader-utils/src/lib/worker-loader-utils/create-loader-worker.ts
+++ b/modules/loader-utils/src/lib/worker-loader-utils/create-loader-worker.ts
@@ -113,14 +113,17 @@ async function parseData({
     throw new Error(`Could not load data with ${loader.name} loader`);
   }
 
-  // Preserve worker-supplied module overrides (for example a caller-provided
-  // Draco URL) while still applying the loader's defaults. Functions cannot be
-  // structured-cloned, but URL strings and other serializable options can.
+  // Preserve worker-supplied URL module overrides while still applying the
+  // loader's defaults. JSON serialization turns runtime module objects into
+  // unusable objects, so only string values can override worker defaults here.
+  const workerModules = Object.fromEntries(
+    Object.entries(options.modules || {}).filter(([, value]) => typeof value === 'string')
+  );
   options = {
     ...options,
     modules: {
       ...((loader && loader.options && loader.options.modules) || {}),
-      ...(options.modules || {})
+      ...workerModules
     },
     core: {
       ...options.core,


### PR DESCRIPTION
## Goals

Fix [#3185](https://github.com/visgl/loaders.gl/issues/3185) so Vite applications can provide local Draco runtime assets without falling back to CDN URLs.

## Changes

- Preserve serializable caller-supplied `options.modules` in loader workers.
- Merge caller overrides after loader defaults so local Draco URLs take precedence.

## Validation

- `git diff --check`
- Full lint/test execution was unavailable because the isolated 4.5 checkout lacks the matching project tooling.

Fixes #3185