### PR TITLE
test(parquet): cover UTF8 byte array strings (#3122)

### DIFF
--- a/modules/parquet/test/index.ts
+++ b/modules/parquet/test/index.ts
@@ -29,3 +29,4 @@ import './parquet-loader.spec';
 import './geoparquet-loader.spec';
 import './geospatial-metadata.spec';
 import './parquet-typed-array.spec';
+import './parquet-issue-3122.cross.spec';

--- a/modules/parquet/test/parquet-issue-3122.cross.spec.ts
+++ b/modules/parquet/test/parquet-issue-3122.cross.spec.ts
@@ -1,0 +1,31 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {encode, load} from '@loaders.gl/core';
+import {ParquetJSWriter, ParquetLoader} from '@loaders.gl/parquet';
+import type {ObjectRowTable} from '@loaders.gl/schema';
+import {expect, test} from 'vitest';
+
+test('ParquetLoader decodes UTF8 BYTE_ARRAY values as strings (#3122)', async () => {
+  const input: ObjectRowTable = {
+    shape: 'object-row-table',
+    schema: {
+      fields: [{name: 'h3', type: 'utf8', nullable: false}],
+      metadata: {}
+    },
+    data: [{h3: '8828d5476bfffff'}, {h3: '8928308280fffff'}]
+  };
+
+  const parquetBuffer = await encode(input, ParquetJSWriter, {worker: false});
+  const output = await load(parquetBuffer, ParquetLoader, {
+    core: {worker: false}
+  });
+
+  expect(output.shape).toBe('object-row-table');
+  if (output.shape !== 'object-row-table') {
+    return;
+  }
+  expect(output.data).toEqual(input.data);
+  expect(output.data.every(row => typeof row.h3 === 'string')).toBe(true);
+});


### PR DESCRIPTION
## Goals

Add regression coverage for issue #3122, ensuring Parquet UTF8 BYTE_ARRAY columns used for H3 indexes are returned as JavaScript strings.

## Changes

- Add a cross-runtime Vitest regression test using an in-memory Parquet fixture.
- Encode the fixture with `ParquetJSWriter` and read it through the production `ParquetLoader`.
- Register the test in the Parquet test suite.

## Validation

- `yarn test-node modules/parquet/test/parquet-issue-3122.cross.spec.ts`
- `yarn test-headless modules/parquet/test/parquet-issue-3122.cross.spec.ts`
- `yarn lint fix modules/parquet/test/index.ts modules/parquet/test/parquet-issue-3122.cross.spec.ts`
- `yarn test-audit`