### PR TITLE
feat(tiles): add Cesium-style skip-LOD traversal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### v5.0.0-alpha.5
 
 - feat(geoarrow): establish the GeoArrow tentpole contract with native columnar conversions, adaptive layouts, validation, resource limits, and format examples
+- feat(tiles): skip intermediate 3D Tiles content requests during Cesium-style skip-LOD traversal
 - chore(math.gl): align all loaders.gl-owned math.gl dependencies with `5.0.0-alpha.4`
 
 ### v5.0.0-alpha.4

--- a/docs/modules/3d-tiles/concepts/tile-hierarchy-and-refinement.md
+++ b/docs/modules/3d-tiles/concepts/tile-hierarchy-and-refinement.md
@@ -68,11 +68,13 @@ While a child subtree is loading, its existing tile stays the traversal boundary
 `ADD` means descendants augment their ancestors. The parent remains part of the result, so descendant requests can safely wait briefly while the camera moves.
 
 Set `skipLevelOfDetail: true` to enable skip-LOD replacement traversal. A ready replacement ancestor
-remains selected while traversal jumps over intermediate levels, so a deep tree can begin showing
-detail before every level is ready. The ancestor is fallback coverage, not a second LOD target: once
-descendants are available they refine independently, and progressive-resolution descendants remain
-urgent. The tradeoff is temporary overdraw and potentially higher bandwidth while the camera is
-moving. The default is `false`, preserving traditional all-required-children replacement behavior.
+remains selected while traversal jumps over intermediate levels without requesting their content,
+so a deep tree can begin showing detail without downloading every level. `baseScreenSpaceError`,
+`skipScreenSpaceErrorFactor`, and `skipLevels` control periodic intermediate coverage requests;
+`immediatelyLoadDesiredLevelOfDetail` disables those requests and loads only final SSE targets. The
+ancestor is fallback coverage, not a second LOD target: once descendants are available they refine
+independently, and progressive-resolution descendants remain urgent. The tradeoff is temporary
+overdraw. The default is `false`, preserving traditional all-required-children replacement behavior.
 
 ## Visibility, Selection, and Requests
 

--- a/docs/modules/tiles/api-reference/tileset-3d.md
+++ b/docs/modules/tiles/api-reference/tileset-3d.md
@@ -250,9 +250,40 @@ For formulas, projection-specific behavior, transform scaling, and tuning guidan
 ### skipLevelOfDetail : Boolean
 
 Enables skip-LOD replacement traversal. When enabled, traversal may descend past one or more
-hierarchy levels without waiting for every intermediate child, while keeping ready replacement
-ancestors selected as temporary coverage. This can improve first-detail latency on deep trees at
-the cost of temporary ancestor/descendant overdraw. `ADD` refinement is unaffected.
+hierarchy levels without requesting every intermediate tile, while keeping ready replacement
+ancestors selected as temporary coverage. Request thresholds periodically load intermediate
+coverage on deep branches. This can improve first-detail latency at the cost of temporary
+ancestor/descendant overdraw. `ADD` refinement is unaffected.
+
+^default false
+
+### baseScreenSpaceError : Number
+
+When skip-LOD is enabled, replacement tiles above this SSE remain in the base traversal and are
+always requested. The active memory-adjusted SSE is used when it is higher than this value.
+
+^default 1024
+
+### skipScreenSpaceErrorFactor : Number
+
+Minimum SSE reduction from the nearest requested or loaded ancestor before another intermediate
+tile is requested. For example, with the default factor, an ancestor at SSE 1600 allows an
+intermediate request below SSE 100 once `skipLevels` is also satisfied.
+
+^default 16
+
+### skipLevels : Number
+
+Minimum number of hierarchy levels skipped between intermediate requests. Final desired tiles are
+still requested regardless of this value.
+
+^default 1
+
+### immediatelyLoadDesiredLevelOfDetail : Boolean
+
+When skip-LOD is enabled, requests only final tiles that meet the active SSE target. Base and
+intermediate threshold requests are disabled. If a suitable ancestor is already loaded, it remains
+selected as fallback coverage while the desired content loads.
 
 ^default false
 

--- a/docs/whats-new.mdx
+++ b/docs/whats-new.mdx
@@ -396,7 +396,7 @@ A minor release that includes:
 - **Region bounding volumes** - Geographic regions that cross the antimeridian now produce tight traversal OBBs instead of spanning the long way around the globe; polar and zero-height regions remain finite.
 - **Transform-correct LOD** Geometric error is scaled conservatively by composed tile and tileset transforms without compounding after runtime updates.
 - **Projection-correct SSE** Orthographic viewports use `metersPerPixel`, while perspective and orthographic traversal consistently use logical pixels without a second device-pixel-ratio correction.
