### PR TITLE
fix(gltf): preserve loaded buffers after post-processing

### DIFF
--- a/docs/modules/gltf/api-reference/post-process-gltf.md
+++ b/docs/modules/gltf/api-reference/post-process-gltf.md
@@ -130,7 +130,7 @@ from their implicit-zero base and optional sparse substitutions before topology 
 
 ### Buffers
 
-The following fields will be populated from the supplied `gltf.buffers` parameter (this parameter is populated by the loader via `options.loadLinkedResources: true`):
+The following fields will be populated from the supplied `gltf.buffers` parameter (this parameter is populated by the loader when `options.gltf.loadBuffers: true`):
 
 - `buffer.arrayBuffer` -
 - `buffer.byteOffset` -

--- a/modules/gltf/src/lib/api/post-process-gltf.ts
+++ b/modules/gltf/src/lib/api/post-process-gltf.ts
@@ -145,12 +145,16 @@ class GLTFPostProcessor {
     assert(json);
 
     this.baseUri = baseUri;
-    this.buffers = buffers;
+    this.buffers = (json.buffers || []).map((buffer, index) => ({
+      ...buffer,
+      ...(buffers[index] || {})
+    }));
     this.images = images;
     this.iterator = new GLTFIterator(gltf);
     this.jsonUnprocessed = json;
 
     this.json = this._resolveTree(gltf.json, options);
+    this.json.buffers = this.buffers;
 
     return this.json;
   }

--- a/modules/gltf/src/lib/api/post-process-gltf.ts
+++ b/modules/gltf/src/lib/api/post-process-gltf.ts
@@ -145,8 +145,9 @@ class GLTFPostProcessor {
     assert(json);
 
     this.baseUri = baseUri;
-    this.buffers = (json.buffers || []).map((buffer, index) => ({
-      ...buffer,
+    const bufferCount = Math.max(json.buffers?.length || 0, buffers.length);
+    this.buffers = Array.from({length: bufferCount}, (_, index) => ({
+      ...(json.buffers?.[index] || {}),
       ...(buffers[index] || {})
     }));
     this.images = images;

--- a/modules/gltf/test/lib/api/post-process-gltf.spec.ts
+++ b/modules/gltf/test/lib/api/post-process-gltf.spec.ts
@@ -57,18 +57,29 @@ test('gltf#postProcessGLTF', () => {
 });
 test('gltf#postProcessGLTF preserves loaded buffer data', () => {
   const arrayBuffer = new Uint8Array([1, 2, 3, 4]).buffer;
+  const generatedArrayBuffer = new Uint8Array([5, 6, 7, 8]).buffer;
   const gltf = postProcessGLTF({
     json: {
       asset: {version: '2.0'},
       buffers: [{byteLength: arrayBuffer.byteLength, uri: 'mesh.bin'}]
     },
-    buffers: [{arrayBuffer, byteOffset: 0, byteLength: arrayBuffer.byteLength}]
+    buffers: [
+      {arrayBuffer, byteOffset: 0, byteLength: arrayBuffer.byteLength},
+      {
+        arrayBuffer: generatedArrayBuffer,
+        byteOffset: 0,
+        byteLength: generatedArrayBuffer.byteLength
+      }
+    ]
   } as GLTFWithBuffers);
 
   expect(gltf.buffers[0].arrayBuffer, 'retains the loaded buffer').toBe(arrayBuffer);
   expect(gltf.buffers[0].byteOffset, 'retains the loaded buffer offset').toBe(0);
   expect(gltf.buffers[0].byteLength, 'retains the loaded buffer length').toBe(4);
   expect(gltf.buffers[0].uri, 'retains the source buffer metadata').toBe('mesh.bin');
+  expect(gltf.buffers[1].arrayBuffer, 'retains extension-generated buffers').toBe(
+    generatedArrayBuffer
+  );
 });
 test('gltf#postProcessGLTF resolves a draft glTF 2.1 thumbnail', () => {
   const json = postProcessGLTF({

--- a/modules/gltf/test/lib/api/post-process-gltf.spec.ts
+++ b/modules/gltf/test/lib/api/post-process-gltf.spec.ts
@@ -55,6 +55,21 @@ test('gltf#postProcessGLTF', () => {
     expect(json, testCase.name).toEqual(testCase.output);
   }
 });
+test('gltf#postProcessGLTF preserves loaded buffer data', () => {
+  const arrayBuffer = new Uint8Array([1, 2, 3, 4]).buffer;
+  const gltf = postProcessGLTF({
+    json: {
+      asset: {version: '2.0'},
+      buffers: [{byteLength: arrayBuffer.byteLength, uri: 'mesh.bin'}]
+    },
+    buffers: [{arrayBuffer, byteOffset: 0, byteLength: arrayBuffer.byteLength}]
+  } as GLTFWithBuffers);
+
+  expect(gltf.buffers[0].arrayBuffer, 'retains the loaded buffer').toBe(arrayBuffer);
+  expect(gltf.buffers[0].byteOffset, 'retains the loaded buffer offset').toBe(0);
+  expect(gltf.buffers[0].byteLength, 'retains the loaded buffer length').toBe(4);
+  expect(gltf.buffers[0].uri, 'retains the source buffer metadata').toBe('mesh.bin');
+});
 test('gltf#postProcessGLTF resolves a draft glTF 2.1 thumbnail', () => {
   const json = postProcessGLTF({
     json: {


### PR DESCRIPTION
## Goals

Fix issue #2740 so `postProcessGLTF` retains loaded linked-buffer data for callers using 3D Tiles and other postprocessed glTF assets.

## Changes

- Merge loaded buffer descriptors into the postprocessed root `gltf.buffers` array.
- Preserve `arrayBuffer`, `byteOffset`, `byteLength`, and source buffer metadata.
- Update the documentation to use `options.gltf.loadBuffers: true`.
- Add regression coverage for loaded buffer preservation.

## Validation

- `yarn lint fix`
- `yarn test-headless modules/gltf/test/lib/api/post-process-gltf.spec.ts` (10 passed)
- Full build attempted; blocked by the unrelated baseline `modules/gis` dependency error for `@math.gl/wkb`.

Closes #2740
