### PR TITLE
fix(core): propagate fetch options to subloaders

### DIFF
--- a/modules/core/src/lib/loader-utils/get-fetch-function.ts
+++ b/modules/core/src/lib/loader-utils/get-fetch-function.ts
@@ -27,8 +27,9 @@ export function getFetchFunction(
   if (typeof fetchOption === 'function') {
     fetchFunction = fetchOption;
   } else if (isObject(fetchOption)) {
+    const baseFetch = context?.fetch || fetchFile;
     fetchFunction = (url, requestOptions) =>
-      fetchFile(url, mergeFetchOptions(fetchOption as RequestInit, requestOptions));
+      baseFetch(url, mergeFetchOptions(fetchOption as RequestInit, requestOptions));
   } else if (context?.fetch) {
     fetchFunction = context.fetch;
   } else {

--- a/modules/core/src/lib/loader-utils/loader-context.ts
+++ b/modules/core/src/lib/loader-utils/loader-context.ts
@@ -19,17 +19,20 @@ type LoaderContextProps = Omit<LoaderContext, 'fetch' | 'coreApi'> &
  *
  * @param context
  * @param options
- * @param previousContext
+ * @param parentContext
  */
 export function getLoaderContext(
   context: LoaderContextProps,
   options: StrictLoaderOptions,
   parentContext: LoaderContext | null
 ): LoaderContext {
-  // For recursive calls, we already have a context
+  // For recursive calls, preserve the context while applying this loader's options
   // TODO - add any additional loaders to context?
   if (parentContext) {
-    return parentContext;
+    return {
+      ...parentContext,
+      fetch: getFetchFunction(options, parentContext)
+    };
   }
 
   const newContext: LoaderContext = {

--- a/modules/core/test/lib/loader-utils/get-fetch-function.spec.ts
+++ b/modules/core/test/lib/loader-utils/get-fetch-function.spec.ts
@@ -5,8 +5,48 @@
 import {describe, expect, test} from 'vitest';
 import {createBearerTokenCredential} from '@loaders.gl/loader-utils';
 import {getFetchFunction} from '../../../src/lib/loader-utils/get-fetch-function';
+import {getLoaderContext} from '../../../src/lib/loader-utils/loader-context';
 
 describe('getFetchFunction', () => {
+  test('applies fetch options to a parent fetch implementation', async () => {
+    const abortController = new AbortController();
+    const requests: Array<{url: string; signal?: AbortSignal}> = [];
+    const parentFetch = async (url: string, options?: RequestInit) => {
+      requests.push({url, signal: options?.signal});
+      return new Response('ok');
+    };
+    const fetchFunction = getFetchFunction({core: {fetch: {signal: abortController.signal}}}, {
+      fetch: parentFetch
+    } as any);
+
+    await fetchFunction('https://example.com/asset');
+
+    expect(requests).toEqual([{url: 'https://example.com/asset', signal: abortController.signal}]);
+  });
+
+  test('preserves fetch options when creating a subloader context', async () => {
+    const abortController = new AbortController();
+    const requests: Array<{url: string; signal?: AbortSignal}> = [];
+    const parentFetch = async (url: string, options?: RequestInit) => {
+      requests.push({url, signal: options?.signal});
+      return new Response('ok');
+    };
+    const parentContext = {
+      fetch: parentFetch,
+      coreApi: {} as any,
+      _parse: async () => null
+    } as any;
+    const childContext = getLoaderContext(
+      {url: 'https://example.com/root.gltf'},
+      {core: {fetch: {signal: abortController.signal}}},
+      parentContext
+    );
+
+    await childContext.fetch('https://example.com/asset');
+
+    expect(requests).toEqual([{url: 'https://example.com/asset', signal: abortController.signal}]);
+  });
+
   test('composes core credentials with custom fetch options', async () => {
     const requests: Array<{url: string; headers: Headers}> = [];
     const fetchFunction = getFetchFunction({

--- a/modules/core/test/lib/loader-utils/get-fetch-function.spec.ts
+++ b/modules/core/test/lib/loader-utils/get-fetch-function.spec.ts
@@ -19,9 +19,9 @@ describe('getFetchFunction', () => {
       fetch: parentFetch
     } as any);
 
-    await fetchFunction('https://example.com/asset');
+    await fetchFunction('asset');
 
-    expect(requests).toEqual([{url: 'https://example.com/asset', signal: abortController.signal}]);
+    expect(requests).toEqual([{url: 'asset', signal: abortController.signal}]);
   });
 
   test('preserves fetch options when creating a subloader context', async () => {
@@ -37,14 +37,14 @@ describe('getFetchFunction', () => {
       _parse: async () => null
     } as any;
     const childContext = getLoaderContext(
-      {url: 'https://example.com/root.gltf'},
+      {url: 'root.gltf'},
       {core: {fetch: {signal: abortController.signal}}},
       parentContext
     );
 
-    await childContext.fetch('https://example.com/asset');
+    await childContext.fetch('asset');
 
-    expect(requests).toEqual([{url: 'https://example.com/asset', signal: abortController.signal}]);
+    expect(requests).toEqual([{url: 'asset', signal: abortController.signal}]);
   });
 
   test('composes core credentials with custom fetch options', async () => {


### PR DESCRIPTION
## Goals

Fix #2541 so fetch options supplied to a top-level loader continue to apply when GLTFLoader recursively invokes subloaders, including AbortSignal cancellation.

## Changes

- Rebuild recursive loader contexts while preserving the parent context.
- Merge object-form fetch options onto the parent fetch implementation.
- Add regression coverage for fetch-option and subloader-context propagation.

## Verification

- `yarn test-headless modules/core/test/lib/loader-utils/get-fetch-function.spec.ts` — 3 tests passed.
- `yarn build-workers` — passed.
- `yarn lint fix` — passed.
- `yarn build` reaches the affected packages but is currently blocked by pre-existing TypeScript rootDir/file-list errors from `modules/pmtiles` importing `modules/mlt/src`.

Closes #2541