-- **Skip-LOD replacement traversal** `Tileset3D` now exposes `skipLevelOfDetail`; enabled traversals retain ready replacement ancestors as fallback coverage while descending through deep hierarchies.
+- **Cesium-style skip-LOD traversal** `Tileset3D` can omit intermediate replacement-content requests while retaining ready ancestors as fallback coverage, with configurable SSE/depth thresholds and a desired-level-only mode.
 - **Dynamic SSE** Perspective traversal can reduce distant, horizon-facing refinement with view-dependent density and height falloff while leaving orthographic and I3S LOD behavior unchanged.
 - **Same-frame dynamic SSE transforms** Animated local tilesets refresh the root transform before density calculation, and tilted oriented boxes derive height from every rotated half axis.
 - **Required-extension validation** Unsupported `extensionsRequired` values fail before normalization or dependent network access; unknown `extensionsUsed` values remain forward-compatible.

--- a/modules/tiles/src/tileset-3d/common/tile-3d.ts
+++ b/modules/tiles/src/tileset-3d/common/tile-3d.ts
@@ -791,9 +791,12 @@ export class Tile3D {
     }
 
     this._foveatedFactor = calculateFoveatedFactor(this.boundingVolume, frameState.camera);
+    const traverser = this.tileset._traverser;
+    const skipLevelOfDetail =
+      traverser.options.skipLevelOfDetail && !traverser.disableSkipLevelOfDetail;
     const deferralEligible = isFoveatedRequestDeferred({
       refinement: this.refine,
-      skipLevelOfDetail: this.tileset._traverser.options.skipLevelOfDetail,
+      skipLevelOfDetail,
       foveatedScreenSpaceError: options.foveatedScreenSpaceError,
       foveatedConeSize: options.foveatedConeSize,
       minimumScreenSpaceErrorRelaxation: options.foveatedMinimumScreenSpaceErrorRelaxation,

--- a/modules/tiles/src/tileset-3d/common/tile-3d.ts
+++ b/modules/tiles/src/tileset-3d/common/tile-3d.ts
@@ -495,7 +495,8 @@ export class Tile3D {
   // eslint-disable-next-line complexity
   private _calculateRequestPriority(allowUnloadedContent: boolean): number {
     const traverser = this.tileset._traverser;
-    const {skipLevelOfDetail} = traverser.options;
+    const skipLevelOfDetail =
+      traverser.options.skipLevelOfDetail && !traverser.disableSkipLevelOfDetail;
 
     /*
      * Tiles that are outside of the camera's frustum could be skipped if we are in 'ADD' mode

--- a/modules/tiles/src/tileset-3d/common/tileset-3d.ts
+++ b/modules/tiles/src/tileset-3d/common/tileset-3d.ts
@@ -87,6 +87,26 @@ export type Tileset3DProps = {
    * @default false
    */
   skipLevelOfDetail?: boolean;
+  /**
+   * SSE above which tiles remain part of the non-skipping base traversal.
+   * @default 1024
+   */
+  baseScreenSpaceError?: number;
+  /**
+   * Required SSE reduction from the nearest requested or loaded ancestor before loading a tile.
+   * @default 16
+   */
+  skipScreenSpaceErrorFactor?: number;
+  /**
+   * Minimum hierarchy levels between requested tiles during skip-LOD traversal.
+   * @default 1
+   */
+  skipLevels?: number;
+  /**
+   * Requests only final tiles that meet the active SSE target when skip-LOD is enabled.
+   * @default false
+   */
+  immediatelyLoadDesiredLevelOfDetail?: boolean;
   /** Enables perspective dynamic SSE to reduce distant, horizon-facing refinement. */
   dynamicScreenSpaceError?: boolean;
   /** Base dynamic SSE fog density in inverse meters. */
@@ -154,6 +174,14 @@ type Props = {
   maximumScreenSpaceError: number;
   /** Whether replacement traversal may skip levels while retaining ancestor coverage. */
   skipLevelOfDetail: boolean;
+  /** SSE above which tiles remain part of the non-skipping base traversal. */
+  baseScreenSpaceError: number;
+  /** Required SSE reduction between requested skip-LOD tiles. */
+  skipScreenSpaceErrorFactor: number;
+  /** Minimum hierarchy levels between requested skip-LOD tiles. */
+  skipLevels: number;
+  /** Whether skip-LOD requests only the final desired tiles. */
+  immediatelyLoadDesiredLevelOfDetail: boolean;
   /** Whether perspective dynamic SSE is enabled. */
   dynamicScreenSpaceError: boolean;
   /** Base dynamic SSE fog density in inverse meters. */
@@ -282,6 +310,10 @@ const DEFAULT_PROPS: Props = {
   foveatedTimeDelay: 0.2,
   maximumScreenSpaceError: 8,
   skipLevelOfDetail: false,
+  baseScreenSpaceError: 1024,
+  skipScreenSpaceErrorFactor: 16,
+  skipLevels: 1,
+  immediatelyLoadDesiredLevelOfDetail: false,
   dynamicScreenSpaceError: true,
   dynamicScreenSpaceErrorDensity: 2.0e-4,
   dynamicScreenSpaceErrorFactor: 24,

--- a/modules/tiles/src/tileset-3d/common/tileset-traverser.ts
+++ b/modules/tiles/src/tileset-3d/common/tileset-traverser.ts
@@ -10,6 +10,14 @@ import {FrameState} from '../helpers/frame-state';
 export type TilesetTraverserProps = {
   loadSiblings?: boolean;
   skipLevelOfDetail?: boolean;
+  /** SSE above which tiles remain part of the non-skipping base traversal. */
+  baseScreenSpaceError?: number;
+  /** Required SSE reduction from the nearest requested or loaded ancestor before loading a tile. */
+  skipScreenSpaceErrorFactor?: number;
+  /** Minimum hierarchy levels between requested tiles during skip-LOD traversal. */
+  skipLevels?: number;
+  /** Requests only final tiles that meet the active SSE target when skip-LOD is enabled. */
+  immediatelyLoadDesiredLevelOfDetail?: boolean;
   updateTransforms?: boolean;
   onTraversalEnd?: (frameState) => any;
   viewportTraversersMap?: Record<string, any>;
@@ -19,6 +27,10 @@ export type TilesetTraverserProps = {
 export const DEFAULT_PROPS: Required<TilesetTraverserProps> = {
   loadSiblings: false,
   skipLevelOfDetail: false,
+  baseScreenSpaceError: 1024,
+  skipScreenSpaceErrorFactor: 16,
+  skipLevels: 1,
+  immediatelyLoadDesiredLevelOfDetail: false,
   updateTransforms: true,
   onTraversalEnd: () => {},
   viewportTraversersMap: {},
@@ -27,6 +39,9 @@ export const DEFAULT_PROPS: Required<TilesetTraverserProps> = {
 
 export class TilesetTraverser {
   options: Required<TilesetTraverserProps>;
+
+  /** Whether loaded content has disabled skip-LOD traversal for this tileset. */
+  disableSkipLevelOfDetail: boolean = false;
 
   // fulfill in traverse call
   root: any = null;
@@ -56,6 +71,11 @@ export class TilesetTraverser {
   // TODO nested props
   constructor(options: TilesetTraverserProps) {
     this.options = {...DEFAULT_PROPS, ...options};
+  }
+
+  /** Returns whether skip-LOD traversal is enabled and supported by the loaded content. */
+  isSkipLevelOfDetailEnabled(): boolean {
+    return this.options.skipLevelOfDetail && !this.disableSkipLevelOfDetail;
   }
 
   // tiles should be visible
@@ -142,7 +162,7 @@ export class TilesetTraverser {
         this.loadTile(tile, frameState);
         // Skip-LOD keeps a ready ancestor selected while descendants stream in. This prevents
         // replacement holes when traversal jumps over one or more hierarchy levels.
-        if (stoppedRefining || this.options.skipLevelOfDetail) {
+        if (stoppedRefining || this.isSkipLevelOfDetailEnabled()) {
           this.selectTile(tile, frameState);
         }
       }
@@ -154,6 +174,11 @@ export class TilesetTraverser {
       tile._shouldRefine = shouldRefine && parentRefines;
     }
 
+    this.completeTraversal(frameState);
+  }
+
+  /** Notifies the owning tileset when traversal is complete or its debounce interval expires. */
+  protected completeTraversal(frameState: FrameState): void {
     const newTime = new Date().getTime();
     if (this.traversalFinished(frameState) || newTime - this.lastUpdate > this.updateDebounceTime) {
       this.lastUpdate = newTime;
@@ -170,7 +195,8 @@ export class TilesetTraverser {
 
   /* eslint-disable complexity, max-statements */
   updateAndPushChildren(tile: Tile3D, frameState: FrameState, stack, depth): boolean {
-    const {loadSiblings, skipLevelOfDetail} = this.options;
+    const {loadSiblings} = this.options;
+    const skipLevelOfDetail = this.isSkipLevelOfDetailEnabled();
 
     const children = tile.children;
 

--- a/modules/tiles/src/tileset-3d/format-3d-tiles/tileset-3d-traverser.ts
+++ b/modules/tiles/src/tileset-3d/format-3d-tiles/tileset-3d-traverser.ts
@@ -230,18 +230,13 @@ export class Tileset3DTraverser extends TilesetTraverser {
    * @param frameState - Current culling state.
    */
   private selectDesiredTile(tile: Tile3D, frameState: FrameState): void {
-    if (tile.contentAvailable) {
-      this.selectTile(tile, frameState);
-      return;
-    }
-
-    let ancestor = tile.parent;
-    while (ancestor) {
-      if (ancestor.contentAvailable) {
-        this.selectTile(ancestor, frameState);
+    let fallbackTile: Tile3D | null = tile;
+    while (fallbackTile) {
+      if (this.shouldSelectTile(fallbackTile, frameState)) {
+        this.selectTile(fallbackTile, frameState);
         return;
       }
-      ancestor = ancestor.parent;
+      fallbackTile = fallbackTile.parent;
     }
     this.selectLoadedDescendants(tile, frameState);
   }

--- a/modules/tiles/src/tileset-3d/format-3d-tiles/tileset-3d-traverser.ts
+++ b/modules/tiles/src/tileset-3d/format-3d-tiles/tileset-3d-traverser.ts
@@ -30,6 +30,247 @@ export class Tileset3DTraverser extends TilesetTraverser {
     return true;
   }
 
+  /**
+   * Runs normal replacement traversal or the dedicated skip-LOD traversal selected by options.
+   *
+   * @param root - Root of the runtime subtree to traverse.
+   * @param frameState - Current culling and LOD state.
+   */
+  executeTraversal(root: Tile3D, frameState: FrameState): void {
+    if (!this.isSkipLevelOfDetailEnabled()) {
+      super.executeTraversal(root, frameState);
+      return;
+    }
+    this.executeSkipTraversal(root, frameState);
+  }
+
+  /**
+   * Traverses visible replacement branches without requesting skipped intermediate content.
+   *
+   * Base-traversal tiles establish coarse coverage. Below that base, only final desired tiles and
+   * tiles that cross the configured depth/SSE thresholds are requested. Already available
+   * ancestors remain selectable while those requests stream in.
+   *
+   * @param root - Root of the runtime subtree to traverse.
+   * @param frameState - Current culling and LOD state.
+   */
+  private executeSkipTraversal(root: Tile3D, frameState: FrameState): void {
+    const stack: Tile3D[] = [root];
+    root._selectionDepth = root.parent ? root.parent._selectionDepth : 1;
+
+    while (stack.length > 0) {
+      const tile = stack.pop() as Tile3D;
+      const parentRefines = !tile.parent || tile.parent._shouldRefine;
+      const shouldRefine =
+        this.canTraverse(tile, frameState) &&
+        this.updateAndPushSkipChildren(tile, frameState, stack) &&
+        parentRefines;
+      const stoppedRefining = !shouldRefine && parentRefines;
+
+      if (!tile.hasRenderContent) {
+        this.emptyTiles[tile.id] = tile;
+        this.loadTile(tile, frameState);
+        if (stoppedRefining) {
+          this.selectDesiredTile(tile, frameState);
+        }
+      } else if (tile.refine === TILE_REFINEMENT.ADD) {
+        this.loadTile(tile, frameState);
+        this.selectDesiredTile(tile, frameState);
+      } else if (tile.refine === TILE_REFINEMENT.REPLACE) {
+        if (this.isInBaseTraversal(tile, frameState)) {
+          this.loadTile(tile, frameState);
+          if (stoppedRefining) {
+            this.selectDesiredTile(tile, frameState);
+          }
+        } else if (stoppedRefining) {
+          this.loadTile(tile, frameState);
+          this.selectDesiredTile(tile, frameState);
+        } else if (this.hasReachedSkippingThreshold(tile, frameState)) {
+          this.loadTile(tile, frameState);
+        }
+      }
+
+      this.touchTile(tile, frameState);
+      tile._shouldRefine = shouldRefine;
+    }
+
+    this.completeTraversal(frameState);
+  }
+
+  /**
+   * Updates and pushes visible children for skip traversal without requiring sibling readiness.
+   *
+   * @param tile - Parent whose children are considered.
+   * @param frameState - Current culling and LOD state.
+   * @param stack - Depth-first traversal stack.
+   * @returns `true` when at least one visible child continues refinement.
+   */
+  private updateAndPushSkipChildren(
+    tile: Tile3D,
+    frameState: FrameState,
+    stack: Tile3D[]
+  ): boolean {
+    this.updateChildTiles(tile, frameState);
+    tile.children.sort(this.compareDistanceToCamera.bind(this));
+
+    let hasVisibleChild = false;
+    for (const child of tile.children) {
+      child._selectionDepth = tile.hasRenderContent
+        ? tile._selectionDepth + 1
+        : tile._selectionDepth;
+      if (child.isVisibleAndInRequestVolume) {
+        stack.push(child);
+        hasVisibleChild = true;
+      } else if (this.options.loadSiblings) {
+        this.loadTile(child, frameState);
+        this.touchTile(child, frameState);
+      }
+    }
+    return hasVisibleChild;
+  }
+
+  /**
+   * Determines whether a tile belongs to the coarse non-skipping portion of the traversal.
+   *
+   * @param tile - Tile considered for loading.
+   * @param frameState - Current traversal frame.
+   * @returns `true` when the tile should always be requested for fallback coverage.
+   */
+  private isInBaseTraversal(tile: Tile3D, frameState: FrameState): boolean {
+    if (this.options.immediatelyLoadDesiredLevelOfDetail) {
+      return false;
+    }
+    if (!this.findNearestRequestedOrLoadedAncestor(tile, frameState)) {
+      return true;
+    }
+
+    const configuredBaseScreenSpaceError = Number.isFinite(this.options.baseScreenSpaceError)
+      ? Math.max(this.options.baseScreenSpaceError, 0)
+      : 1024;
+    const baseScreenSpaceError = Math.max(
+      configuredBaseScreenSpaceError,
+      tile.tileset.memoryAdjustedScreenSpaceError
+    );
+    if (tile._screenSpaceError === 0 && tile.parent) {
+      return tile.parent._screenSpaceError > baseScreenSpaceError;
+    }
+    return tile._screenSpaceError > baseScreenSpaceError;
+  }
+
+  /**
+   * Determines whether a skipped branch has crossed its configured request threshold.
+   *
+   * @param tile - Tile considered for loading.
+   * @param frameState - Current traversal frame.
+   * @returns `true` when the tile must be requested instead of skipped.
+   */
+  private hasReachedSkippingThreshold(tile: Tile3D, frameState: FrameState): boolean {
+    if (this.options.immediatelyLoadDesiredLevelOfDetail) {
+      return false;
+    }
+    const progressiveResolutionLeaf =
+      tile._priorityProgressiveResolution &&
+      tile._screenSpaceErrorProgressiveResolution <= tile.tileset.memoryAdjustedScreenSpaceError &&
+      Boolean(
+        tile.parent &&
+          tile.parent._screenSpaceErrorProgressiveResolution >
+            tile.tileset.memoryAdjustedScreenSpaceError
+      );
+    if (progressiveResolutionLeaf) {
+      return true;
+    }
+
+    const ancestor = this.findNearestRequestedOrLoadedAncestor(tile, frameState);
+    if (!ancestor) {
+      return false;
+    }
+    const skipScreenSpaceErrorFactor =
+      Number.isFinite(this.options.skipScreenSpaceErrorFactor) &&
+      this.options.skipScreenSpaceErrorFactor > 0
+        ? this.options.skipScreenSpaceErrorFactor
+        : 16;
+    const skipLevels = Number.isFinite(this.options.skipLevels)
+      ? Math.max(Math.floor(this.options.skipLevels), 0)
+      : 1;
+    return (
+      tile._screenSpaceError < ancestor._screenSpaceError / skipScreenSpaceErrorFactor &&
+      tile.depth > ancestor.depth + skipLevels
+    );
+  }
+
+  /**
+   * Finds the nearest ancestor whose render content is loaded, loading, or requested this frame.
+   *
+   * @param tile - Descendant whose request threshold needs an anchor.
+   * @param frameState - Current traversal frame.
+   * @returns The nearest request anchor, or `null` when none exists.
+   */
+  private findNearestRequestedOrLoadedAncestor(
+    tile: Tile3D,
+    frameState: FrameState
+  ): Tile3D | null {
+    let ancestor = tile.parent;
+    while (ancestor) {
+      const contentIsUsableAnchor =
+        ancestor.hasRenderContent &&
+        !ancestor.contentFailed &&
+        (!ancestor.hasUnloadedContent || ancestor._requestedFrame === frameState.frameNumber);
+      if (contentIsUsableAnchor) {
+        return ancestor;
+      }
+      ancestor = ancestor.parent;
+    }
+    return null;
+  }
+
+  /**
+   * Selects the desired tile, its nearest ready ancestor, or nearby ready descendants.
+   *
+   * @param tile - Tile that ended the desired refinement branch.
+   * @param frameState - Current culling state.
+   */
+  private selectDesiredTile(tile: Tile3D, frameState: FrameState): void {
+    if (tile.contentAvailable) {
+      this.selectTile(tile, frameState);
+      return;
+    }
+
+    let ancestor = tile.parent;
+    while (ancestor) {
+      if (ancestor.contentAvailable) {
+        this.selectTile(ancestor, frameState);
+        return;
+      }
+      ancestor = ancestor.parent;
+    }
+    this.selectLoadedDescendants(tile, frameState);
+  }
+
+  /**
+   * Selects ready descendants near an unavailable desired tile to reduce temporary empty regions.
+   *
+   * @param root - Unavailable tile whose descendants are searched.
+   * @param frameState - Current culling state.
+   */
+  private selectLoadedDescendants(root: Tile3D, frameState: FrameState): void {
+    const stack: Array<{tile: Tile3D; depth: number}> = [{tile: root, depth: 0}];
+    while (stack.length > 0) {
+      const {tile, depth} = stack.pop() as {tile: Tile3D; depth: number};
+      for (const child of tile.children) {
+        this.updateTile(child, frameState);
+        if (!child.isVisibleAndInRequestVolume) {
+          continue;
+        }
+        if (child.contentAvailable) {
+          this.selectTile(child, frameState);
+          this.touchTile(child, frameState);
+        } else if (depth < 1) {
+          stack.push({tile: child, depth: depth + 1});
+        }
+      }
+    }
+  }
+
   compareDistanceToCamera(a, b) {
     // Sort by farthest child first since this is going on a stack
     return b._distanceToCamera === 0 && a._distanceToCamera === 0

--- a/modules/tiles/test/tileset/tileset-3d-skip-traversal.spec.ts
+++ b/modules/tiles/test/tileset/tileset-3d-skip-traversal.spec.ts
@@ -1,0 +1,149 @@
+// loaders.gl
+// SPDX-License-Identifier: MIT AND Apache-2.0
+// Copyright vis.gl contributors
+
+import {expect, test, vi} from 'vitest';
+import {TILE_REFINEMENT} from '../../src/constants';
+import type {Tile3D} from '../../src/tileset-3d/common/tile-3d';
+import {Tileset3DTraverser} from '../../src/tileset-3d/format-3d-tiles/tileset-3d-traverser';
+
+type TestTileset = {
+  memoryAdjustedScreenSpaceError: number;
+  _cache: {touch: ReturnType<typeof vi.fn>};
+};
+
+/** Creates the minimal runtime tile shape needed by the traversal algorithm. */
+function createTraversalTile(
+  tileset: TestTileset,
+  id: string,
+  depth: number,
+  screenSpaceError: number,
+  contentAvailable = false
+): Tile3D {
+  const tile = {
+    id,
+    depth,
+    parent: null,
+    children: [],
+    header: {},
+    tileset,
+    refine: TILE_REFINEMENT.REPLACE,
+    hasRenderContent: true,
+    hasEmptyContent: false,
+    hasTilesetContent: false,
+    contentAvailable,
+    hasUnloadedContent: !contentAvailable,
+    contentUnloaded: !contentAvailable,
+    contentExpired: false,
+    contentFailed: false,
+    isVisible: true,
+    isVisibleAndInRequestVolume: true,
+    priorityDeferred: false,
+    _distanceToCamera: depth,
+    _screenSpaceError: screenSpaceError,
+    _screenSpaceErrorProgressiveResolution: 0,
+    _priorityProgressiveResolution: false,
+    _selectionDepth: 0,
+    _shouldRefine: false,
+    _requestedFrame: 0,
+    _priority: 0,
+    get hasChildren() {
+      return this.children.length > 0;
+    },
+    _getPriority: () => 0,
+    contentVisibility: () => 'inside'
+  };
+  return tile as unknown as Tile3D;
+}
+
+/** Links a child into a synthetic traversal tree. */
+function appendChild(parent: Tile3D, child: Tile3D): void {
+  child.parent = parent;
+  parent.children.push(child);
+}
+
+/** Creates a four-level replacement tree with decreasing screen-space error. */
+function createReplacementTree(rootContentAvailable = false): {
+  root: Tile3D;
+  intermediate: Tile3D;
+  threshold: Tile3D;
+  leaf: Tile3D;
+} {
+  const tileset: TestTileset = {
+    memoryAdjustedScreenSpaceError: 8,
+    _cache: {touch: vi.fn()}
+  };
+  const root = createTraversalTile(tileset, 'root', 0, 2048, rootContentAvailable);
+  const intermediate = createTraversalTile(tileset, 'intermediate', 1, 512);
+  const threshold = createTraversalTile(tileset, 'threshold', 2, 64);
+  const leaf = createTraversalTile(tileset, 'leaf', 3, 0);
+  appendChild(root, intermediate);
+  appendChild(intermediate, threshold);
+  appendChild(threshold, leaf);
+  return {root, intermediate, threshold, leaf};
+}
+
+/** Runs the dedicated skip traversal without requiring camera or bounding-volume fixtures. */
+function traverseReplacementTree(
+  root: Tile3D,
+  options: ConstructorParameters<typeof Tileset3DTraverser>[0]
+): Tileset3DTraverser {
+  const traverser = new Tileset3DTraverser({
+    skipLevelOfDetail: true,
+    baseScreenSpaceError: 1024,
+    skipScreenSpaceErrorFactor: 16,
+    skipLevels: 1,
+    onTraversalEnd: vi.fn(),
+    ...options
+  });
+  traverser.updateTile = () => {};
+  traverser.traverse(root, {frameNumber: 1, viewport: {id: 'test'}} as any, {});
+  return traverser;
+}
+
+test('Tileset3DTraverser#skip LOD omits intermediate content requests', () => {
+  const {root, intermediate, threshold, leaf} = createReplacementTree();
+  const traverser = traverseReplacementTree(root, {});
+
+  expect(Object.keys(traverser.requestedTiles)).toEqual(['root', 'threshold', 'leaf']);
+  expect(traverser.requestedTiles[intermediate.id]).toBeUndefined();
+  expect(threshold._requestedFrame).toBe(1);
+  expect(leaf._requestedFrame).toBe(1);
+});
+
+test('Tileset3DTraverser#immediatelyLoadDesiredLevelOfDetail requests only the final tile', () => {
+  const {root, intermediate, threshold, leaf} = createReplacementTree();
+  const traverser = traverseReplacementTree(root, {
+    immediatelyLoadDesiredLevelOfDetail: true
+  });
+
+  expect(Object.keys(traverser.requestedTiles)).toEqual(['leaf']);
+  expect(traverser.requestedTiles[root.id]).toBeUndefined();
+  expect(traverser.requestedTiles[intermediate.id]).toBeUndefined();
+  expect(traverser.requestedTiles[threshold.id]).toBeUndefined();
+});
+
+test('Tileset3DTraverser#skip LOD retains the nearest ready ancestor as coverage', () => {
+  const {root, leaf} = createReplacementTree(true);
+  const traverser = traverseReplacementTree(root, {
+    immediatelyLoadDesiredLevelOfDetail: true
+  });
+
+  expect(Object.keys(traverser.requestedTiles)).toEqual(['leaf']);
+  expect(Object.keys(traverser.selectedTiles)).toEqual(['root']);
+  expect(root._selectedFrame).toBe(1);
+});
+
+test('Tileset3DTraverser#skip LOD ignores disabled progressive-resolution thresholds', () => {
+  const {root, intermediate, threshold, leaf} = createReplacementTree();
+  intermediate._screenSpaceErrorProgressiveResolution = 16;
+  threshold._screenSpaceErrorProgressiveResolution = 4;
+  threshold._priorityProgressiveResolution = false;
+
+  const traverser = traverseReplacementTree(root, {
+    skipScreenSpaceErrorFactor: 1000
+  });
+
+  expect(Object.keys(traverser.requestedTiles)).toEqual(['root', 'leaf']);
+  expect(traverser.requestedTiles[threshold.id]).toBeUndefined();
+});

--- a/modules/tiles/test/tileset/tileset-3d-skip-traversal.spec.ts
+++ b/modules/tiles/test/tileset/tileset-3d-skip-traversal.spec.ts
@@ -134,6 +134,21 @@ test('Tileset3DTraverser#skip LOD retains the nearest ready ancestor as coverage
   expect(root._selectedFrame).toBe(1);
 });
 
+test('Tileset3DTraverser#skip LOD continues past a culled loaded ancestor', () => {
+  const {root, intermediate, leaf} = createReplacementTree(true);
+  intermediate.contentAvailable = true;
+  intermediate.hasUnloadedContent = false;
+  intermediate.contentUnloaded = false;
+  intermediate.contentVisibility = () => 'outside';
+
+  const traverser = traverseReplacementTree(root, {
+    immediatelyLoadDesiredLevelOfDetail: true
+  });
+
+  expect(Object.keys(traverser.requestedTiles)).toEqual(['leaf']);
+  expect(Object.keys(traverser.selectedTiles)).toEqual(['root']);
+});
+
 test('Tileset3DTraverser#skip LOD ignores disabled progressive-resolution thresholds', () => {
   const {root, intermediate, threshold, leaf} = createReplacementTree();
   intermediate._screenSpaceErrorProgressiveResolution = 16;

--- a/modules/tiles/test/tileset/tileset-3d-traversal.slow.spec.ts
+++ b/modules/tiles/test/tileset/tileset-3d-traversal.slow.spec.ts
@@ -264,7 +264,7 @@ test('Tileset3D#loadTiles option', async () => {
   expect(tileLoadCounter).toBe(0);
 });
 
-test('Tileset3D#skipLevelOfDetail retains replacement ancestors as coverage', async () => {
+test('Tileset3D#skipLevelOfDetail releases replacement ancestors after descendants load', async () => {
   expect.assertions(3);
   const tilesetJson = await load(TILESET_REPLACEMENT_URL, Tiles3DLoader);
   const viewport = VIEWPORTS[0];
@@ -281,6 +281,6 @@ test('Tileset3D#skipLevelOfDetail retains replacement ancestors as coverage', as
   await waitForCondition(() => tileLoadCounter > 0, ASYNC_TRAVERSAL_TIMEOUT);
   tileset.update(viewport);
   expect(tileset.options.skipLevelOfDetail).toBe(true);
-  expect(tileset.selectedTiles.some(tile => tile.depth === 0)).toBe(true);
+  expect(tileset.selectedTiles.every(tile => tile.depth > 0)).toBe(true);
   expect(tileset.selectedTiles.length).toBeGreaterThan(1);
 });


### PR DESCRIPTION
## Goals

- Match CesiumJS skip-LOD request behavior for deep replacement trees.
- Resolve the remaining behavior reported in #2850: `skipLevelOfDetail` should omit skipped intermediate tile-content requests, not merely render ancestors and descendants together.
- Preserve usable fallback coverage while desired descendants are streaming.

## Behavior

This adds a dedicated 3D Tiles skip traversal. Normal replacement traversal and I3S traversal are unchanged.

For visible `REPLACE` branches, the new traversal:

- walks through unloaded hierarchy levels without requiring every intermediate tile to become ready
- requests coarse base tiles, configured threshold-crossing tiles, and final SSE targets
- keeps the nearest selectable loaded ancestor as temporary coverage while desired content loads
- searches nearby loaded descendants when no ancestor can cover an unavailable target
- stops selecting the fallback ancestor once desired descendants are available
- continues past a loaded ancestor whose content bounding volume is culled
- preserves `loadSiblings`, progressive-resolution priority, foveated request deferral, implicit subtree loading, and the existing vector/geometry skip-LOD opt-out

`ADD` refinement remains additive and is not converted to replacement behavior.

## Public options

The following Cesium-compatible controls are now exposed on `Tileset3D`:

| Option | Default | Effect |
| --- | ---: | --- |
| `baseScreenSpaceError` | `1024` | Keeps high-SSE tiles in the coarse non-skipping traversal. |
| `skipScreenSpaceErrorFactor` | `16` | Requires this SSE reduction from the nearest requested or loaded ancestor before requesting another intermediate tile. |
| `skipLevels` | `1` | Sets the minimum hierarchy spacing between intermediate requests. |
| `immediatelyLoadDesiredLevelOfDetail` | `false` | When enabled, bypasses base and intermediate requests and requests only final desired tiles. |

## Tests

New request-set regression coverage verifies that:

- default skip thresholds omit an intermediate tile
- desired-level-only mode requests only the final tile
- a ready ancestor remains selected while the final tile is unavailable
- fallback selection continues past a culled loaded ancestor
- disabled progressive-resolution behavior cannot introduce an intermediate request

The existing slow integration test now verifies that a replacement ancestor is released after desired descendants load.

Local validation:

- `yarn lint fix`
- `yarn build`
- `yarn build-workers`
- `yarn test-node` — 72 files, 444 passed, 6 skipped
- `yarn test-headless` — 644 files, 4,853 passed, 39 skipped
- focused slow traversal integration — 6 passed
- `yarn test-audit` — 766 files, 0 violations

## Documentation

- documents true intermediate-request skipping and all new tuning options
- updates the 3D Tiles refinement concept guide, release notes, and changelog
- tracks the explicit no-intermediate-request parity requirement in roadmap #1245

Fixes #2850
